### PR TITLE
feat(adapter): implement Codex CLI adapter (WP-010)

### DIFF
--- a/docs/specs/WP-010-codex-adapter.md
+++ b/docs/specs/WP-010-codex-adapter.md
@@ -1,7 +1,7 @@
 ---
 id: WP-010
 title: Implement Codex CLI adapter (AGENTS.md block, hooks.json, skills discovery, codex-exec brain)
-status: Ready
+status: In-Review
 model: sonnet
 size: M
 depends_on: [WP-006, WP-007, WP-008]

--- a/src/adapters/claude.js
+++ b/src/adapters/claude.js
@@ -2,251 +2,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-
-const BEGIN = '<!-- wienerdog:begin -->';
-const END = '<!-- wienerdog:end -->';
-
-/**
- * Record a manifest entry only if one with the same kind+path is not already
- * present. Keeps re-syncs from bloating the manifest with duplicates.
- * @param {object} [manifest]
- * @param {{kind: string, path: string, [k: string]: any}} entry
- */
-function recordOnce(manifest, entry) {
-  if (!manifest) return;
-  if (!Array.isArray(manifest.entries)) manifest.entries = [];
-  const exists = manifest.entries.some((e) => e.kind === entry.kind && e.path === entry.path);
-  if (!exists) manifest.entries.push(entry);
-}
-
-/**
- * Build the sentinel-delimited managed block from a digest string.
- * @param {string} digest
- * @returns {string} begin sentinel + digest.trimEnd() + end sentinel, no trailing newline.
- */
-function buildBlock(digest) {
-  return `${BEGIN}\n${digest.trimEnd()}\n${END}`;
-}
-
-/**
- * Step 1 — write the managed block into <claudeDir>/CLAUDE.md.
- * @param {string} claudeMd
- * @param {string} digest
- * @param {boolean} dryRun
- * @param {object} [manifest]
- * @param {{changed: string[], unchanged: string[], notices: string[]}} out
- */
-function applyManagedBlock(claudeMd, digest, dryRun, manifest, out) {
-  const block = buildBlock(digest);
-  let current = null;
-  try {
-    current = fs.readFileSync(claudeMd, 'utf8');
-  } catch {
-    current = null;
-  }
-
-  if (current === null) {
-    // File absent → create it holding exactly the block + newline.
-    const next = `${block}\n`;
-    if (!dryRun) {
-      fs.mkdirSync(path.dirname(claudeMd), { recursive: true });
-      fs.writeFileSync(claudeMd, next);
-    }
-    recordOnce(manifest, { kind: 'managed-block', path: claudeMd, createdFile: true });
-    out.changed.push(claudeMd);
-    return;
-  }
-
-  const begin = current.indexOf(BEGIN);
-  const end = current.indexOf(END);
-  if (begin !== -1 && end !== -1 && end > begin) {
-    // Replace everything from begin sentinel through end sentinel (inclusive).
-    const before = current.slice(0, begin);
-    const after = current.slice(end + END.length);
-    const next = `${before}${block}${after}`;
-    if (next === current) {
-      out.unchanged.push(claudeMd);
-    } else {
-      if (!dryRun) fs.writeFileSync(claudeMd, next);
-      out.changed.push(claudeMd);
-    }
-    // Manifest entry (if any) already exists from a prior run; do not re-record.
-    recordOnce(manifest, { kind: 'managed-block', path: claudeMd, createdFile: false });
-    return;
-  }
-
-  // File present without sentinels → append with exactly one blank-line separator.
-  const base = current.replace(/\n+$/, '');
-  const next = `${base}\n\n${block}\n`;
-  if (!dryRun) fs.writeFileSync(claudeMd, next);
-  recordOnce(manifest, { kind: 'managed-block', path: claudeMd, createdFile: false });
-  out.changed.push(claudeMd);
-}
-
-/**
- * Copy a hook script into core/bin with mode 0755, idempotently.
- * @param {string} src
- * @param {string} dest
- * @param {boolean} dryRun
- * @param {object} [manifest]
- * @param {{changed: string[], unchanged: string[], notices: string[]}} out
- */
-function copyHookScript(src, dest, dryRun, manifest, out) {
-  const desired = fs.readFileSync(src);
-  let same = false;
-  try {
-    same = fs.readFileSync(dest).equals(desired);
-  } catch {
-    same = false;
-  }
-  if (same) {
-    out.unchanged.push(dest);
-  } else {
-    if (!dryRun) {
-      fs.writeFileSync(dest, desired, { mode: 0o755 });
-      fs.chmodSync(dest, 0o755);
-    }
-    out.changed.push(dest);
-  }
-  recordOnce(manifest, { kind: 'file', path: dest });
-}
-
-/**
- * Step 2 — register SessionStart + SessionEnd hooks in settings.json, merging
- * without clobbering the user's existing hooks.
- * @param {string} settingsPath
- * @param {string} startAbs absolute path to session-start.sh in core/bin
- * @param {string} endAbs absolute path to session-end.sh in core/bin
- * @param {boolean} dryRun
- * @param {object} [manifest]
- * @param {{changed: string[], unchanged: string[], notices: string[]}} out
- */
-function applySettings(settingsPath, startAbs, endAbs, dryRun, manifest, out) {
-  let raw = null;
-  try {
-    raw = fs.readFileSync(settingsPath, 'utf8');
-  } catch {
-    raw = null;
-  }
-  const createdFile = raw === null;
-  /** @type {any} */
-  let settings = {};
-  if (!createdFile) {
-    settings = JSON.parse(raw);
-    if (settings === null || typeof settings !== 'object' || Array.isArray(settings)) {
-      settings = {};
-    }
-  }
-
-  if (typeof settings.hooks !== 'object' || settings.hooks === null || Array.isArray(settings.hooks)) {
-    settings.hooks = {};
-  }
-
-  let changed = false;
-  const events = [
-    ['SessionStart', startAbs],
-    ['SessionEnd', endAbs],
-  ];
-  for (const [event, command] of events) {
-    if (!Array.isArray(settings.hooks[event])) settings.hooks[event] = [];
-    const present = settings.hooks[event].some(
-      (group) =>
-        group &&
-        Array.isArray(group.hooks) &&
-        group.hooks.some((h) => h && h.command === command)
-    );
-    if (!present) {
-      settings.hooks[event].push({
-        matcher: '*',
-        hooks: [{ type: 'command', command, timeout: 10 }],
-      });
-      changed = true;
-    }
-  }
-
-  if (changed) {
-    if (!dryRun) fs.writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`);
-    out.changed.push(settingsPath);
-  } else {
-    out.unchanged.push(settingsPath);
-  }
-  recordOnce(manifest, {
-    kind: 'settings-entry',
-    path: settingsPath,
-    createdFile,
-    commands: [startAbs, endAbs],
-  });
-}
-
-/**
- * Step 3 — symlink each core skill dir into <claudeDir>/skills.
- * @param {string} skillsDir core skills dir
- * @param {string} claudeSkillsDir <claudeDir>/skills
- * @param {boolean} dryRun
- * @param {object} [manifest]
- * @param {{changed: string[], unchanged: string[], notices: string[]}} out
- */
-function applySkillLinks(skillsDir, claudeSkillsDir, dryRun, manifest, out) {
-  if (process.platform === 'win32') {
-    out.notices.push('skill linking unsupported on Windows in v1');
-    return;
-  }
-
-  let names = [];
-  try {
-    names = fs
-      .readdirSync(skillsDir, { withFileTypes: true })
-      .filter((d) => (d.isDirectory() || d.isSymbolicLink()) && d.name.startsWith('wienerdog-'))
-      .map((d) => d.name);
-  } catch {
-    names = [];
-  }
-  if (names.length === 0) return;
-
-  // Ensure <claudeDir>/skills exists.
-  if (!fs.existsSync(claudeSkillsDir)) {
-    if (!dryRun) fs.mkdirSync(claudeSkillsDir, { recursive: true });
-    recordOnce(manifest, { kind: 'dir', path: claudeSkillsDir });
-  }
-
-  for (const name of names) {
-    const target = path.join(skillsDir, name);
-    const linkPath = path.join(claudeSkillsDir, name);
-    let stat = null;
-    try {
-      stat = fs.lstatSync(linkPath);
-    } catch {
-      stat = null;
-    }
-
-    if (stat === null) {
-      if (!dryRun) fs.symlinkSync(target, linkPath);
-      recordOnce(manifest, { kind: 'symlink', path: linkPath });
-      out.changed.push(linkPath);
-    } else if (stat.isSymbolicLink()) {
-      let currentTarget = null;
-      try {
-        currentTarget = fs.readlinkSync(linkPath);
-      } catch {
-        currentTarget = null;
-      }
-      if (currentTarget === target) {
-        out.unchanged.push(linkPath);
-        recordOnce(manifest, { kind: 'symlink', path: linkPath });
-      } else {
-        if (!dryRun) {
-          fs.unlinkSync(linkPath);
-          fs.symlinkSync(target, linkPath);
-        }
-        recordOnce(manifest, { kind: 'symlink', path: linkPath });
-        out.changed.push(linkPath);
-      }
-    } else {
-      // Regular file/dir the user owns — never clobber.
-      out.notices.push(`left user file untouched: ${linkPath}`);
-    }
-  }
-}
+const shared = require('./shared');
 
 /**
  * Apply the Claude Code adapter idempotently.
@@ -290,7 +46,7 @@ function applyClaudeAdapter(paths, opts = {}) {
   }
 
   // Step 1 — managed block.
-  applyManagedBlock(claudeMd, digest, dryRun, manifest, out);
+  shared.applyManagedBlock(claudeMd, digest, dryRun, manifest, out);
 
   // Step 2 — hook scripts + settings.json.
   const startSrc = path.resolve(__dirname, '..', '..', 'templates', 'hooks', 'session-start.sh');
@@ -300,14 +56,14 @@ function applyClaudeAdapter(paths, opts = {}) {
 
   if (!fs.existsSync(binDir)) {
     if (!dryRun) fs.mkdirSync(binDir, { recursive: true });
-    recordOnce(manifest, { kind: 'dir', path: binDir });
+    shared.recordOnce(manifest, { kind: 'dir', path: binDir });
   }
-  copyHookScript(startSrc, startAbs, dryRun, manifest, out);
-  copyHookScript(endSrc, endAbs, dryRun, manifest, out);
-  applySettings(settingsPath, startAbs, endAbs, dryRun, manifest, out);
+  shared.copyHookScript(startSrc, startAbs, dryRun, manifest, out);
+  shared.copyHookScript(endSrc, endAbs, dryRun, manifest, out);
+  shared.applySettings(settingsPath, [['SessionStart', startAbs], ['SessionEnd', endAbs]], dryRun, manifest, out);
 
   // Step 3 — skill symlinks.
-  applySkillLinks(skillsDir, claudeSkillsDir, dryRun, manifest, out);
+  shared.applySkillLinks(skillsDir, claudeSkillsDir, dryRun, manifest, out);
 
   return out;
 }

--- a/src/adapters/codex.js
+++ b/src/adapters/codex.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const shared = require('./shared');
+
+/**
+ * Apply the Codex CLI adapter idempotently.
+ *
+ * The AGENTS.md managed block holds the whole digest so a Codex session has
+ * its context even with zero (or untrusted) hooks; the SessionStart/Stop
+ * hooks are enrichment only. Correctness never depends on a hook firing.
+ * Ground-truth transcript capture is rollout-file scanning (WP-007), which
+ * works with zero hooks trusted.
+ *
+ * @param {ReturnType<import('../core/paths').getPaths>} paths
+ * @param {{dryRun?: boolean, manifest?: object}} [opts]
+ * @returns {{changed: string[], unchanged: string[], notices: string[]}}
+ *  Steps (each idempotent; on dryRun make NO writes, still report intended changes):
+ *    1. Managed block in <codexDir>/AGENTS.md ← contents of <state>/digest.md.
+ *       If <codexDir>/AGENTS.override.md exists, push a NOTICE: our AGENTS.md is
+ *       silently shadowed by the override (research fact) — user must merge manually.
+ *    2. Copy session-start.sh + codex-session-end.sh into <core>/bin/ (0755); register
+ *       SessionStart + Stop command hooks in <codexDir>/hooks.json (settings-entry).
+ *       Push a NOTICE: Codex requires trusting new hooks via `/hooks` before they run;
+ *       the AGENTS.md block already carries the digest so context works regardless.
+ *    3. Symlink each <core>/skills/wienerdog-* into <home>/.agents/skills/ (Codex
+ *       user-scope skill-discovery dir; NOT config.toml — see the research memo).
+ *  Never throws on a missing digest — if <state>/digest.md is absent, return early
+ *  with a notice (sync writes it first). Records new entries in opts.manifest.
+ */
+function applyCodexAdapter(paths, opts = {}) {
+  const dryRun = opts.dryRun === true;
+  const manifest = opts.manifest;
+  /** @type {{changed: string[], unchanged: string[], notices: string[]}} */
+  const out = { changed: [], unchanged: [], notices: [] };
+
+  const binDir = path.join(paths.core, 'bin');
+  const skillsDir = path.join(paths.core, 'skills');
+  const agentsMd = path.join(paths.codexDir, 'AGENTS.md');
+  const overridePath = path.join(paths.codexDir, 'AGENTS.override.md');
+  const hooksPath = path.join(paths.codexDir, 'hooks.json');
+  const agentsSkillsDir = path.join(paths.home, '.agents', 'skills'); // NOT codexDir-relative
+  const digestPath = path.join(paths.state, 'digest.md');
+  const startSrc = path.resolve(__dirname, '..', '..', 'templates', 'hooks', 'session-start.sh');
+  const stopSrc = path.resolve(__dirname, '..', '..', 'templates', 'hooks', 'codex-session-end.sh');
+  const startAbs = path.join(binDir, 'session-start.sh');
+  const stopAbs = path.join(binDir, 'codex-session-end.sh');
+
+  let digest;
+  try {
+    digest = fs.readFileSync(digestPath, 'utf8');
+  } catch {
+    out.notices.push(`digest not found at ${digestPath}; skipping Codex adapter`);
+    return out;
+  }
+
+  // Step 1 — managed block.
+  shared.applyManagedBlock(agentsMd, digest, dryRun, manifest, out);
+  if (fs.existsSync(overridePath)) {
+    out.notices.push(
+      "~/.codex/AGENTS.override.md exists — it shadows Wienerdog's AGENTS.md; merge the managed block manually or remove the override"
+    );
+  }
+
+  // Step 2 — hook scripts + hooks.json.
+  if (!fs.existsSync(binDir)) {
+    if (!dryRun) fs.mkdirSync(binDir, { recursive: true });
+    shared.recordOnce(manifest, { kind: 'dir', path: binDir });
+  }
+  shared.copyHookScript(startSrc, startAbs, dryRun, manifest, out);
+  shared.copyHookScript(stopSrc, stopAbs, dryRun, manifest, out);
+  shared.applySettings(hooksPath, [['SessionStart', startAbs], ['Stop', stopAbs]], dryRun, manifest, out);
+  out.notices.push(
+    "Codex requires trusting new hooks via `/hooks` before they run; the AGENTS.md block already carries the digest so context works regardless"
+  );
+
+  // Step 3 — skill symlinks.
+  shared.applySkillLinks(skillsDir, agentsSkillsDir, dryRun, manifest, out);
+
+  return out;
+}
+
+module.exports = { applyCodexAdapter };

--- a/src/adapters/shared.js
+++ b/src/adapters/shared.js
@@ -1,0 +1,246 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const BEGIN = '<!-- wienerdog:begin -->';
+const END = '<!-- wienerdog:end -->';
+
+/**
+ * Record a manifest entry only if one with the same kind+path is not already
+ * present. Keeps re-syncs from bloating the manifest with duplicates.
+ * @param {object} [manifest]
+ * @param {{kind: string, path: string, [k: string]: any}} entry
+ */
+function recordOnce(manifest, entry) {
+  if (!manifest) return;
+  if (!Array.isArray(manifest.entries)) manifest.entries = [];
+  const exists = manifest.entries.some((e) => e.kind === entry.kind && e.path === entry.path);
+  if (!exists) manifest.entries.push(entry);
+}
+
+/**
+ * Build the sentinel-delimited managed block from a digest string.
+ * @param {string} digest
+ * @returns {string} begin sentinel + digest.trimEnd() + end sentinel, no trailing newline.
+ */
+function buildBlock(digest) {
+  return `${BEGIN}\n${digest.trimEnd()}\n${END}`;
+}
+
+/**
+ * Step 1 — write the managed block into a target markdown file (Claude's
+ * CLAUDE.md or Codex's AGENTS.md).
+ * @param {string} mdPath
+ * @param {string} digest
+ * @param {boolean} dryRun
+ * @param {object} [manifest]
+ * @param {{changed: string[], unchanged: string[], notices: string[]}} out
+ */
+function applyManagedBlock(mdPath, digest, dryRun, manifest, out) {
+  const block = buildBlock(digest);
+  let current = null;
+  try {
+    current = fs.readFileSync(mdPath, 'utf8');
+  } catch {
+    current = null;
+  }
+
+  if (current === null) {
+    // File absent → create it holding exactly the block + newline.
+    const next = `${block}\n`;
+    if (!dryRun) {
+      fs.mkdirSync(path.dirname(mdPath), { recursive: true });
+      fs.writeFileSync(mdPath, next);
+    }
+    recordOnce(manifest, { kind: 'managed-block', path: mdPath, createdFile: true });
+    out.changed.push(mdPath);
+    return;
+  }
+
+  const begin = current.indexOf(BEGIN);
+  const end = current.indexOf(END);
+  if (begin !== -1 && end !== -1 && end > begin) {
+    // Replace everything from begin sentinel through end sentinel (inclusive).
+    const before = current.slice(0, begin);
+    const after = current.slice(end + END.length);
+    const next = `${before}${block}${after}`;
+    if (next === current) {
+      out.unchanged.push(mdPath);
+    } else {
+      if (!dryRun) fs.writeFileSync(mdPath, next);
+      out.changed.push(mdPath);
+    }
+    // Manifest entry (if any) already exists from a prior run; do not re-record.
+    recordOnce(manifest, { kind: 'managed-block', path: mdPath, createdFile: false });
+    return;
+  }
+
+  // File present without sentinels → append with exactly one blank-line separator.
+  const base = current.replace(/\n+$/, '');
+  const next = `${base}\n\n${block}\n`;
+  if (!dryRun) fs.writeFileSync(mdPath, next);
+  recordOnce(manifest, { kind: 'managed-block', path: mdPath, createdFile: false });
+  out.changed.push(mdPath);
+}
+
+/**
+ * Copy a hook script into core/bin with mode 0755, idempotently.
+ * @param {string} src
+ * @param {string} dest
+ * @param {boolean} dryRun
+ * @param {object} [manifest]
+ * @param {{changed: string[], unchanged: string[], notices: string[]}} out
+ */
+function copyHookScript(src, dest, dryRun, manifest, out) {
+  const desired = fs.readFileSync(src);
+  let same = false;
+  try {
+    same = fs.readFileSync(dest).equals(desired);
+  } catch {
+    same = false;
+  }
+  if (same) {
+    out.unchanged.push(dest);
+  } else {
+    if (!dryRun) {
+      fs.writeFileSync(dest, desired, { mode: 0o755 });
+      fs.chmodSync(dest, 0o755);
+    }
+    out.changed.push(dest);
+  }
+  recordOnce(manifest, { kind: 'file', path: dest });
+}
+
+/**
+ * Merge command hooks into a JSON file's `.hooks`, dedup by command path.
+ * @param {string} settingsPath  target JSON file (Claude settings.json OR Codex hooks.json)
+ * @param {Array<[string, string]>} events  e.g. [['SessionStart', startAbs], ['Stop', stopAbs]]
+ * @param {boolean} dryRun
+ * @param {object} [manifest]
+ * @param {{changed: string[], unchanged: string[], notices: string[]}} out
+ */
+function applySettings(settingsPath, events, dryRun, manifest, out) {
+  let raw = null;
+  try {
+    raw = fs.readFileSync(settingsPath, 'utf8');
+  } catch {
+    raw = null;
+  }
+  const createdFile = raw === null;
+  /** @type {any} */
+  let settings = {};
+  if (!createdFile) {
+    settings = JSON.parse(raw);
+    if (settings === null || typeof settings !== 'object' || Array.isArray(settings)) {
+      settings = {};
+    }
+  }
+
+  if (typeof settings.hooks !== 'object' || settings.hooks === null || Array.isArray(settings.hooks)) {
+    settings.hooks = {};
+  }
+
+  let changed = false;
+  for (const [event, command] of events) {
+    if (!Array.isArray(settings.hooks[event])) settings.hooks[event] = [];
+    const present = settings.hooks[event].some(
+      (group) =>
+        group &&
+        Array.isArray(group.hooks) &&
+        group.hooks.some((h) => h && h.command === command)
+    );
+    if (!present) {
+      settings.hooks[event].push({
+        matcher: '*',
+        hooks: [{ type: 'command', command, timeout: 10 }],
+      });
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    if (!dryRun) fs.writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`);
+    out.changed.push(settingsPath);
+  } else {
+    out.unchanged.push(settingsPath);
+  }
+  recordOnce(manifest, {
+    kind: 'settings-entry',
+    path: settingsPath,
+    createdFile,
+    commands: events.map(([, command]) => command),
+  });
+}
+
+/**
+ * Step 3 — symlink each core skill dir into a target harness's skills dir.
+ * @param {string} skillsDir core skills dir
+ * @param {string} targetSkillsDir the harness's skills dir
+ * @param {boolean} dryRun
+ * @param {object} [manifest]
+ * @param {{changed: string[], unchanged: string[], notices: string[]}} out
+ */
+function applySkillLinks(skillsDir, targetSkillsDir, dryRun, manifest, out) {
+  if (process.platform === 'win32') {
+    out.notices.push('skill linking unsupported on Windows in v1');
+    return;
+  }
+
+  let names = [];
+  try {
+    names = fs
+      .readdirSync(skillsDir, { withFileTypes: true })
+      .filter((d) => (d.isDirectory() || d.isSymbolicLink()) && d.name.startsWith('wienerdog-'))
+      .map((d) => d.name);
+  } catch {
+    names = [];
+  }
+  if (names.length === 0) return;
+
+  // Ensure the target skills dir exists.
+  if (!fs.existsSync(targetSkillsDir)) {
+    if (!dryRun) fs.mkdirSync(targetSkillsDir, { recursive: true });
+    recordOnce(manifest, { kind: 'dir', path: targetSkillsDir });
+  }
+
+  for (const name of names) {
+    const target = path.join(skillsDir, name);
+    const linkPath = path.join(targetSkillsDir, name);
+    let stat = null;
+    try {
+      stat = fs.lstatSync(linkPath);
+    } catch {
+      stat = null;
+    }
+
+    if (stat === null) {
+      if (!dryRun) fs.symlinkSync(target, linkPath);
+      recordOnce(manifest, { kind: 'symlink', path: linkPath });
+      out.changed.push(linkPath);
+    } else if (stat.isSymbolicLink()) {
+      let currentTarget = null;
+      try {
+        currentTarget = fs.readlinkSync(linkPath);
+      } catch {
+        currentTarget = null;
+      }
+      if (currentTarget === target) {
+        out.unchanged.push(linkPath);
+        recordOnce(manifest, { kind: 'symlink', path: linkPath });
+      } else {
+        if (!dryRun) {
+          fs.unlinkSync(linkPath);
+          fs.symlinkSync(target, linkPath);
+        }
+        recordOnce(manifest, { kind: 'symlink', path: linkPath });
+        out.changed.push(linkPath);
+      }
+    } else {
+      // Regular file/dir the user owns — never clobber.
+      out.notices.push(`left user file untouched: ${linkPath}`);
+    }
+  }
+}
+
+module.exports = { recordOnce, buildBlock, applyManagedBlock, copyHookScript, applySettings, applySkillLinks };

