### PR TITLE
feat(gws): implement send grants and alert path (WP-018)

### DIFF
--- a/bin/wienerdog.js
+++ b/bin/wienerdog.js
@@ -14,6 +14,7 @@ Commands:
   doctor      Check an existing install for problems
   uninstall   Remove everything Wienerdog created (reverses the install)
   gws         Read Gmail/Calendar/Drive and draft mail (Google Workspace)
+  grant       Authorize a routine to send email (typed confirmation required)
 
 Global options:
   --dry-run   Show what would happen; make no changes
@@ -39,6 +40,7 @@ async function main() {
     doctor: () => require('../src/cli/doctor'),
     uninstall: () => require('../src/cli/uninstall'),
     gws: () => require('../src/gws/index'),
+    grant: () => require('../src/cli/grant'),
   };
 
   const loader = commands[cmd];

--- a/docs/specs/WP-018-gws-send-grants.md
+++ b/docs/specs/WP-018-gws-send-grants.md
@@ -1,7 +1,7 @@
 ---
 id: WP-018
 title: Implement gws send grants, Gmail send, and _alert (ADR-0007)
-status: Ready
+status: In-Review
 model: opus
 size: M
 depends_on: [WP-011]

--- a/src/cli/grant.js
+++ b/src/cli/grant.js
@@ -1,0 +1,126 @@
+'use strict';
+
+const readline = require('node:readline');
+const { getPaths } = require('../core/paths');
+const { WienerdogError } = require('../core/errors');
+const grantLib = require('../gws/grant');
+
+/**
+ * `wienerdog grant send` — the ONLY way a send grant is created (ADR-0007).
+ * The typed-word confirmation is the security boundary: it is driven by real
+ * stdin and `--yes` does NOT bypass it, so no skill, hook, dream, or headless
+ * job (nothing scriptable via `--yes`) can mint or widen a grant.
+ */
+
+/**
+ * Default prompt: read one line from stdin. Injectable so the CLI is unit
+ * testable without a real TTY.
+ * @param {string} question
+ * @returns {Promise<string>}
+ */
+function defaultPrompt(question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer);
+    });
+  });
+}
+
+/**
+ * Parse `--routine <name>` and `--to <csv>` out of an argv tail. Unknown flags
+ * (including `--yes`) are ignored — `--yes` must never bypass the confirmation.
+ * @param {string[]} argv
+ * @returns {{routine:string|null, to:string|null}}
+ */
+function parseArgs(argv) {
+  const out = { routine: null, to: null };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--routine') out.routine = argv[++i];
+    else if (argv[i] === '--to') out.to = argv[++i];
+  }
+  return out;
+}
+
+/**
+ * Basic address sanity: exactly one `@` and a dot after it (not last char).
+ * @param {string} addr
+ * @returns {boolean}
+ */
+function looksLikeAddress(addr) {
+  const at = addr.indexOf('@');
+  if (at <= 0 || addr.indexOf('@', at + 1) !== -1) return false;
+  const dot = addr.indexOf('.', at);
+  return dot > at + 1 && dot < addr.length - 1;
+}
+
+/**
+ * Best-effort lookup of the authenticated Google address, to decide whether a
+ * recipient is the user's own account. Never throws and never fails the grant:
+ * if no token/profile is available, returns null and all recipients are treated
+ * as third-party (and warned about).
+ * @param {import('../core/paths').WienerdogPaths} paths
+ * @returns {Promise<string|null>}
+ */
+async function authenticatedAddress(paths) {
+  try {
+    const client = require('../gws/client');
+    client.loadToken(paths); // throws if no token — keeps us fully offline then
+    const services = client.getServices(paths);
+    const res = await services.gmail.users.getProfile({ userId: 'me' });
+    return (res && res.data && res.data.emailAddress) || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * `wienerdog grant send --routine <name> --to <a@b>[,<c@d>...]`.
+ * @param {string[]} argv
+ * @param {{promptFn?:(q:string)=>Promise<string>,
+ *          paths?:import('../core/paths').WienerdogPaths}} [opts] injection seam
+ * @returns {Promise<void>}
+ */
+async function run(argv, opts = {}) {
+  const promptFn = opts.promptFn || defaultPrompt;
+  const paths = opts.paths || getPaths();
+
+  const verb = argv[0];
+  if (verb !== 'send') {
+    throw new WienerdogError(`unknown grant command '${verb || ''}' — only 'send' is supported`);
+  }
+
+  const parsed = parseArgs(argv.slice(1));
+  if (!parsed.routine) throw new WienerdogError('missing required flag --routine');
+  if (!parsed.to) throw new WienerdogError('missing required flag --to');
+  const recipients = parsed.to.split(',').map((s) => s.trim()).filter(Boolean);
+  if (recipients.length === 0) throw new WienerdogError('missing required flag --to');
+  for (const r of recipients) {
+    if (!looksLikeAddress(r)) throw new WienerdogError(`not a valid email address: ${r}`);
+  }
+
+  const self = await authenticatedAddress(paths);
+  const thirdParty = recipients.filter(
+    (r) => !self || r.toLowerCase() !== self.toLowerCase()
+  );
+
+  const out = process.stdout;
+  out.write(`You are about to let the "${parsed.routine}" routine SEND email to:\n`);
+  for (const r of recipients) out.write(`  - ${r}\n`);
+  out.write('Anything this routine emails will go to those addresses without further prompting.\n');
+  if (thirdParty.length > 0) {
+    out.write('These are third-party addresses; email sent here leaves your control.\n');
+  }
+
+  const answer = await promptFn('Type the word "grant" to confirm (anything else cancels): ');
+  if (String(answer).trim() !== 'grant') {
+    out.write('Cancelled.\n');
+    return;
+  }
+
+  grantLib.saveGrant(paths, { routine: parsed.routine, to: recipients });
+  out.write(`wienerdog: granted "${parsed.routine}" → ${recipients.join(', ')}.\n`);
+}
+
+module.exports = { run };

--- a/src/gws/alert.js
+++ b/src/gws/alert.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const { WienerdogError } = require('../core/errors');
+const { buildMime } = require('./gmail');
+
+/**
+ * gws _alert — fixed-template mail to the user's OWN address, used by the
+ * run-job watchdog for fail-loud notification (WP-013). This is a built-in
+ * self-grant: it needs no configured grant BECAUSE the recipient is always the
+ * authenticated account itself, so it can never become an exfiltration path.
+ * It accepts no recipient argument.
+ */
+
+/** Fixed preamble/footer identifying the mail as an automated Wienerdog alert. */
+const PREAMBLE = 'This is an automated alert from Wienerdog, running on your own machine.';
+const FOOTER =
+  '— You are receiving this because Wienerdog sent it to your own account. ' +
+  'No one else received it.';
+
+/**
+ * @param {{gmail:object}} services
+ * @param {{subject:string, body:string}} opts
+ * @returns {Promise<{sent:boolean, to:string, messageId:string}>}
+ */
+async function run(services, opts) {
+  let self;
+  try {
+    const res = await services.gmail.users.getProfile({ userId: 'me' });
+    self = res && res.data && res.data.emailAddress;
+  } catch {
+    self = null;
+  }
+  if (!self || !String(self).includes('@')) {
+    // No fallback recipient — refusing to send is the safe outcome.
+    throw new WienerdogError(
+      'could not determine your Google account address — alert not sent'
+    );
+  }
+
+  // The recipient is fixed to the authenticated account and never taken from
+  // opts; asserting it makes the self-only invariant explicit.
+  const to = self;
+  if (to !== self) throw new WienerdogError('alert recipient must be the authenticated account');
+
+  const raw = buildMime({
+    to,
+    subject: `[wienerdog alert] ${opts.subject}`,
+    body: `${PREAMBLE}\n\n${opts.body}\n\n${FOOTER}`,
+  });
+  const sendRes = await services.gmail.users.messages.send({
+    userId: 'me',
+    requestBody: { raw },
+  });
+  return { sent: true, to, messageId: (sendRes.data && sendRes.data.id) || '' };
+}
+
+module.exports = { run };

--- a/src/gws/gmail.js
+++ b/src/gws/gmail.js
@@ -126,6 +126,47 @@ async function draft(services, opts) {
 }
 
 /**
+ * gmail send — grant-gated (ADR-0007). Sends ONLY under a matching send grant;
+ * otherwise degrades to a draft + notice (never throws for a missing grant).
+ * @param {{gmail:object}} services
+ * @param {{to:string, subject:string, body:string, routine:string|null,
+ *          paths:import('../core/paths').WienerdogPaths}} opts
+ * @returns {Promise<{sent:boolean, degraded:boolean, draftId?:string,
+ *   messageId?:string, notice?:string}>}
+ */
+async function send(services, opts) {
+  const { findGrant, isSendAllowed } = require('./grant');
+  const recipients = String(opts.to)
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const routine = opts.routine || null;
+  const grant = findGrant(opts.paths, routine);
+  const decision = isSendAllowed(grant, recipients);
+
+  if (decision.allowed) {
+    const raw = buildMime(opts);
+    const res = await services.gmail.users.messages.send({
+      userId: 'me',
+      requestBody: { raw },
+    });
+    return { sent: true, degraded: false, messageId: (res.data && res.data.id) || '' };
+  }
+
+  // Fail-safe, fail-visible: no/insufficient grant → draft instead of send.
+  const d = await draft(services, opts);
+  return {
+    sent: false,
+    degraded: true,
+    draftId: d.draftId,
+    messageId: d.messageId,
+    notice:
+      `No matching send grant (${decision.reason}); saved a draft instead. ` +
+      'Run: wienerdog grant send --routine <name> --to <recipients>',
+  };
+}
+
+/**
  * Build an RFC-2822 message, base64url-encoded (no padding, '+/'→'-_').
  * Exported for reuse by gmail send (WP-018).
  * @param {{to:string, subject:string, body:string, from?:string}} m
@@ -143,4 +184,4 @@ function buildMime(m) {
   return Buffer.from(mime).toString('base64url');
 }
 
-module.exports = { search, read, draft, buildMime };
+module.exports = { search, read, draft, send, buildMime };

--- a/src/gws/grant.js
+++ b/src/gws/grant.js
@@ -1,0 +1,198 @@
+'use strict';
+
+const fs = require('node:fs');
+const crypto = require('node:crypto');
+
+const manifestLib = require('../core/manifest');
+
+/**
+ * Send grants (ADR-0007). Grants are the security boundary that keeps outbound
+ * email from becoming an exfiltration channel (THREAT-MODEL T4a): they are
+ * mechanics, not vault, so no model-writable surface can create or widen one.
+ * They live in a comment-fenced managed section of ~/.wienerdog/config.yaml,
+ * written ONLY by the interactive `wienerdog grant` CLI. This module owns
+ * parsing/writing that section (it knows the exact shape it writes) and the
+ * pure enforcement decision consulted by `gws gmail send`.
+ *
+ * @typedef {import('../core/paths').WienerdogPaths} WienerdogPaths
+ * @typedef {{routine:string, to:string[]}} Grant
+ */
+
+/** The exact begin/end sentinels (full lines, including the leading `#`). */
+const BEGIN = '# --- wienerdog:grants (managed by `wienerdog grant`; do not edit by hand) ---';
+const END = '# --- end wienerdog:grants ---';
+
+/** @param {string} content @returns {string} sha256 hex. */
+function sha256(content) {
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+/**
+ * De-duplicate a recipient list case-insensitively, preserving order and the
+ * first-seen (trimmed) spelling.
+ * @param {string[]} list
+ * @returns {string[]}
+ */
+function dedupTo(list) {
+  const seen = new Set();
+  const out = [];
+  for (const a of list || []) {
+    const trimmed = String(a).trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+/**
+ * Parse the grants managed-section out of config.yaml content. Reads only
+ * between the two sentinels; tolerant of the exact block this module writes.
+ * Absent section → [].
+ * @param {string} configText
+ * @returns {Grant[]}
+ */
+function parseGrants(configText) {
+  const beginIdx = configText.indexOf(BEGIN);
+  const endIdx = configText.indexOf(END);
+  if (beginIdx === -1 || endIdx === -1 || endIdx < beginIdx) return [];
+  const inner = configText.slice(beginIdx + BEGIN.length, endIdx);
+  /** @type {Grant[]} */
+  const grants = [];
+  let current = null;
+  for (const line of inner.split('\n')) {
+    const routineMatch = line.match(/^\s*-\s*routine:\s*(.+?)\s*$/);
+    if (routineMatch) {
+      current = { routine: routineMatch[1], to: [] };
+      grants.push(current);
+      continue;
+    }
+    const toItem = line.match(/^\s*-\s*(\S+)\s*$/);
+    if (toItem && current) current.to.push(toItem[1]);
+    // `grants:`, `to:`, blank, and comment lines are ignored.
+  }
+  return grants;
+}
+
+/**
+ * Render the managed section (sentinels + indented YAML) for `grants`.
+ * @param {Grant[]} grants
+ * @returns {string} ends with a single trailing newline
+ */
+function renderSection(grants) {
+  const lines = [BEGIN, 'grants:'];
+  for (const g of grants) {
+    lines.push(`  - routine: ${g.routine}`);
+    lines.push('    to:');
+    for (const addr of g.to) lines.push(`      - ${addr}`);
+  }
+  lines.push(END);
+  return `${lines.join('\n')}\n`;
+}
+
+/**
+ * Remove the managed section (and the one blank-line separator we insert before
+ * it), returning the content that lives outside the sentinels byte-for-byte.
+ * @param {string} configText
+ * @returns {string}
+ */
+function stripSection(configText) {
+  const beginIdx = configText.indexOf(BEGIN);
+  if (beginIdx === -1) return configText;
+  const endIdx = configText.indexOf(END);
+  let afterEnd = endIdx + END.length;
+  if (configText[afterEnd] === '\n') afterEnd += 1;
+  let before = configText.slice(0, beginIdx);
+  const after = configText.slice(afterEnd);
+  // Undo the single blank-line separator written before BEGIN.
+  if (before.endsWith('\n')) before = before.slice(0, -1);
+  return before + after;
+}
+
+/**
+ * Return config.yaml content with the grants section replaced by `grants`
+ * (removed entirely if grants is empty). Everything OUTSIDE the sentinels is
+ * preserved byte-for-byte; the section is (re)written just before EOF with
+ * exactly one blank line before it.
+ * @param {string} configText
+ * @param {Grant[]} grants
+ * @returns {string}
+ */
+function renderConfigWithGrants(configText, grants) {
+  const base = stripSection(configText);
+  if (!grants || grants.length === 0) return base;
+  const sep = base.endsWith('\n') ? '\n' : '\n\n';
+  return base + sep + renderSection(grants);
+}
+
+/**
+ * Upsert one grant (add, or replace an existing grant with the same routine)
+ * and persist config.yaml, then re-sync the manifest hash so uninstall stays
+ * clean.
+ * @param {WienerdogPaths} paths
+ * @param {Grant} grant
+ */
+function saveGrant(paths, grant) {
+  const configText = fs.readFileSync(paths.config, 'utf8');
+  const grants = parseGrants(configText);
+  const entry = { routine: grant.routine, to: dedupTo(grant.to) };
+  const idx = grants.findIndex((g) => g.routine === grant.routine);
+  if (idx >= 0) grants[idx] = entry;
+  else grants.push(entry);
+
+  const next = renderConfigWithGrants(configText, grants);
+  fs.writeFileSync(paths.config, next);
+
+  // Mirror init.js: keep the recorded hash in sync with our own rewrite so
+  // uninstall removes config.yaml rather than "keeping … modified since install".
+  const manifest = manifestLib.load(paths);
+  const configEntry = manifest.entries.find((e) => e.kind === 'file' && e.path === paths.config);
+  if (configEntry) {
+    configEntry.hash = sha256(next);
+    manifestLib.save(paths, manifest);
+  }
+}
+
+/**
+ * Look up the grant for a routine.
+ * @param {WienerdogPaths} paths
+ * @param {string|null} routine
+ * @returns {Grant|null} null if routine is null/absent
+ */
+function findGrant(paths, routine) {
+  if (!routine) return null;
+  let configText;
+  try {
+    configText = fs.readFileSync(paths.config, 'utf8');
+  } catch {
+    return null;
+  }
+  return parseGrants(configText).find((g) => g.routine === routine) || null;
+}
+
+/**
+ * THE ENFORCEMENT DECISION (pure; unit-tested). Allowed IFF grant is non-null
+ * AND every recipient is in grant.to (case-insensitive, trimmed exact-address
+ * match — no wildcards, no domain grants). Otherwise allowed=false with a
+ * plain-language reason naming what was missing.
+ * @param {Grant|null} grant
+ * @param {string[]} recipients
+ * @returns {{allowed:boolean, reason:string}}
+ */
+function isSendAllowed(grant, recipients) {
+  if (!grant) {
+    return { allowed: false, reason: 'no send grant for this routine' };
+  }
+  const allow = new Set((grant.to || []).map((a) => String(a).trim().toLowerCase()));
+  for (const r of recipients) {
+    const norm = String(r).trim().toLowerCase();
+    if (!allow.has(norm)) {
+      return { allowed: false, reason: `recipient ${String(r).trim()} not in allowlist` };
+    }
+  }
+  return { allowed: true, reason: 'all recipients granted' };
+}
+
+module.exports = { parseGrants, renderConfigWithGrants, saveGrant, findGrant, isSendAllowed };

--- a/tests/unit/gws-grant.test.js
+++ b/tests/unit/gws-grant.test.js
@@ -1,0 +1,217 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const grant = require('../../src/gws/grant');
+const grantCli = require('../../src/cli/grant');
+const manifestLib = require('../../src/core/manifest');
+const { getPaths } = require('../../src/core/paths');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const bin = path.join(repoRoot, 'bin', 'wienerdog.js');
+
+/** @param {string} s @returns {string} */
+function sha256(s) {
+  return crypto.createHash('sha256').update(s).digest('hex');
+}
+
+/** Isolated temp core that never touches the real ~/.wienerdog. */
+function tempEnv() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-grant-'));
+  const core = path.join(root, 'wd');
+  return {
+    root,
+    core,
+    env: {
+      ...process.env,
+      WIENERDOG_HOME: core,
+      WIENERDOG_VAULT: path.join(root, 'vault'),
+      CLAUDE_CONFIG_DIR: path.join(root, 'absent-claude'),
+      CODEX_HOME: path.join(root, 'absent-codex'),
+    },
+  };
+}
+
+/** Run `init --yes` for a temp env and return its computed paths. */
+function initPaths(env) {
+  execFileSync('node', [bin, 'init', '--yes'], { env, stdio: 'ignore' });
+  return getPaths(env);
+}
+
+const BASE_CONFIG =
+  '# Wienerdog configuration\nversion: 1\nvault: /home/x/wienerdog\nmemory_mode: standard\n';
+
+// --- parse / render round-trip ------------------------------------------------
+
+test('renderConfigWithGrants round-trips and preserves content outside sentinels', () => {
+  const grants = [
+    { routine: 'daily-digest', to: ['gyula@example.com'] },
+    { routine: 'weekly-review', to: ['gyula@example.com', 'ada@example.com'] },
+  ];
+  const withGrants = grant.renderConfigWithGrants(BASE_CONFIG, grants);
+
+  assert.match(withGrants, /# --- wienerdog:grants/);
+  assert.deepEqual(grant.parseGrants(withGrants), grants);
+  // Exactly one blank line separates prior content from the begin sentinel.
+  assert.match(withGrants, /memory_mode: standard\n\n# --- wienerdog:grants/);
+  // Re-rendering from the parsed grants is byte-identical.
+  assert.equal(grant.renderConfigWithGrants(BASE_CONFIG, grant.parseGrants(withGrants)), withGrants);
+  // Removing all grants restores the original byte-for-byte.
+  assert.equal(grant.renderConfigWithGrants(withGrants, []), BASE_CONFIG);
+});
+
+test('parseGrants returns [] when the section is absent', () => {
+  assert.deepEqual(grant.parseGrants(BASE_CONFIG), []);
+});
+
+// --- isSendAllowed truth table ------------------------------------------------
+
+test('isSendAllowed allows only when every recipient is granted (case-insensitive, exact)', () => {
+  const g = { routine: 'r', to: ['A@x.com', 'b@x.com'] };
+  assert.equal(grant.isSendAllowed(g, ['a@x.com']).allowed, true);
+  assert.equal(grant.isSendAllowed(g, ['A@X.COM', ' b@x.com ']).allowed, true);
+
+  const partial = grant.isSendAllowed(g, ['a@x.com', 'c@x.com']);
+  assert.equal(partial.allowed, false);
+  assert.match(partial.reason, /c@x\.com not in allowlist/);
+
+  const nullGrant = grant.isSendAllowed(null, ['a@x.com']);
+  assert.equal(nullGrant.allowed, false);
+  assert.match(nullGrant.reason, /no send grant/);
+
+  // No wildcards / no domain grants.
+  assert.equal(grant.isSendAllowed({ routine: 'r', to: ['*@x.com'] }, ['z@x.com']).allowed, false);
+  assert.equal(grant.isSendAllowed({ routine: 'r', to: ['x.com'] }, ['z@x.com']).allowed, false);
+});
+
+test('findGrant returns null for a null routine', () => {
+  const { env } = tempEnv();
+  const paths = initPaths(env);
+  grant.saveGrant(paths, { routine: 'daily-digest', to: ['me@example.com'] });
+  assert.equal(grant.findGrant(paths, null), null);
+  assert.deepEqual(grant.findGrant(paths, 'daily-digest'), {
+    routine: 'daily-digest',
+    to: ['me@example.com'],
+  });
+  assert.equal(grant.findGrant(paths, 'no-such-routine'), null);
+});
+
+// --- saveGrant upsert + manifest-hash resync ---------------------------------
+
+test('saveGrant upserts by routine and re-syncs the manifest hash (uninstall stays clean)', () => {
+  const { env } = tempEnv();
+  const paths = initPaths(env);
+
+  grant.saveGrant(paths, { routine: 'daily-digest', to: ['gyula@example.com'] });
+  let cfg = fs.readFileSync(paths.config, 'utf8');
+  assert.match(cfg, /wienerdog:grants/);
+  assert.deepEqual(grant.parseGrants(cfg), [
+    { routine: 'daily-digest', to: ['gyula@example.com'] },
+  ]);
+
+  // Same routine replaces (dedup case-insensitively, preserve order).
+  grant.saveGrant(paths, {
+    routine: 'daily-digest',
+    to: ['gyula@example.com', 'ADA@example.com', 'ada@example.com'],
+  });
+  cfg = fs.readFileSync(paths.config, 'utf8');
+  assert.deepEqual(grant.parseGrants(cfg), [
+    { routine: 'daily-digest', to: ['gyula@example.com', 'ADA@example.com'] },
+  ]);
+
+  // A different routine appends a second grant.
+  grant.saveGrant(paths, { routine: 'weekly-review', to: ['gyula@example.com'] });
+  cfg = fs.readFileSync(paths.config, 'utf8');
+  assert.equal(grant.parseGrants(cfg).length, 2);
+
+  // The manifest hash was re-synced, so uninstall removes config.yaml cleanly.
+  const manifest = manifestLib.load(paths);
+  const entry = manifest.entries.find((e) => e.kind === 'file' && e.path === paths.config);
+  assert.equal(entry.hash, sha256(cfg));
+  manifestLib.reverse(paths, manifest);
+  assert.equal(fs.existsSync(paths.config), false);
+});
+
+// --- CLI confirmation gating -------------------------------------------------
+
+test('grant CLI writes a grant only after the typed word "grant"', async () => {
+  const { env } = tempEnv();
+  const paths = initPaths(env);
+  await grantCli.run(['send', '--routine', 'daily-digest', '--to', 'me@example.com'], {
+    paths,
+    promptFn: async () => 'grant',
+  });
+  assert.deepEqual(grant.findGrant(paths, 'daily-digest'), {
+    routine: 'daily-digest',
+    to: ['me@example.com'],
+  });
+});
+
+test('grant CLI cancels with no write when confirmation is not exactly "grant"', async () => {
+  const { env } = tempEnv();
+  const paths = initPaths(env);
+  await grantCli.run(['send', '--routine', 'daily-digest', '--to', 'me@example.com'], {
+    paths,
+    promptFn: async () => 'yes',
+  });
+  assert.equal(grant.findGrant(paths, 'daily-digest'), null);
+  assert.doesNotMatch(fs.readFileSync(paths.config, 'utf8'), /wienerdog:grants/);
+});
+
+test('grant CLI: --yes does NOT bypass the typed confirmation', async () => {
+  const { env } = tempEnv();
+  const paths = initPaths(env);
+  let asked = false;
+  await grantCli.run(['send', '--routine', 'r', '--to', 'me@example.com', '--yes'], {
+    paths,
+    promptFn: async () => {
+      asked = true;
+      return 'nope';
+    },
+  });
+  assert.equal(asked, true); // the prompt still ran
+  assert.equal(grant.findGrant(paths, 'r'), null);
+});
+
+test('grant CLI warns about third-party recipients before prompting', async () => {
+  const { env } = tempEnv();
+  const paths = getPaths(env); // no token → all recipients treated as third-party
+  const lines = [];
+  const orig = process.stdout.write;
+  process.stdout.write = (s) => {
+    lines.push(String(s));
+    return true;
+  };
+  try {
+    await grantCli.run(['send', '--routine', 'r', '--to', 'stranger@evil.com'], {
+      paths,
+      promptFn: async () => 'nope',
+    });
+  } finally {
+    process.stdout.write = orig;
+  }
+  assert.match(lines.join(''), /third-party addresses/);
+});
+
+test('grant CLI rejects a bad address and a missing flag', async () => {
+  const { env } = tempEnv();
+  const paths = getPaths(env);
+  await assert.rejects(
+    () => grantCli.run(['send', '--routine', 'r', '--to', 'not-an-email'], { paths, promptFn: async () => 'grant' }),
+    /valid email/
+  );
+  await assert.rejects(
+    () => grantCli.run(['send', '--to', 'a@b.com'], { paths, promptFn: async () => 'grant' }),
+    /--routine/
+  );
+  await assert.rejects(
+    () => grantCli.run(['revoke', '--routine', 'r', '--to', 'a@b.com'], { paths, promptFn: async () => 'grant' }),
+    /only 'send'/
+  );
+});

--- a/tests/unit/gws-send.test.js
+++ b/tests/unit/gws-send.test.js
@@ -1,0 +1,190 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const gmail = require('../../src/gws/gmail');
+const alert = require('../../src/gws/alert');
+const grant = require('../../src/gws/grant');
+const { getPaths } = require('../../src/core/paths');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const bin = path.join(repoRoot, 'bin', 'wienerdog.js');
+
+/** Isolated temp core; init writes config + manifest so grants can be saved. */
+function initPaths() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-send-'));
+  const core = path.join(root, 'wd');
+  const env = {
+    ...process.env,
+    WIENERDOG_HOME: core,
+    WIENERDOG_VAULT: path.join(root, 'vault'),
+    CLAUDE_CONFIG_DIR: path.join(root, 'absent-claude'),
+    CODEX_HOME: path.join(root, 'absent-codex'),
+  };
+  execFileSync('node', [bin, 'init', '--yes'], { env, stdio: 'ignore' });
+  return getPaths(env);
+}
+
+/** Stub Gmail service: spies for send/drafts/getProfile, no network. */
+function stubGmail(emailAddress = 'me@example.com') {
+  const calls = { send: [], drafts: [], profile: 0 };
+  const services = {
+    gmail: {
+      users: {
+        messages: {
+          send: async (args) => {
+            calls.send.push(args);
+            return { data: { id: 'sent-1' } };
+          },
+        },
+        drafts: {
+          create: async (args) => {
+            calls.drafts.push(args);
+            return { data: { id: 'r-9', message: { id: 'm-9' } } };
+          },
+        },
+        getProfile: async () => {
+          calls.profile++;
+          return { data: { emailAddress } };
+        },
+      },
+    },
+  };
+  return { calls, services };
+}
+
+/** @param {string} raw @returns {string} */
+function decode(raw) {
+  return Buffer.from(raw, 'base64url').toString('utf8');
+}
+
+test('send executes a real send under a matching grant', async () => {
+  const paths = initPaths();
+  grant.saveGrant(paths, { routine: 'daily-digest', to: ['me@example.com'] });
+  const s = stubGmail();
+
+  const res = await gmail.send(s.services, {
+    to: 'me@example.com',
+    subject: 'Digest',
+    body: 'Morning.',
+    routine: 'daily-digest',
+    paths,
+  });
+
+  assert.deepEqual(res, { sent: true, degraded: false, messageId: 'sent-1' });
+  assert.equal(s.calls.send.length, 1);
+  assert.equal(s.calls.drafts.length, 0);
+  assert.match(decode(s.calls.send[0].requestBody.raw), /To: me@example\.com/);
+});
+
+test('send matches the allowlist case-insensitively', async () => {
+  const paths = initPaths();
+  grant.saveGrant(paths, { routine: 'daily-digest', to: ['Me@Example.com'] });
+  const s = stubGmail();
+  const res = await gmail.send(s.services, {
+    to: 'me@example.com',
+    subject: 'x',
+    body: 'y',
+    routine: 'daily-digest',
+    paths,
+  });
+  assert.equal(res.sent, true);
+});
+
+test('send degrades to a draft when a recipient is not granted (no throw)', async () => {
+  const paths = initPaths();
+  grant.saveGrant(paths, { routine: 'daily-digest', to: ['me@example.com'] });
+  const s = stubGmail();
+
+  const res = await gmail.send(s.services, {
+    to: 'attacker@evil.com',
+    subject: 'x',
+    body: 'y',
+    routine: 'daily-digest',
+    paths,
+  });
+
+  assert.equal(res.sent, false);
+  assert.equal(res.degraded, true);
+  assert.equal(res.draftId, 'r-9');
+  assert.equal(res.messageId, 'm-9');
+  assert.match(res.notice, /recipient attacker@evil\.com not in allowlist/);
+  assert.match(res.notice, /saved a draft instead/);
+  assert.match(res.notice, /wienerdog grant send --routine <name> --to <recipients>/);
+  assert.equal(s.calls.send.length, 0);
+  assert.equal(s.calls.drafts.length, 1);
+});
+
+test('send degrades when only SOME recipients are granted', async () => {
+  const paths = initPaths();
+  grant.saveGrant(paths, { routine: 'daily-digest', to: ['me@example.com'] });
+  const s = stubGmail();
+  const res = await gmail.send(s.services, {
+    to: 'me@example.com, stranger@evil.com',
+    subject: 'x',
+    body: 'y',
+    routine: 'daily-digest',
+    paths,
+  });
+  assert.equal(res.degraded, true);
+  assert.equal(s.calls.send.length, 0);
+  assert.equal(s.calls.drafts.length, 1);
+});
+
+test('a null routine always degrades to a draft (fail-safe)', async () => {
+  const paths = initPaths();
+  grant.saveGrant(paths, { routine: 'daily-digest', to: ['me@example.com'] });
+  const s = stubGmail();
+  const res = await gmail.send(s.services, {
+    to: 'me@example.com',
+    subject: 'x',
+    body: 'y',
+    routine: null,
+    paths,
+  });
+  assert.equal(res.sent, false);
+  assert.equal(res.degraded, true);
+  assert.equal(s.calls.send.length, 0);
+});
+
+test('_alert sends only to the authenticated account with the fixed template', async () => {
+  const s = stubGmail('owner@example.com');
+  const res = await alert.run(s.services, { subject: 'watchdog failed', body: 'job X crashed' });
+
+  assert.equal(res.sent, true);
+  assert.equal(res.to, 'owner@example.com');
+  assert.equal(res.messageId, 'sent-1');
+  assert.equal(s.calls.send.length, 1);
+
+  const decoded = decode(s.calls.send[0].requestBody.raw);
+  assert.match(decoded, /To: owner@example\.com/);
+  assert.match(decoded, /Subject: \[wienerdog alert\] watchdog failed/);
+  assert.match(decoded, /job X crashed/);
+  assert.match(decoded, /automated alert from Wienerdog/);
+});
+
+test('_alert throws (no fallback recipient) when the profile lookup fails', async () => {
+  const calls = { send: 0 };
+  const services = {
+    gmail: {
+      users: {
+        getProfile: async () => {
+          throw new Error('network down');
+        },
+        messages: {
+          send: async () => {
+            calls.send++;
+            return { data: { id: 'x' } };
+          },
+        },
+      },
+    },
+  };
+  await assert.rejects(() => alert.run(services, { subject: 's', body: 'b' }), /account address/);
+  assert.equal(calls.send, 0);
+});


### PR DESCRIPTION
Spec: docs/specs/WP-018-gws-send-grants.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

Files: `src/gws/grant.js`, `src/cli/grant.js`, `bin/wienerdog.js`,
`src/gws/gmail.js`, `src/gws/alert.js`, `tests/unit/gws-grant.test.js`,
`tests/unit/gws-send.test.js` (+ the spec's own status line).

## Verification output

```
$ npm test -- --test-name-pattern gws-grant   # gws-grant.test.js ✔
$ npm test -- --test-name-pattern gws-send     # gws-send.test.js  ✔
$ npm test
ℹ tests 131
ℹ pass 131
ℹ fail 0

$ npm run lint
--- markdownlint ---   Summary: 0 error(s)
--- shellcheck ---
--- frontmatter check ---   frontmatter check passed: 6 spec(s), 4 agent(s)
lint passed

# Manual confirmation UX (temp machine):
$ node bin/wienerdog.js init --yes
$ printf 'grant\n' | node bin/wienerdog.js grant send --routine daily-digest --to me@example.com
You are about to let the "daily-digest" routine SEND email to:
  - me@example.com
Anything this routine emails will go to those addresses without further prompting.
These are third-party addresses; email sent here leaves your control.
Type the word "grant" to confirm (anything else cancels): wienerdog: granted "daily-digest" → me@example.com.
$ grep -n 'wienerdog:grants' "$WIENERDOG_HOME/config.yaml"
9:# --- wienerdog:grants (managed by `wienerdog grant`; do not edit by hand) ---
14:# --- end wienerdog:grants ---
$ node bin/wienerdog.js uninstall --yes && test ! -f "$WIENERDOG_HOME/config.yaml" && echo "config removed cleanly"
config removed cleanly

# Cancel path (anything but "grant" cancels; --yes does not bypass):
$ printf 'y\n' | node bin/wienerdog.js grant send --routine weekly-review --to a@b.com
Type the word "grant" to confirm (anything else cancels): Cancelled.
```

## Decisions made

- **`isSendAllowed` reasons** are short plain-language strings: `no send grant
  for this routine` (null grant / null routine) and `recipient <addr> not in
  allowlist` (the latter matches the spec's example notice verbatim).
- **`to` de-dup** in `saveGrant` is case-insensitive, preserving order and the
  first-seen spelling (spec said "dedup `to`" without specifying casing; chose
  the same case-insensitive rule the enforcement uses).
- **"Own account" detection** in `grant.js` is best-effort via
  `loadToken` + `getProfile`; with no saved token it stays fully offline and
  treats every recipient as third-party (prints the extra warning), never
  failing the grant — as the spec directs.
- **`_alert` template** uses a fixed preamble/footer identifying it as an
  automated Wienerdog self-alert; subject is prefixed `[wienerdog alert] `.
- **CLI injection seam**: `src/cli/grant.js` `run(argv, {promptFn, paths})`
  exposes an injectable prompt + paths so the typed-confirmation gating is unit
  tested without a TTY or network. The default path (readline on real stdin) is
  unchanged and is what `bin` invokes.

## Discovered issues (out of scope, not fixed)

- **`src/gws/index.js` wiring does not match the spec's function signatures**
  (index.js is not in this WP's Deliverables, so it was left untouched). The
  merged dispatch table calls `require('./gmail').send(services(), flags)` and
  `require('./alert').run(paths, flags)`, but the spec's contracts are
  `send(services, {to,subject,body,routine,paths})` and
  `alert.run(services, {subject,body})`. Also `parseFlags` does not parse
  `--routine`, and the spec's described routine resolution
  (`--routine` / `WIENERDOG_JOB` / null) is not implemented in index.js. I built
  the functions to the spec's exact contracts (all covered by unit tests via the
  stub seam); the live `gws gmail send` / `gws _alert` CLI paths are
  M5-manual-verification (real OAuth) and will need index.js updated to pass
  `paths`/`routine` (and to pass `services`, not `paths`, to `_alert`). Flagging
  for the architect since fixing it means touching a file outside this WP.

---
Generated-by: claude-opus-4-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EA5BsHCfHRViJFXdovC86
