### PR TITLE
feat(gws): implement gws foundation and Gmail read/draft (WP-011)

### DIFF
--- a/bin/wienerdog.js
+++ b/bin/wienerdog.js
@@ -13,6 +13,7 @@ Commands:
   dream       Consolidate recent sessions into vault memory (one commit)
   doctor      Check an existing install for problems
   uninstall   Remove everything Wienerdog created (reverses the install)
+  gws         Read Gmail/Calendar/Drive and draft mail (Google Workspace)
 
 Global options:
   --dry-run   Show what would happen; make no changes
@@ -37,6 +38,7 @@ async function main() {
     dream: () => require('../src/cli/dream'),
     doctor: () => require('../src/cli/doctor'),
     uninstall: () => require('../src/cli/uninstall'),
+    gws: () => require('../src/gws/index'),
   };
 
   const loader = commands[cmd];

--- a/docs/specs/WP-011-gws-foundation.md
+++ b/docs/specs/WP-011-gws-foundation.md
@@ -1,7 +1,7 @@
 ---
 id: WP-011
 title: Implement gws foundation (OAuth auth, client seam, Gmail read/draft)
-status: Ready
+status: In-Review
 model: opus
 size: M
 depends_on: [WP-003]

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "wienerdog",
       "version": "0.0.0",
       "license": "MIT",
+      "dependencies": {
+        "googleapis": "^173.0.0"
+      },
       "bin": {
         "wienerdog": "bin/wienerdog.js"
       },
@@ -16,6 +19,46 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -54,6 +97,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@sindresorhus/merge-streams": {
@@ -100,11 +153,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -113,12 +174,68 @@
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
     },
     "node_modules/braces": {
       "version": "3.0.3",
@@ -131,6 +248,41 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/character-entities": {
@@ -166,6 +318,24 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/commander": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
@@ -176,11 +346,33 @@
         "node": ">= 12"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -232,6 +424,41 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -244,6 +471,42 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -272,6 +535,29 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -285,6 +571,71 @@
         "node": ">=8"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
@@ -296,6 +647,64 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -330,6 +739,157 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
+      "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "173.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-173.0.0.tgz",
+      "integrity": "sha512-xEJJYLZ4qeenVyfzispNfRjCe9bsv7CzBv5zYFLvScOze9snJ8S9W6hjQ729CWPQt5mvn/JrcRaCHzQiukt0ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.2.0",
+        "googleapis-common": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-8.0.2.tgz",
+      "integrity": "sha512-5MXeQzIZaqCH7B+HJWqhQm946VARpZep6acbWSr/fcgF2cQANq7allgX+i/G0EqF0WyUxB277gtWMzRYHMl9tg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "7.1.3",
+        "google-auth-library": "10.5.0",
+        "google-logging-utils": "1.1.3",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/gaxios": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/google-auth-library": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^8.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ignore": {
@@ -389,6 +949,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -436,6 +1005,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.0.tgz",
@@ -459,6 +1049,15 @@
         "js-yaml": "bin/js-yaml.mjs"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/jsonc-parser": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
@@ -474,6 +1073,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/katex": {
@@ -512,6 +1132,12 @@
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/markdown-it": {
       "version": "14.2.0",
@@ -603,6 +1229,15 @@
       },
       "peerDependencies": {
         "markdownlint-cli2": ">=0.0.4"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mdurl": {
@@ -1172,12 +1807,91 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/parse-entities": {
       "version": "4.0.2",
@@ -1197,6 +1911,31 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/picomatch": {
@@ -1220,6 +1959,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -1254,6 +2009,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -1276,6 +2046,131 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/slash": {
@@ -1321,11 +2216,46 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -1335,6 +2265,28 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/to-regex-range": {
@@ -1365,6 +2317,144 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "skills/",
     "templates/"
   ],