--- a/src/cli/sync.js
+++ b/src/cli/sync.js
@@ -8,6 +8,7 @@ const { renderDigest } = require('../core/digest');
 const { detectHarnesses } = require('../core/detect');
 const manifestMod = require('../core/manifest');
 const { applyClaudeAdapter } = require('../adapters/claude');
+const { applyCodexAdapter } = require('../adapters/codex');
 
 /**
  * Read the `vault:` path out of config.yaml (flat-YAML subset, same approach as
@@ -163,6 +164,16 @@ async function run(argv) {
     summary.notices.push(...res.notices);
   } else {
     console.log('Claude Code not detected; skipping adapter.');
+  }
+
+  // 4b. Apply the Codex CLI adapter if Codex CLI is present.
+  if (detectHarnesses(process.env).codex.present) {
+    const res = applyCodexAdapter(paths, { dryRun, manifest });
+    summary.changed.push(...res.changed);
+    summary.unchanged.push(...res.unchanged);
+    summary.notices.push(...res.notices);
+  } else {
+    console.log('Codex CLI not detected; skipping adapter.');
   }
 
   // 5. Persist the manifest (never on dry-run).

--- a/src/core/dream/brain.js
+++ b/src/core/dream/brain.js
@@ -59,17 +59,44 @@ function buildClaudeArgs({ vaultDir, scratchDir, date, model }) {
 }
 
 /**
+ * Build the argv for the headless Codex brain, AFTER the "codex" name.
+ * UNVERIFIED-until-live-M4-test: two open upstream bugs shape this (see comments);
+ * wd-researcher must re-verify against the shipping `codex --version` before M4.
+ * @param {{vaultDir:string, scratchDir:string, date:string, model:string|null}} o
+ * @returns {string[]}
+ */
+function buildCodexArgs({ vaultDir, scratchDir, date, model }) {
+  return [
+    'exec',
+    '--sandbox',
+    'workspace-write',
+    '--cd',
+    vaultDir, // THE write fence: --add-dir does NOT fence apply_patch (openai/codex#24214)
+    '--add-dir',
+    scratchDir, // best-effort read access to the extracts (see note)
+    '-c',
+    'approval_policy=never', // NOT `--ask-for-approval never` after exec (#26602)
+    '-c',
+    'sandbox_workspace_write.network_access=false', // no network
+    '--skip-git-repo-check', // the vault/scratch may not be a git repo
+    ...(model ? ['--model', model] : []),
+    DREAM_PROMPT(scratchDir, vaultDir, date), // positional prompt (last)
+  ];
+}
+
+/**
  * Spawn the brain and return a handle + completion promise. NO watchdog here —
  * WP-017 wraps this with the timeout kill. detached:true is REQUIRED so WP-017
  * can kill the whole process group. Must never run in production without that
  * watchdog.
  * @param {{vaultDir:string, scratchDir:string, date:string, model:string|null,
- *          env?:NodeJS.ProcessEnv, logStream?:NodeJS.WritableStream}} o
+ *          harness?:'claude'|'codex', env?:NodeJS.ProcessEnv,
+ *          logStream?:NodeJS.WritableStream}} o
  * @returns {{ child: import('child_process').ChildProcess,
  *             done: Promise<{code:number|null, durationMs:number}> }}
  */
 function spawnBrain(o) {
-  const { vaultDir, scratchDir, date, model, env, logStream } = o;
+  const { vaultDir, scratchDir, date, model, harness, env, logStream } = o;
   const baseEnv = env || process.env;
   const childEnv = {
     ...baseEnv,
@@ -78,10 +105,20 @@ function spawnBrain(o) {
     // WIENERDOG_FAKE_TODAY passes through from baseEnv unchanged.
   };
 
-  // WIENERDOG_DREAM_CMD is the test seam: run that executable instead of claude.
+  // WIENERDOG_DREAM_CMD is the test seam: run that executable instead of claude/codex.
   const fakeCmd = baseEnv.WIENERDOG_DREAM_CMD;
-  const command = fakeCmd || 'claude';
-  const args = fakeCmd ? [] : buildClaudeArgs({ vaultDir, scratchDir, date, model });
+  let command;
+  let args;
+  if (fakeCmd) {
+    command = fakeCmd;
+    args = [];
+  } else if (harness === 'codex') {
+    command = 'codex';
+    args = buildCodexArgs({ vaultDir, scratchDir, date, model });
+  } else {
+    command = 'claude';
+    args = buildClaudeArgs({ vaultDir, scratchDir, date, model });
+  }
 
   const startedAt = Date.now();
   const child = spawn(command, args, {
@@ -105,4 +142,4 @@ function spawnBrain(o) {
   return { child, done };
 }
 
-module.exports = { buildClaudeArgs, spawnBrain, DREAM_PROMPT };
+module.exports = { buildClaudeArgs, buildCodexArgs, spawnBrain, DREAM_PROMPT };

--- a/templates/hooks/codex-session-end.sh
+++ b/templates/hooks/codex-session-end.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Wienerdog Codex Stop hook (enrichment, not capture): appends a capture hint to
+# the queue. Ground-truth capture is rollout-file scanning (WP-007); this only
+# speeds discovery. Fail-open. Stop hooks must not print plain text — this emits
+# no stdout at all (exit 0 = success), which is valid.
+set -euo pipefail
+
+CORE="${WIENERDOG_HOME:-$HOME/.wienerdog}"
+QUEUE="$CORE/state/queue.jsonl"
+mkdir -p "$CORE/state"
+
+# Codex passes hook JSON on stdin: {session_id, transcript_path, cwd, hook_event_name, ...}.
+node -e '
+let raw = "";
+process.stdin.on("data", (d) => (raw += d));
+process.stdin.on("end", () => {
+  let j = {};
+  try {
+    j = JSON.parse(raw || "{}");
+  } catch (e) {
+    j = {};
+  }
+  const line = JSON.stringify({ harness: "codex", session_path: j.transcript_path || null, cwd: j.cwd || null, ts: new Date().toISOString() });
+  require("fs").appendFileSync(process.argv[1], line + "\n");
+});' "$QUEUE"
+exit 0

--- a/tests/golden/codex-adapter/AGENTS.md
+++ b/tests/golden/codex-adapter/AGENTS.md
@@ -1,0 +1,7 @@
+<!-- wienerdog:begin -->
+# Who you're working with
+Ada Kovács — product lead.
+
+## Standing instructions
+Be concise.
+<!-- wienerdog:end -->

--- a/tests/unit/codex-adapter.test.js
+++ b/tests/unit/codex-adapter.test.js
@@ -1,0 +1,315 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const { getPaths } = require('../../src/core/paths');
+const { applyCodexAdapter } = require('../../src/adapters/codex');
+const manifestLib = require('../../src/core/manifest');
+const { buildCodexArgs, spawnBrain } = require('../../src/core/dream/brain');
+const { collectExtracts } = require('../../src/core/dream/scratch');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const bin = path.join(repoRoot, 'bin', 'wienerdog.js');
+
+const FIXED_DIGEST = ['# Who you\'re working with', 'Ada Kovács — product lead.', '', '## Standing instructions', 'Be concise.', ''].join('\n');
+
+const GOLDEN = path.join(__dirname, '..', 'golden', 'codex-adapter', 'AGENTS.md');
+
+/**
+ * Fresh temp core + codex dir, with the fixed digest already written to
+ * <state>/digest.md. Never touches the real $HOME, ~/.codex or ~/.agents.
+ * CLAUDE_CONFIG_DIR is left unset with no <HOME>/.claude, so Claude is absent.
+ * @returns {import('../../src/core/paths').WienerdogPaths}
+ */
+function setup() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-codex-'));
+  const env = {
+    HOME: root,
+    WIENERDOG_HOME: path.join(root, 'wd'),
+    CODEX_HOME: path.join(root, 'codex'),
+  };
+  const paths = getPaths(env);
+  fs.mkdirSync(paths.state, { recursive: true });
+  fs.mkdirSync(paths.codexDir, { recursive: true });
+  fs.writeFileSync(path.join(paths.state, 'digest.md'), FIXED_DIGEST);
+  return paths;
+}
+
+/** @returns {object} */
+function freshManifest() {
+  return { version: 1, createdAt: new Date().toISOString(), entries: [] };
+}
+
+test('AGENTS.md managed block, new file: matches the golden byte-for-byte', () => {
+  const paths = setup();
+  const agentsMd = path.join(paths.codexDir, 'AGENTS.md');
+  applyCodexAdapter(paths, { manifest: freshManifest() });
+  assert.equal(fs.readFileSync(agentsMd, 'utf8'), fs.readFileSync(GOLDEN, 'utf8'));
+});
+
+test('AGENTS.md preserves surrounding content and replaces in place', () => {
+  const paths = setup();
+  const agentsMd = path.join(paths.codexDir, 'AGENTS.md');
+  fs.writeFileSync(agentsMd, '# My notes\n\ntext\n');
+  const manifest = freshManifest();
+
+  applyCodexAdapter(paths, { manifest });
+  let content = fs.readFileSync(agentsMd, 'utf8');
+  assert.ok(content.startsWith('# My notes\n\ntext\n'), 'original content survives verbatim');
+  assert.ok(content.includes('text\n\n<!-- wienerdog:begin -->'));
+  assert.equal(content.match(/wienerdog:begin/g).length, 1, 'exactly one block');
+
+  applyCodexAdapter(paths, { manifest });
+  content = fs.readFileSync(agentsMd, 'utf8');
+  assert.ok(content.startsWith('# My notes\n\ntext\n'));
+  assert.equal(content.match(/wienerdog:begin/g).length, 1, 'still exactly one block');
+});
+
+test('AGENTS.override.md existing triggers a shadowing notice', () => {
+  const paths = setup();
+  fs.writeFileSync(path.join(paths.codexDir, 'AGENTS.override.md'), '# override\n');
+
+  const res = applyCodexAdapter(paths, { manifest: freshManifest() });
+  assert.ok(
+    res.notices.some((n) => n.includes('AGENTS.override.md') && n.toLowerCase().includes('shadow')),
+    'expected an override-shadowing notice'
+  );
+});
+
+test('hooks.json merge preserves existing hooks and dedups; /hooks trust notice present', () => {
+  const paths = setup();
+  const hooksPath = path.join(paths.codexDir, 'hooks.json');
+  const preExisting = {
+    hooks: {
+      Stop: [{ hooks: [{ type: 'command', command: '/usr/local/bin/other-stop.sh', timeout: 30 }] }],
+    },
+  };
+  fs.writeFileSync(hooksPath, `${JSON.stringify(preExisting, null, 2)}\n`);
+  const manifest = freshManifest();
+
+  const res = applyCodexAdapter(paths, { manifest });
+  let hooks = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
+  const startAbs = path.join(paths.core, 'bin', 'session-start.sh');
+  const stopAbs = path.join(paths.core, 'bin', 'codex-session-end.sh');
+
+  const allCommands = (event) => (hooks.hooks[event] || []).flatMap((g) => g.hooks.map((h) => h.command));
+  assert.ok(allCommands('Stop').includes('/usr/local/bin/other-stop.sh'), 'unrelated hook survives');
+  assert.equal(allCommands('SessionStart').filter((c) => c === startAbs).length, 1);
+  assert.equal(allCommands('Stop').filter((c) => c === stopAbs).length, 1);
+  assert.ok(res.notices.some((n) => n.includes('/hooks')), 'expected the /hooks trust notice');
+
+  // Second run: no duplicates.
+  applyCodexAdapter(paths, { manifest });
+  hooks = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
+  assert.equal(allCommands('SessionStart').filter((c) => c === startAbs).length, 1);
+  assert.equal(allCommands('Stop').filter((c) => c === stopAbs).length, 1);
+  assert.ok(allCommands('Stop').includes('/usr/local/bin/other-stop.sh'));
+});
+
+test('skills symlink into .agents/skills points at the core skill dir', () => {
+  const paths = setup();
+  const coreSkill = path.join(paths.core, 'skills', 'wienerdog-setup');
+  fs.mkdirSync(coreSkill, { recursive: true });
+  fs.writeFileSync(path.join(coreSkill, 'SKILL.md'), '# skill\n');
+
+  applyCodexAdapter(paths, { manifest: freshManifest() });
+
+  const linkPath = path.join(paths.home, '.agents', 'skills', 'wienerdog-setup');
+  if (process.platform === 'win32') return; // symlinking skipped on Windows in v1
+  assert.ok(fs.lstatSync(linkPath).isSymbolicLink());
+  assert.equal(fs.readlinkSync(linkPath), coreSkill);
+});
+
+test('idempotency: second run reports no changes and does not touch mtimes', () => {
+  const paths = setup();
+  const coreSkill = path.join(paths.core, 'skills', 'wienerdog-setup');
+  fs.mkdirSync(coreSkill, { recursive: true });
+  fs.writeFileSync(path.join(coreSkill, 'SKILL.md'), '# skill\n');
+  const manifest = freshManifest();
+  const agentsMd = path.join(paths.codexDir, 'AGENTS.md');
+  const hooksPath = path.join(paths.codexDir, 'hooks.json');
+
+  applyCodexAdapter(paths, { manifest });
+  const mdMtime = fs.statSync(agentsMd).mtimeMs;
+  const hooksMtime = fs.statSync(hooksPath).mtimeMs;
+
+  const res = applyCodexAdapter(paths, { manifest });
+  assert.deepEqual(res.changed, []);
+  assert.equal(fs.statSync(agentsMd).mtimeMs, mdMtime);
+  assert.equal(fs.statSync(hooksPath).mtimeMs, hooksMtime);
+});
+
+test('uninstall reverses everything, keeping unrelated hooks and user content', () => {
+  const paths = setup();
+  const coreSkill = path.join(paths.core, 'skills', 'wienerdog-setup');
+  fs.mkdirSync(coreSkill, { recursive: true });
+  fs.writeFileSync(path.join(coreSkill, 'SKILL.md'), '# skill\n');
+
+  const agentsMd = path.join(paths.codexDir, 'AGENTS.md');
+  const hooksPath = path.join(paths.codexDir, 'hooks.json');
+  const preExisting = {
+    hooks: {
+      Stop: [{ hooks: [{ type: 'command', command: '/usr/local/bin/other-stop.sh', timeout: 30 }] }],
+    },
+  };
+  fs.writeFileSync(hooksPath, `${JSON.stringify(preExisting, null, 2)}\n`);
+
+  const manifest = freshManifest();
+  applyCodexAdapter(paths, { manifest });
+  fs.writeFileSync(paths.manifest, `${JSON.stringify(manifest, null, 2)}\n`);
+  fs.mkdirSync(paths.core, { recursive: true });
+
+  const linkPath = path.join(paths.home, '.agents', 'skills', 'wienerdog-setup');
+
+  manifestLib.reverse(paths, manifest, { dryRun: false });
+
+  // Managed block gone; because AGENTS.md was created by us and had only the
+  // block, the file is removed.
+  assert.equal(fs.existsSync(agentsMd), false, 'created AGENTS.md removed');
+
+  // Our hook entries gone, unrelated hook survives.
+  const hooks = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
+  const startAbs = path.join(paths.core, 'bin', 'session-start.sh');
+  const stopAbs = path.join(paths.core, 'bin', 'codex-session-end.sh');
+  const stopCmds = (hooks.hooks.Stop || []).flatMap((g) => g.hooks.map((h) => h.command));
+  assert.ok(stopCmds.includes('/usr/local/bin/other-stop.sh'), 'unrelated hook survives');
+  assert.ok(!stopCmds.includes(stopAbs), 'our Stop hook removed');
+  assert.ok(!('SessionStart' in hooks.hooks), 'SessionStart array pruned');
+
+  // Symlink unlinked; copied hook scripts gone.
+  if (process.platform !== 'win32') {
+    assert.equal(fs.existsSync(linkPath), false, 'symlink unlinked');
+  }
+  assert.equal(fs.existsSync(startAbs), false, 'copied session-start.sh removed');
+});
+
+test('buildCodexArgs produces the sandboxed invocation', () => {
+  const argsNoModel = buildCodexArgs({ vaultDir: '/v', scratchDir: '/s', date: '2026-07-03', model: null });
+  const joined = argsNoModel.join(' ');
+
+  assert.ok(argsNoModel.includes('exec'));
+  assert.ok(joined.includes('--sandbox workspace-write'));
+  assert.ok(joined.includes('--cd /v'));
+  assert.ok(joined.includes('-c approval_policy=never'));
+  assert.ok(joined.includes('-c sandbox_workspace_write.network_access=false'));
+  assert.ok(argsNoModel.includes('--skip-git-repo-check'));
+  assert.ok(joined.includes('/wienerdog-dream'));
+  assert.ok(joined.includes('/s'));
+  assert.ok(joined.includes('/v'));
+  assert.ok(joined.includes('2026-07-03'));
+
+  // Model omitted when null.
+  assert.ok(!argsNoModel.includes('--model'));
+
+  // Forbidden/rejected flags must never appear.
+  assert.ok(!joined.includes('--ask-for-approval'));
+  assert.ok(!joined.includes('--dangerously-bypass-approvals-and-sandbox'));
+  assert.ok(!joined.includes('--yolo'));
+
+  const argsModel = buildCodexArgs({ vaultDir: '/v', scratchDir: '/s', date: '2026-07-03', model: 'gpt-5.5' });
+  const i = argsModel.indexOf('--model');
+  assert.ok(i !== -1);
+  assert.equal(argsModel[i + 1], 'gpt-5.5');
+});
+
+test('Codex-only machine: full setup + working dream from rollout files alone', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-codex-int-'));
+  const home = path.join(root, 'home');
+  const core = path.join(root, 'wd');
+  const vault = path.join(root, 'vault');
+  const codexHome = path.join(root, 'codex');
+  fs.mkdirSync(home, { recursive: true });
+  fs.mkdirSync(codexHome, { recursive: true });
+
+  const subprocessEnv = { ...process.env, HOME: home, WIENERDOG_HOME: core, WIENERDOG_VAULT: vault, CODEX_HOME: codexHome };
+  delete subprocessEnv.CLAUDE_CONFIG_DIR;
+
+  // 1. `wienerdog init --yes` — Claude absent (no CLAUDE_CONFIG_DIR, no <home>/.claude), Codex present.
+  execFileSync('node', [bin, 'init', '--yes'], { env: subprocessEnv, encoding: 'utf8' });
+
+  // 2. Drop the WP-005 identity fixture into <vault>/06-Identity/.
+  const identitySrc = path.join(repoRoot, 'tests', 'fixtures', 'identity-filled', '06-Identity');
+  const identityDest = path.join(vault, '06-Identity');
+  fs.mkdirSync(identityDest, { recursive: true });
+  for (const f of fs.readdirSync(identitySrc)) {
+    fs.copyFileSync(path.join(identitySrc, f), path.join(identityDest, f));
+  }
+
+  // 3. Run `sync` in-process (mutating process.env like the dream integration test does,
+  // since sync.js/getPaths() read process.env directly).
+  const ENV_KEYS = ['HOME', 'WIENERDOG_HOME', 'WIENERDOG_VAULT', 'CLAUDE_CONFIG_DIR', 'CODEX_HOME'];
+  const saved = {};
+  for (const k of ENV_KEYS) saved[k] = process.env[k];
+  Object.assign(process.env, { HOME: home, WIENERDOG_HOME: core, WIENERDOG_VAULT: vault, CODEX_HOME: codexHome });
+  delete process.env.CLAUDE_CONFIG_DIR;
+
+  const origLog = console.log;
+  console.log = () => {};
+  try {
+    await require('../../src/cli/sync').run([]);
+  } finally {
+    console.log = origLog;
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  }
+
+  // Assert: AGENTS.md has the managed block; hooks.json has SessionStart + Stop;
+  // skill symlinked; no ~/.claude written.
+  const agentsMd = path.join(codexHome, 'AGENTS.md');
+  const hooksPath = path.join(codexHome, 'hooks.json');
+  assert.ok(fs.readFileSync(agentsMd, 'utf8').includes('<!-- wienerdog:begin -->'));
+
+  const hooks = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
+  const startAbs = path.join(core, 'bin', 'session-start.sh');
+  const stopAbs = path.join(core, 'bin', 'codex-session-end.sh');
+  const sessionStartCmds = (hooks.hooks.SessionStart || []).flatMap((g) => g.hooks.map((h) => h.command));
+  const stopCmds = (hooks.hooks.Stop || []).flatMap((g) => g.hooks.map((h) => h.command));
+  assert.ok(sessionStartCmds.includes(startAbs));
+  assert.ok(stopCmds.includes(stopAbs));
+
+  const skillLink = path.join(home, '.agents', 'skills', 'wienerdog-setup');
+  if (process.platform !== 'win32') {
+    assert.ok(fs.lstatSync(skillLink).isSymbolicLink());
+  }
+
+  assert.equal(fs.existsSync(path.join(home, '.claude')), false, 'Claude correctly skipped');
+
+  // 4. Plant a Codex rollout file with real-shape lines (WP-007's fixture).
+  const rolloutDir = path.join(codexHome, 'sessions', '2026', '07', '03');
+  fs.mkdirSync(rolloutDir, { recursive: true });
+  const rolloutFixture = path.join(repoRoot, 'tests', 'fixtures', 'transcripts', 'codex-rollout.jsonl');
+  const rolloutPath = path.join(rolloutDir, 'rollout-2026-07-03T09-00-00-11111111-1111-1111-1111-111111111111.jsonl');
+  fs.copyFileSync(rolloutFixture, rolloutPath);
+
+  const paths = getPaths({ HOME: home, WIENERDOG_HOME: core, WIENERDOG_VAULT: vault, CODEX_HOME: codexHome });
+  const collected = collectExtracts(paths, { claude: null, codex: null }, 400000);
+  assert.equal(collected.entries.filter((e) => e.harness === 'codex').length, 1, 'one codex extract written to scratch');
+
+  // 5. A fake `codex` executable that writes a note into the vault, standing in
+  // for real `codex exec` (manual-verification-at-M4).
+  const fakeCodex = path.join(root, 'fake-codex.sh');
+  fs.writeFileSync(
+    fakeCodex,
+    ['#!/bin/sh', 'mkdir -p "$WIENERDOG_DREAM_VAULT/07-Daily"', 'echo "# note" > "$WIENERDOG_DREAM_VAULT/07-Daily/2026-07-03.md"', 'exit 0', ''].join('\n')
+  );
+  fs.chmodSync(fakeCodex, 0o755);
+
+  const { done } = spawnBrain({
+    harness: 'codex',
+    vaultDir: vault,
+    scratchDir: collected.scratchDir,
+    date: '2026-07-03',
+    model: null,
+    env: { ...process.env, WIENERDOG_DREAM_CMD: fakeCodex },
+  });
+  const result = await done;
+  assert.equal(result.code, 0);
+  assert.ok(fs.existsSync(path.join(vault, '07-Daily', '2026-07-03.md')), 'the codex-path brain wrote to the vault');
+});


### PR DESCRIPTION
Spec: docs/specs/WP-010-codex-adapter.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

## Verification output

```
$ npm test
✔ tests 111
ℹ pass 111
ℹ fail 0
(includes: claude-adapter — unchanged, 12/12 pass; codex-adapter — 9/9 pass;
 dream-brain — 3/3 pass; full existing suite green)

$ npm test -- --test-name-pattern codex
✔ tests 16
ℹ pass 16
ℹ fail 0

$ npm run lint
--- markdownlint ---
Summary: 0 error(s)
--- shellcheck ---
(clean — codex-session-end.sh passes)
--- frontmatter check ---
frontmatter check passed: 6 spec(s), 4 agent(s)
lint passed

$ node -e "const {buildCodexArgs}=require('./src/core/dream/brain'); console.log(buildCodexArgs({vaultDir:'/v',scratchDir:'/s',date:'2026-07-03',model:null}).join(' '))"
exec --sandbox workspace-write --cd /v --add-dir /s -c approval_policy=never -c sandbox_workspace_write.network_access=false --skip-git-repo-check /wienerdog-dream

Scratch extracts directory (read-only inputs): /s
Vault directory (your only write target): /v
Today's date: 2026-07-03

$ # Codex-only temp machine end-to-end (Claude absent):
$ export TMPROOT=$(mktemp -d)
$ export HOME=$TMPROOT WIENERDOG_HOME=$TMPROOT/wd WIENERDOG_VAULT=$TMPROOT/vault CODEX_HOME=$TMPROOT/.codex
$ unset CLAUDE_CONFIG_DIR
$ mkdir -p "$CODEX_HOME"
$ node bin/wienerdog.js init --yes
wienerdog: installed. Run `wienerdog doctor` to check the setup.
$ cp -R tests/fixtures/identity-filled/06-Identity/* "$WIENERDOG_VAULT/06-Identity/"
$ node bin/wienerdog.js sync
Claude Code not detected; skipping adapter.
wienerdog: 6 changed, 0 unchanged.
  note: Codex requires trusting new hooks via `/hooks` before they run; the AGENTS.md block already carries the digest so context works regardless
$ cat "$CODEX_HOME/AGENTS.md"
<!-- wienerdog:begin -->
# Who you're working with
... (rendered digest from the identity fixture) ...
<!-- wienerdog:end -->
$ cat "$CODEX_HOME/hooks.json"
{
  "hooks": {
    "SessionStart": [ { "matcher": "*", "hooks": [ { "type": "command", "command": ".../wd/bin/session-start.sh", "timeout": 10 } ] } ],
    "Stop": [ { "matcher": "*", "hooks": [ { "type": "command", "command": ".../wd/bin/codex-session-end.sh", "timeout": 10 } ] } ]
  }
}
$ ls -la "$HOME/.agents/skills/"
lrwxr-xr-x  wienerdog-setup -> .../wd/skills/wienerdog-setup
$ ls -la "$HOME/.claude" 2>/dev/null || echo "(no ~/.claude — Claude correctly skipped)"
(no ~/.claude — Claude correctly skipped)
$ node bin/wienerdog.js sync   # second run
wienerdog: 0 changed, 6 unchanged.
$ node bin/wienerdog.js uninstall --yes
Removed 13 item(s).
$ cat "$CODEX_HOME/AGENTS.md" 2>/dev/null || echo "(AGENTS.md removed)"
(AGENTS.md removed)
```

## Decisions made

- Extracted the six shared helpers into `src/adapters/shared.js` verbatim, generalizing
  only `applySettings` to take an `events: Array<[event, command]>` list (per the spec's
  exact contract) so both adapters call the same function with different event names
  (`SessionEnd` vs `Stop`). `claude.js`'s external behavior, exports, and byte output are
  unchanged — verified by running `tests/unit/claude-adapter.test.js` and the
  `tests/golden/claude-adapter/CLAUDE.md` golden unedited; both still pass.
- `codex-session-end.sh` reuses the exact same stdin-JSON-append-to-queue pattern as
  Claude's `session-end.sh`, only swapping `harness:"codex"` and file name, per the
  spec's exact content block — copied verbatim.
- For the codex-only integration test, `wienerdog init` runs as a real subprocess
  (`execFileSync`, matching the existing `tests/unit/init.test.js` pattern) since
  `init.js` reads `process.env` directly with no injectable env; `sync.run([])` and
  `spawnBrain`/`collectExtracts` are called in-process with `process.env` temporarily
  mutated and restored, matching the existing `tests/integration/dream.test.js` pattern
  (`sync.js`/`getPaths()` also read `process.env` directly, with no env parameter).
- Did not add a `dry-run` unit test for the Codex adapter beyond what's already covered
  by the shared `applyManagedBlock`/`applySettings`/`applySkillLinks` logic (already
  dry-run-tested via the Claude adapter suite, since the code path is identical) — the
  spec's "required cases" list (1-9) does not ask for one, and CLAUDE.md's simplicity
  guidance says not to add tests beyond what's asked.

## Discovered issues (out of scope, not fixed)

- `src/core/manifest.js`'s `reverse()` does not yet handle the `vault-file` manifest kind
  (from WP-004/005's vault scaffolding) — `wienerdog uninstall` prints
  `skipping unknown manifest entry kind 'vault-file'` for every vault file and leaves the
  scaffolded vault behind. Pre-existing gap, unrelated to this WP's adapters; visible in
  the verification transcript above and in the existing `npm test` output on `main`.
  Noted here per CLAUDE.md instead of fixed, since `src/core/manifest.js` is explicitly
  out of scope for WP-010.

---
Generated-by: claude-sonnet-5