+  "dependencies": {
+    "googleapis": "^173.0.0"
+  },
   "scripts": {
     "test": "node --test",
     "lint": "node scripts/lint.js",

--- a/src/gws/auth.js
+++ b/src/gws/auth.js
@@ -1,0 +1,145 @@
+'use strict';
+
+const fs = require('node:fs');
+const http = require('node:http');
+
+const { WienerdogError } = require('../core/errors');
+const { SCOPES, persistToken, persistClientJson } = require('./client');
+
+/**
+ * @typedef {import('../core/paths').WienerdogPaths} WienerdogPaths
+ */
+
+const CLOSE_PAGE =
+  '<!doctype html><html><body style="font-family:sans-serif">' +
+  '<h2>Wienerdog is connected.</h2><p>You can close this tab and return to your terminal.</p>' +
+  '</body></html>';
+
+/**
+ * Run the interactive OAuth loopback flow and persist the token.
+ * @param {WienerdogPaths} paths
+ * @param {{clientPath?: string, googleapis?: object, oauthClient?: object,
+ *          openBrowser?: (url:string)=>void}} opts
+ * @returns {Promise<{email:string|null, tokenPath:string}>}
+ */
+async function run(paths, opts = {}) {
+  if (!opts.clientPath) {
+    throw new WienerdogError(
+      'missing --client <path> — download the OAuth client JSON from Google Cloud Console first'
+    );
+  }
+
+  // 1. Read and persist a copy of the Desktop-app client JSON.
+  let clientJson;
+  try {
+    clientJson = JSON.parse(fs.readFileSync(opts.clientPath, 'utf8'));
+  } catch {
+    throw new WienerdogError(
+      `could not read the client JSON at ${opts.clientPath}`
+    );
+  }
+  const cfg = clientJson.installed || clientJson.web;
+  if (!cfg || !cfg.client_id || !cfg.client_secret) {
+    throw new WienerdogError(
+      `${opts.clientPath} is not a valid Google OAuth client JSON`
+    );
+  }
+  persistClientJson(paths, clientJson);
+
+  // 3. Start the loopback listener on an ephemeral port before building the URL.
+  const { server, port, waitForCode } = await startLoopback();
+
+  try {
+    const redirectUri = `http://127.0.0.1:${port}/`;
+
+    // 2. Build an OAuth2 client (injectable for tests).
+    const oauth =
+      opts.oauthClient ||
+      new (opts.googleapis || require('googleapis')).google.auth.OAuth2(
+        cfg.client_id,
+        cfg.client_secret,
+        redirectUri
+      );
+
+    // 4. Generate + present the consent URL.
+    const authUrl = oauth.generateAuthUrl({
+      access_type: 'offline',
+      prompt: 'consent',
+      scope: SCOPES,
+    });
+    process.stdout.write(
+      `\nOpen this URL in your browser to authorize Wienerdog:\n\n${authUrl}\n\n`
+    );
+    if (opts.openBrowser) opts.openBrowser(authUrl);
+
+    // 5. Wait for the single loopback redirect carrying ?code=...
+    const code = await waitForCode;
+
+    // 6. Exchange the code for tokens and persist them.
+    const token = (await oauth.getToken(code)).tokens;
+    oauth.setCredentials(token);
+    persistToken(paths, token);
+
+    // 7. Best-effort account email for the confirmation line.
+    const email = await fetchEmail(oauth, opts);
+
+    return { email, tokenPath: require('./client').tokenPath(paths) };
+  } finally {
+    // No socket may outlive the command (ADR-0004).
+    server.close();
+  }
+}
+
+/**
+ * Best-effort read of the signed-in account's email address. Returns null on
+ * any failure (the confirmation line is cosmetic).
+ * @param {object} oauth
+ * @param {{googleapis?: object}} opts
+ * @returns {Promise<string|null>}
+ */
+async function fetchEmail(oauth, opts) {
+  try {
+    const { google } = opts.googleapis || require('googleapis');
+    const gmail = google.gmail({ version: 'v1', auth: oauth });
+    const res = await gmail.users.getProfile({ userId: 'me' });
+    return (res.data && res.data.emailAddress) || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Start a one-shot loopback HTTP listener on 127.0.0.1:0. Resolves the code
+ * from the first request's `?code=` query param; the listener is closed by the
+ * caller's finally block.
+ * @returns {Promise<{server:import('node:http').Server, port:number,
+ *   waitForCode:Promise<string>}>}
+ */
+function startLoopback() {
+  return new Promise((resolve, reject) => {
+    let resolveCode;
+    let rejectCode;
+    const waitForCode = new Promise((res, rej) => {
+      resolveCode = res;
+      rejectCode = rej;
+    });
+
+    const server = http.createServer((req, res) => {
+      const url = new URL(req.url, 'http://127.0.0.1');
+      const code = url.searchParams.get('code');
+      const error = url.searchParams.get('error');
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(CLOSE_PAGE);
+      if (error) rejectCode(new WienerdogError(`Google denied authorization: ${error}`));
+      else if (code) resolveCode(code);
+    });
+
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const port = server.address().port;
+      resolve({ server, port, waitForCode });
+    });
+  });
+}
+
+module.exports = { run };

--- a/src/gws/client.js
+++ b/src/gws/client.js
@@ -1,0 +1,164 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const { WienerdogError } = require('../core/errors');
+
+/**
+ * @typedef {import('../core/paths').WienerdogPaths} WienerdogPaths
+ */
+
+/**
+ * The exact OAuth scopes the user consents to. Order is a tested contract.
+ * `gmail.compose` permits sending at the Google layer, but Wienerdog never
+ * calls `messages.send` here — sending is gated by a send grant (ADR-0007,
+ * WP-018). Draft is the only write verb in this WP and is inherently safe.
+ */
+const SCOPES = [
+  'https://www.googleapis.com/auth/gmail.readonly',
+  'https://www.googleapis.com/auth/gmail.compose',
+  'https://www.googleapis.com/auth/calendar',
+  'https://www.googleapis.com/auth/drive.readonly',
+];
+
+/**
+ * Absolute path of the OAuth token file.
+ * @param {WienerdogPaths} paths
+ * @returns {string}
+ */
+function tokenPath(paths) {
+  return path.join(paths.secrets, 'google-token.json');
+}
+
+/**
+ * Absolute path of the saved Cloud-Console client JSON.
+ * @param {WienerdogPaths} paths
+ * @returns {string}
+ */
+function clientJsonPath(paths) {
+  return path.join(paths.secrets, 'google-client.json');
+}
+
+/**
+ * Load and JSON.parse a JSON file from secrets, throwing a plain-language
+ * WienerdogError if it is missing, unreadable, or invalid.
+ * @param {string} file
+ * @param {string} what
+ * @returns {object}
+ */
+function loadJsonOrThrow(file, what) {
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch {
+    throw new WienerdogError(
+      `no Google ${what} found — run \`wienerdog gws auth\` first`
+    );
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new WienerdogError(
+      `Google ${what} file is corrupted (${file}) — run \`wienerdog gws auth\` again`
+    );
+  }
+}
+
+/**
+ * Load and JSON.parse the token file.
+ * @param {WienerdogPaths} paths
+ * @returns {object}
+ */
+function loadToken(paths) {
+  return loadJsonOrThrow(tokenPath(paths), 'sign-in');
+}
+
+/**
+ * Load and JSON.parse the saved client JSON ({ installed } or { web }).
+ * @param {WienerdogPaths} paths
+ * @returns {object}
+ */
+function loadClientJson(paths) {
+  return loadJsonOrThrow(clientJsonPath(paths), 'app credentials');
+}
+
+/**
+ * Atomically write a JSON payload at mode 0600 (temp file + rename + chmod).
+ * Creates paths.secrets (mode 0700) if absent.
+ * @param {WienerdogPaths} paths
+ * @param {string} dest
+ * @param {object} payload
+ */
+function writeSecretJson(paths, dest, payload) {
+  fs.mkdirSync(paths.secrets, { recursive: true, mode: 0o700 });
+  const tmp = path.join(
+    paths.secrets,
+    `.${path.basename(dest)}.${crypto.randomBytes(6).toString('hex')}.tmp`
+  );
+  fs.writeFileSync(tmp, JSON.stringify(payload, null, 2), { mode: 0o600 });
+  fs.chmodSync(tmp, 0o600);
+  fs.renameSync(tmp, dest);
+  fs.chmodSync(dest, 0o600);
+}
+
+/**
+ * Write the token file atomically at mode 0600.
+ * @param {WienerdogPaths} paths
+ * @param {object} token
+ */
+function persistToken(paths, token) {
+  writeSecretJson(paths, tokenPath(paths), token);
+}
+
+/**
+ * Write the client JSON to clientJsonPath at mode 0600.
+ * @param {WienerdogPaths} paths
+ * @param {object} clientJson
+ */
+function persistClientJson(paths, clientJson) {
+  writeSecretJson(paths, clientJsonPath(paths), clientJson);
+}
+
+/**
+ * THE INJECTION SEAM. Build authenticated Google service objects.
+ * @param {WienerdogPaths} paths
+ * @param {{factory?: (auth:object)=>{gmail:object,calendar:object,drive:object},
+ *          googleapis?: object}} [opts]
+ * @returns {{gmail:object, calendar:object, drive:object}}
+ */
+function getServices(paths, opts = {}) {
+  const token = loadToken(paths);
+  const client = loadClientJson(paths);
+
+  // Unit-test seam: return the fake factory's object, touching no real googleapis.
+  if (opts.factory) {
+    return opts.factory(token);
+  }
+
+  const { google } = opts.googleapis || require('googleapis');
+  const cfg = client.installed || client.web;
+  const oauth = new google.auth.OAuth2(
+    cfg.client_id,
+    cfg.client_secret,
+    cfg.redirect_uris ? cfg.redirect_uris[0] : undefined
+  );
+  oauth.setCredentials(token);
+  return {
+    gmail: google.gmail({ version: 'v1', auth: oauth }),
+    calendar: google.calendar({ version: 'v3', auth: oauth }),
+    drive: google.drive({ version: 'v3', auth: oauth }),
+  };
+}
+
+module.exports = {
+  SCOPES,
+  tokenPath,
+  clientJsonPath,
+  loadToken,
+  loadClientJson,
+  persistToken,
+  persistClientJson,
+  getServices,
+};

--- a/src/gws/gmail.js
+++ b/src/gws/gmail.js
@@ -1,0 +1,146 @@
+'use strict';
+
+/**
+ * Gmail verb functions. Each takes `(services, opts)` and returns plain data;
+ * they perform no console I/O (that is index.js's job). `services` is the
+ * object from getServices; tests pass a stub with just the methods used.
+ */
+
+/**
+ * Pull a header value (case-insensitive) from a Gmail headers array.
+ * @param {Array<{name:string,value:string}>} headers
+ * @param {string} name
+ * @returns {string}
+ */
+function header(headers, name) {
+  const lower = name.toLowerCase();
+  const hit = (headers || []).find((h) => h.name.toLowerCase() === lower);
+  return hit ? hit.value : '';
+}
+
+/**
+ * Decode a base64url string (Gmail body encoding) to a UTF-8 string.
+ * @param {string} data
+ * @returns {string}
+ */
+function decodeBody(data) {
+  return Buffer.from(data, 'base64url').toString('utf8');
+}
+
+/**
+ * Depth-first search a payload tree for the first text/plain body.
+ * @param {object} payload
+ * @returns {string|null}
+ */
+function findPlainText(payload) {
+  if (!payload) return null;
+  if (payload.mimeType === 'text/plain' && payload.body && payload.body.data) {
+    return decodeBody(payload.body.data);
+  }
+  for (const part of payload.parts || []) {
+    const found = findPlainText(part);
+    if (found !== null) return found;
+  }
+  return null;
+}
+
+/**
+ * gmail search — list message headers matching a Gmail query.
+ * @param {{gmail:object}} services
+ * @param {{query:string, max?:number}} opts
+ * @returns {Promise<Array<{id:string, threadId:string, from:string,
+ *   subject:string, date:string, snippet:string}>>}
+ */
+async function search(services, opts) {
+  const listRes = await services.gmail.users.messages.list({
+    userId: 'me',
+    q: opts.query,
+    maxResults: opts.max || 20,
+  });
+  const messages = (listRes.data && listRes.data.messages) || [];
+  const out = [];
+  for (const m of messages) {
+    const res = await services.gmail.users.messages.get({
+      userId: 'me',
+      id: m.id,
+      format: 'metadata',
+      metadataHeaders: ['From', 'Subject', 'Date'],
+    });
+    const data = res.data || {};
+    const headers = (data.payload && data.payload.headers) || [];
+    out.push({
+      id: data.id || m.id,
+      threadId: data.threadId || m.threadId,
+      from: header(headers, 'From'),
+      subject: header(headers, 'Subject'),
+      date: header(headers, 'Date'),
+      snippet: data.snippet || '',
+    });
+  }
+  return out;
+}
+
+/**
+ * gmail read — full plaintext of one message.
+ * @param {{gmail:object}} services
+ * @param {{id:string}} opts
+ * @returns {Promise<{id:string, from:string, to:string, subject:string,
+ *   date:string, body:string}>}
+ */
+async function read(services, opts) {
+  const res = await services.gmail.users.messages.get({
+    userId: 'me',
+    id: opts.id,
+    format: 'full',
+  });
+  const data = res.data || {};
+  const headers = (data.payload && data.payload.headers) || [];
+  const body = findPlainText(data.payload);
+  return {
+    id: data.id || opts.id,
+    from: header(headers, 'From'),
+    to: header(headers, 'To'),
+    subject: header(headers, 'Subject'),
+    date: header(headers, 'Date'),
+    body: body !== null ? body : data.snippet || '',
+  };
+}
+
+/**
+ * gmail draft — create a draft (NO send; safe, ungated).
+ * @param {{gmail:object}} services
+ * @param {{to:string, subject:string, body:string}} opts
+ * @returns {Promise<{draftId:string, messageId:string}>}
+ */
+async function draft(services, opts) {
+  const raw = buildMime(opts);
+  const res = await services.gmail.users.drafts.create({
+    userId: 'me',
+    requestBody: { message: { raw } },
+  });
+  const data = res.data || {};
+  return {
+    draftId: data.id || '',
+    messageId: (data.message && data.message.id) || '',
+  };
+}
+
+/**
+ * Build an RFC-2822 message, base64url-encoded (no padding, '+/'→'-_').
+ * Exported for reuse by gmail send (WP-018).
+ * @param {{to:string, subject:string, body:string, from?:string}} m
+ * @returns {string}
+ */
+function buildMime(m) {
+  const lines = [];
+  if (m.from) lines.push(`From: ${m.from}`);
+  lines.push(`To: ${m.to}`);
+  lines.push(`Subject: ${m.subject}`);
+  lines.push('Content-Type: text/plain; charset="UTF-8"');
+  lines.push('');
+  lines.push(m.body);
+  const mime = lines.join('\r\n');
+  return Buffer.from(mime).toString('base64url');
+}
+
+module.exports = { search, read, draft, buildMime };

--- a/src/gws/index.js
+++ b/src/gws/index.js
@@ -1,0 +1,154 @@
+'use strict';
+
+const { getPaths } = require('../core/paths');
+const { WienerdogError } = require('../core/errors');
+const { getServices } = require('./client');
+
+/**
+ * Parse `gws` flags out of an argv tail, returning flags plus leftover
+ * positionals. Supported: --json (bool), --max <n>, --to <s>, --subject <s>,
+ * --body <s>, --client <path>.
+ * @param {string[]} argv
+ * @returns {{json:boolean, max?:number, to?:string, subject?:string,
+ *   body?:string, client?:string, positionals:string[]}}
+ */
+function parseFlags(argv) {
+  const flags = { json: false, positionals: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case '--json':
+        flags.json = true;
+        break;
+      case '--max':
+        flags.max = Number(argv[++i]);
+        break;
+      case '--to':
+        flags.to = argv[++i];
+        break;
+      case '--subject':
+        flags.subject = argv[++i];
+        break;
+      case '--body':
+        flags.body = argv[++i];
+        break;
+      case '--client':
+        flags.client = argv[++i];
+        break;
+      default:
+        flags.positionals.push(a);
+    }
+  }
+  return flags;
+}
+
+/**
+ * Require a flag to be present, else throw a WienerdogError naming it.
+ * @param {*} value
+ * @param {string} name
+ * @returns {*}
+ */
+function require_(value, name) {
+  if (value === undefined || value === null || value === '') {
+    throw new WienerdogError(`missing required flag ${name}`);
+  }
+  return value;
+}
+
+/**
+ * The `<group> <verb>` dispatch table. Each handler lazily requires its module
+ * so a group whose module is not shipped yet (WP-018/WP-019) fails only when
+ * invoked, without touching this file.
+ * @type {Record<string, (ctx:{paths:object, flags:object, services:()=>object})=>Promise<*>>}
+ */
+const DISPATCH = {
+  'auth': ({ paths, flags }) =>
+    require('./auth').run(paths, { clientPath: require_(flags.client, '--client') }),
+  'gmail search': ({ flags, services }) =>
+    require('./gmail').search(services(), {
+      query: require_(flags.positionals[0], '<query>'),
+      max: flags.max,
+    }),
+  'gmail read': ({ flags, services }) =>
+    require('./gmail').read(services(), {
+      id: require_(flags.positionals[0], '<id>'),
+    }),
+  'gmail draft': ({ flags, services }) =>
+    require('./gmail').draft(services(), {
+      to: require_(flags.to, '--to'),
+      subject: require_(flags.subject, '--subject'),
+      body: require_(flags.body, '--body'),
+    }),
+  'gmail send': ({ flags, services }) =>
+    require('./gmail').send(services(), flags), // WP-018; require throws until then
+  'cal': ({ flags, services }) => require('./calendar').run(services(), flags), // WP-019
+  'drive': ({ flags, services }) => require('./drive').run(services(), flags), // WP-019
+  '_alert': ({ paths, flags }) => require('./alert').run(paths, flags), // WP-018
+};
+
+/**
+ * Render a verb result to stdout — JSON when --json, else a short summary.
+ * @param {string} key
+ * @param {*} result
+ * @param {boolean} json
+ */
+function render(key, result, json) {
+  if (result === undefined) return;
+  if (json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+  if (key === 'gmail search' && Array.isArray(result)) {
+    for (const m of result) {
+      process.stdout.write(`${m.date}  ${m.from}  ${m.subject}\n`);
+    }
+  } else if (key === 'gmail read') {
+    process.stdout.write(
+      `From: ${result.from}\nTo: ${result.to}\nDate: ${result.date}\n` +
+        `Subject: ${result.subject}\n\n${result.body}\n`
+    );
+  } else if (key === 'gmail draft') {
+    process.stdout.write(`Draft created (draftId ${result.draftId}).\n`);
+  } else if (key === 'auth') {
+    const who = result.email ? ` as ${result.email}` : '';
+    process.stdout.write(`Connected to Google${who}. Token saved to ${result.tokenPath}.\n`);
+  } else {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  }
+}
+
+/**
+ * `wienerdog gws <group> <verb> [flags]`.
+ * @param {string[]} argv
+ * @returns {Promise<void>}
+ */
+async function run(argv) {
+  const group = argv[0];
+  // `auth` and the single-word groups (cal/drive/_alert) key on group alone;
+  // gmail keys on "<group> <verb>".
+  let key;
+  let rest;
+  if (group === 'gmail') {
+    key = `gmail ${argv[1]}`;
+    rest = argv.slice(2);
+  } else {
+    key = group;
+    rest = argv.slice(1);
+  }
+
+  const handler = DISPATCH[key];
+  if (!handler) {
+    throw new WienerdogError(`unknown gws command: ${argv.slice(0, 2).join(' ').trim()}`);
+  }
+
+  const flags = parseFlags(rest);
+  const paths = getPaths();
+  // Build services lazily so `auth` (which needs no token) never loads one.
+  let cached;
+  const services = () => (cached || (cached = getServices(paths)));
+
+  const result = await handler({ paths, flags, services });
+  render(key, result, flags.json);
+}
+
+module.exports = { run };

--- a/tests/unit/gws-client.test.js
+++ b/tests/unit/gws-client.test.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { getPaths } = require('../../src/core/paths');
+const { WienerdogError } = require('../../src/core/errors');
+const client = require('../../src/gws/client');
+
+/** Create a fresh temp core with an existing secrets/ (0700) and return paths. */
+function tempPaths() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-gws-'));
+  const core = path.join(root, 'wd');
+  const paths = getPaths({ HOME: root, WIENERDOG_HOME: core });
+  fs.mkdirSync(paths.secrets, { recursive: true, mode: 0o700 });
+  return paths;
+}
+
+test('SCOPES is exactly the four consented scopes, in order', () => {
+  assert.deepEqual(client.SCOPES, [
+    'https://www.googleapis.com/auth/gmail.readonly',
+    'https://www.googleapis.com/auth/gmail.compose',
+    'https://www.googleapis.com/auth/calendar',
+    'https://www.googleapis.com/auth/drive.readonly',
+  ]);
+});
+
+test('persistToken writes google-token.json at mode 0600 and loadToken round-trips', () => {
+  const paths = tempPaths();
+  const token = { access_token: 'a', refresh_token: 'r', expiry_date: 123 };
+  client.persistToken(paths, token);
+
+  const file = client.tokenPath(paths);
+  assert.equal(file, path.join(paths.secrets, 'google-token.json'));
+  const mode = fs.statSync(file).mode & 0o777;
+  assert.equal(mode, 0o600, `expected 0600, got ${mode.toString(8)}`);
+  assert.deepEqual(client.loadToken(paths), token);
+});
+
+test('persistToken creates secrets/ at 0700 when absent', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-gws-'));
+  const core = path.join(root, 'wd');
+  const paths = getPaths({ HOME: root, WIENERDOG_HOME: core });
+  assert.equal(fs.existsSync(paths.secrets), false);
+
+  client.persistToken(paths, { access_token: 'x' });
+  const dirMode = fs.statSync(paths.secrets).mode & 0o777;
+  assert.equal(dirMode, 0o700, `expected 0700, got ${dirMode.toString(8)}`);
+});
+
+test('persistClientJson writes google-client.json at mode 0600 and loadClientJson round-trips', () => {
+  const paths = tempPaths();
+  const cj = { installed: { client_id: 'id', client_secret: 'sec', redirect_uris: ['http://x'] } };
+  client.persistClientJson(paths, cj);
+
+  const file = client.clientJsonPath(paths);
+  assert.equal(file, path.join(paths.secrets, 'google-client.json'));
+  const mode = fs.statSync(file).mode & 0o777;
+  assert.equal(mode, 0o600, `expected 0600, got ${mode.toString(8)}`);
+  assert.deepEqual(client.loadClientJson(paths), cj);
+});
+
+test('loadToken throws a WienerdogError telling the user to run gws auth when missing', () => {
+  const paths = tempPaths();
+  assert.throws(
+    () => client.loadToken(paths),
+    (err) => err instanceof WienerdogError && /wienerdog gws auth/.test(err.message)
+  );
+});
+
+test('loadToken throws a WienerdogError on corrupt JSON', () => {
+  const paths = tempPaths();
+  fs.writeFileSync(client.tokenPath(paths), 'not json', { mode: 0o600 });
+  assert.throws(
+    () => client.loadToken(paths),
+    (err) => err instanceof WienerdogError
+  );
+});
+
+test('getServices with opts.factory returns the factory object and loads no real googleapis', () => {
+  const paths = tempPaths();
+  const token = { access_token: 'a' };
+  client.persistToken(paths, token);
+  client.persistClientJson(paths, { installed: { client_id: 'id', client_secret: 's' } });
+
+  const stub = { gmail: {}, calendar: {}, drive: {} };
+  let seenToken;
+  const services = client.getServices(paths, {
+    factory: (t) => {
+      seenToken = t;
+      return stub;
+    },
+  });
+
+  assert.equal(services, stub);
+  assert.deepEqual(seenToken, token);
+  // The real googleapis package must not have been loaded by the factory path.
+  // (Robust whether or not googleapis is installed: if it can't even resolve,
+  // it certainly wasn't loaded.)
+  let resolved;
+  try {
+    resolved = require.resolve('googleapis');
+  } catch {
+    resolved = null;
+  }
+  if (resolved) assert.equal(require.cache[resolved], undefined);
+});

--- a/tests/unit/gws-gmail.test.js
+++ b/tests/unit/gws-gmail.test.js
@@ -1,0 +1,169 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const gmail = require('../../src/gws/gmail');
+
+/** base64url-encode a plain string the way Gmail returns body data. */
+function b64url(s) {
+  return Buffer.from(s, 'utf8').toString('base64url');
+}
+
+test('search returns the mapped header array (list + per-message metadata get)', async () => {
+  const calls = [];
+  const services = {
+    gmail: {
+      users: {
+        messages: {
+          list: async (args) => {
+            calls.push(['list', args]);
+            return { data: { messages: [{ id: 'm1', threadId: 't1' }] } };
+          },
+          get: async (args) => {
+            calls.push(['get', args]);
+            return {
+              data: {
+                id: 'm1',
+                threadId: 't1',
+                snippet: 'Can you review the deck before...',
+                payload: {
+                  headers: [
+                    { name: 'From', value: 'Boss <boss@acme.com>' },
+                    { name: 'Subject', value: 'Q3 plan' },
+                    { name: 'Date', value: 'Wed, 2 Jul 2026 09:12:00 +0000' },
+                  ],
+                },
+              },
+            };
+          },
+        },
+      },
+    },
+  };
+
+  const result = await gmail.search(services, { query: 'from:boss is:unread', max: 2 });
+  assert.deepEqual(result, [
+    {
+      id: 'm1',
+      threadId: 't1',
+      from: 'Boss <boss@acme.com>',
+      subject: 'Q3 plan',
+      date: 'Wed, 2 Jul 2026 09:12:00 +0000',
+      snippet: 'Can you review the deck before...',
+    },
+  ]);
+  // maxResults passthrough and metadata format.
+  assert.equal(calls[0][1].q, 'from:boss is:unread');
+  assert.equal(calls[0][1].maxResults, 2);
+  assert.equal(calls[1][1].format, 'metadata');
+
+  // JSON output shape is valid JSON.
+  const json = JSON.stringify(result);
+  assert.deepEqual(JSON.parse(json), result);
+});
+
+test('read returns decoded plaintext from a nested multipart payload', async () => {
+  const services = {
+    gmail: {
+      users: {
+        messages: {
+          get: async () => ({
+            data: {
+              id: 'm2',
+              snippet: 'fallback snippet',
+              payload: {
+                mimeType: 'multipart/alternative',
+                headers: [
+                  { name: 'From', value: 'a@x.com' },
+                  { name: 'To', value: 'me@x.com' },
+                  { name: 'Subject', value: 'Hi' },
+                  { name: 'Date', value: 'Wed, 2 Jul 2026 09:12:00 +0000' },
+                ],
+                parts: [
+                  { mimeType: 'text/html', body: { data: b64url('<p>ignored</p>') } },
+                  { mimeType: 'text/plain', body: { data: b64url('Hello, world.') } },
+                ],
+              },
+            },
+          }),
+        },
+      },
+    },
+  };
+
+  const result = await gmail.read(services, { id: 'm2' });
+  assert.deepEqual(result, {
+    id: 'm2',
+    from: 'a@x.com',
+    to: 'me@x.com',
+    subject: 'Hi',
+    date: 'Wed, 2 Jul 2026 09:12:00 +0000',
+    body: 'Hello, world.',
+  });
+});
+
+test('read falls back to the snippet when no text/plain part exists', async () => {
+  const services = {
+    gmail: {
+      users: {
+        messages: {
+          get: async () => ({
+            data: {
+              id: 'm3',
+              snippet: 'only a snippet',
+              payload: { headers: [], parts: [{ mimeType: 'text/html', body: {} }] },
+            },
+          }),
+        },
+      },
+    },
+  };
+  const result = await gmail.read(services, { id: 'm3' });
+  assert.equal(result.body, 'only a snippet');
+});
+
+test('draft calls drafts.create with a base64url raw message and returns ids', async () => {
+  let seen;
+  const services = {
+    gmail: {
+      users: {
+        drafts: {
+          create: async (args) => {
+            seen = args;
+            return { data: { id: 'r-482', message: { id: '18f' } } };
+          },
+        },
+      },
+    },
+  };
+
+  const result = await gmail.draft(services, {
+    to: 'ada@acme.com',
+    subject: 'Re: deck',
+    body: 'On it.',
+  });
+  assert.deepEqual(result, { draftId: 'r-482', messageId: '18f' });
+
+  // The raw message decodes back to a well-formed MIME message.
+  assert.equal(seen.userId, 'me');
+  const raw = seen.requestBody.message.raw;
+  const decoded = Buffer.from(raw, 'base64url').toString('utf8');
+  assert.match(decoded, /^To: ada@acme\.com\r\n/);
+  assert.match(decoded, /Subject: Re: deck\r\n/);
+  assert.match(decoded, /Content-Type: text\/plain; charset="UTF-8"\r\n\r\nOn it\.$/);
+
+  // JSON output shape.
+  assert.deepEqual(JSON.parse(JSON.stringify(result)), result);
+});
+
+test('buildMime produces base64url with To/Subject/Content-Type headers and body', () => {
+  const raw = gmail.buildMime({ to: 't@x.com', subject: 'S', body: 'B', from: 'f@x.com' });
+  assert.doesNotMatch(raw, /[+/=]/); // base64url, no padding
+  const decoded = Buffer.from(raw, 'base64url').toString('utf8');
+  assert.equal(
+    decoded,
+    'From: f@x.com\r\nTo: t@x.com\r\nSubject: S\r\n' +
+      'Content-Type: text/plain; charset="UTF-8"\r\n\r\nB'
+  );
+});


### PR DESCRIPTION
Spec: docs/specs/WP-011-gws-foundation.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

Ships the `wienerdog gws` foundation: OAuth loopback `auth`, an injectable
client seam (`getServices`) so unit tests never touch the network, and Gmail
`search`/`read`/`draft` verbs. `googleapis` added as the single ADR-approved
runtime dependency. Dispatch table ships the full `<group> <verb>` map with
lazy `require`s so WP-018 (`send`/`_alert`) and WP-019 (`cal`/`drive`) slot in
without editing `index.js`. No send verb, no calendar/drive verbs here.

## Verification output

```
$ npm test
tests 114 | pass 114 | fail 0

$ npm test -- --test-name-pattern gws
tests 17 | pass 17 | fail 0

$ npm run lint
--- markdownlint ---   Summary: 0 error(s)
--- shellcheck ---
--- frontmatter check ---   frontmatter check passed: 6 spec(s), 4 agent(s)
lint passed

$ node -e "console.log(require('./src/gws/client').SCOPES.join('\n'))"
https://www.googleapis.com/auth/gmail.readonly
https://www.googleapis.com/auth/gmail.compose
https://www.googleapis.com/auth/calendar
https://www.googleapis.com/auth/drive.readonly

# No-token error path:
$ export WIENERDOG_HOME=$(mktemp -d)/wd
$ node bin/wienerdog.js init --yes >/dev/null
$ node bin/wienerdog.js gws gmail search "test"
wienerdog: no Google sign-in found — run `wienerdog gws auth` first
(exited non-zero as expected)
```

## Decisions made

- **Pinned `googleapis` to `^173.0.0`** — the latest stable major on npm at
  implementation time (the spec's `^140.0.0` was an illustrative example).
- **Live OAuth consent flow is NOT unit-tested** (per spec: manual verification
  at M5). `auth.js`'s loopback + browser-open + token-exchange path is used
  only via injected `oauthClient`/`googleapis` seams; unit tests cover
  `persistToken`/`loadToken`/`getServices` seam and the Gmail verbs against
  stubs. I did NOT attempt the live flow.
- **No-token message wording**: `loadToken` failure reads
  "no Google sign-in found — run `wienerdog gws auth` first"; a corrupt token
  file gets a distinct "file is corrupted … run auth again" message. Both are
  `WienerdogError` (plain-language, exit 1).
- **PR title** follows the launch instruction's exact wording
  (`feat(gws): implement gws foundation and Gmail read/draft (WP-011)`), which
  differs slightly from the spec DoD phrasing. Same WP, same scope.
- **`memory/lessons/inbox.md` not edited** — per launch instruction the owner
  appends lessons on main; lessons are listed in the final session message.
- **Loopback listener** is a one-shot `http.Server` on `127.0.0.1:0`, closed in
  a `finally` before `run` resolves (ADR-0004: no socket outlives the command).

## Discovered issues (out of scope, not fixed)

None.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EA5BsHCfHRViJFXdovC86

Generated-by: claude-opus-4-8
