### PR TITLE
feat(scheduler): implement schedule command and OS generators (WP-013)

### DIFF
--- a/bin/wienerdog.js
+++ b/bin/wienerdog.js
@@ -11,6 +11,7 @@ Commands:
   init        Create the Wienerdog core (~/.wienerdog) and detect your AI tools
   sync        Re-render the session digest from your vault's identity notes
   dream       Consolidate recent sessions into vault memory (one commit)
+  schedule    Add, remove, or list scheduled jobs (dream, routines)
   doctor      Check an existing install for problems
   uninstall   Remove everything Wienerdog created (reverses the install)
   gws         Read Gmail/Calendar/Drive and draft mail (Google Workspace)
@@ -36,6 +37,7 @@ async function main() {
     init: () => require('../src/cli/init'),
     sync: () => require('../src/cli/sync'),
     dream: () => require('../src/cli/dream'),
+    schedule: () => require('../src/cli/schedule'),
     doctor: () => require('../src/cli/doctor'),
     uninstall: () => require('../src/cli/uninstall'),
     gws: () => require('../src/gws/index'),

--- a/docs/specs/WP-013-scheduler-generators.md
+++ b/docs/specs/WP-013-scheduler-generators.md
@@ -1,7 +1,7 @@
 ---
 id: WP-013
 title: Implement scheduler generators and the schedule command (launchd + systemd, reversible)
-status: Ready
+status: In-Review
 model: opus
 size: M
 depends_on: [WP-003]

--- a/src/cli/schedule.js
+++ b/src/cli/schedule.js
@@ -1,0 +1,319 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const { getPaths } = require('../core/paths');
+const { WienerdogError } = require('../core/errors');
+const manifestLib = require('../core/manifest');
+const jobsLib = require('../scheduler/jobs');
+const gen = require('../scheduler/generators');
+
+/**
+ * Loader seam: the ONE place that registers/loads entries with the OS scheduler.
+ * Tests inject a spy so they never touch real launchd/systemd.
+ * @param {string[]} argv  e.g. ['launchctl','bootstrap','gui/501','<plist>']
+ * @returns {{status:number}} real impl: spawnSync(argv[0], argv.slice(1)).
+ */
+function defaultLoader(argv) {
+  const r = spawnSync(argv[0], argv.slice(1));
+  return { status: r.status == null ? 1 : r.status };
+}
+
+/** @param {string} p @returns {boolean} */
+function isFile(p) {
+  try {
+    return fs.statSync(p).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Parse `--flag value` and bare-positional argv. Returns positionals plus a flag
+ * map (flags with no following value → true).
+ * @param {string[]} argv
+ * @param {Set<string>} valueFlags  flags that take a value
+ * @returns {{positionals:string[], flags:Record<string,string|boolean>}}
+ */
+function parseArgs(argv, valueFlags) {
+  /** @type {string[]} */ const positionals = [];
+  /** @type {Record<string,string|boolean>} */ const flags = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith('--')) {
+      const key = a.slice(2);
+      if (valueFlags.has(key)) {
+        flags[key] = argv[++i];
+      } else {
+        flags[key] = true;
+      }
+    } else {
+      positionals.push(a);
+    }
+  }
+  return { positionals, flags };
+}
+
+/** @returns {boolean} true when this Linux host runs systemd. */
+function hasSystemd() {
+  if (fs.existsSync('/run/systemd/system')) return true;
+  const r = spawnSync('systemctl', ['--version']);
+  return !r.error;
+}
+
+/**
+ * Write `content` to `filePath` and record a scheduler-entry (once) in the
+ * manifest. Idempotent: if the file already exists with identical content AND a
+ * manifest entry already tracks it, nothing is written and false is returned.
+ * @param {import('../core/manifest').Manifest} manifest
+ * @param {string} filePath
+ * @param {string} content
+ * @param {string[]|null} unload  argv that unregisters the entry, or null.
+ * @returns {boolean} true if the file was (re)written (i.e. an OS reload is due).
+ */
+function ensureEntry(manifest, filePath, content, unload) {
+  const identical = isFile(filePath) && fs.readFileSync(filePath, 'utf8') === content;
+  const hasEntry = manifest.entries.some(
+    (e) => e.kind === 'scheduler-entry' && e.path === filePath
+  );
+  if (identical && hasEntry) return false;
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+  if (!hasEntry) {
+    /** @type {import('../core/manifest').ManifestEntry} */
+    const entry = { kind: 'scheduler-entry', path: filePath };
+    if (unload) entry.unload = unload;
+    manifestLib.record(manifest, entry);
+  }
+  return true;
+}
+
+/**
+ * Ensure the macOS catch-up plist exists and is registered (once, idempotent).
+ * @param {import('../core/paths').WienerdogPaths} paths
+ * @param {import('../core/manifest').Manifest} manifest
+ * @param {(argv:string[])=>{status:number}} loader
+ * @param {number} uid
+ */
+function ensureCatchup(paths, manifest, loader, uid) {
+  const logDir = path.join(paths.logs, 'catchup');
+  const content = gen.catchupPlist({ node: gen.nodePath(), bin: gen.wienerdogBin(), logDir });
+  const label = 'ai.wienerdog.catchup';
+  const plistPath = path.join(gen.launchAgentsDir(paths.home), `${label}.plist`);
+  const unload = ['launchctl', 'bootout', `gui/${uid}/${label}`];
+  if (ensureEntry(manifest, plistPath, content, unload)) {
+    loader(['launchctl', 'bootstrap', `gui/${uid}`, plistPath]);
+  }
+}
+
+/**
+ * Register the per-job OS entry(ies) for the current platform.
+ * @param {import('../core/paths').WienerdogPaths} paths
+ * @param {import('../core/manifest').Manifest} manifest
+ * @param {{name:string, hour:number, minute:number}} o
+ * @param {(argv:string[])=>{status:number}} loader
+ * @returns {{platform:string, changed:boolean}}
+ */
+function registerPlatform(paths, manifest, o, loader) {
+  const node = gen.nodePath();
+  const bin = gen.wienerdogBin();
+
+  if (process.platform === 'darwin') {
+    const uid = process.getuid();
+    const logDir = path.join(paths.logs, o.name);
+    const label = gen.launchdLabel(o.name);
+    const plistPath = path.join(gen.launchAgentsDir(paths.home), `${label}.plist`);
+    const content = gen.launchdPlist({ ...o, node, bin, logDir });
+    const unload = ['launchctl', 'bootout', `gui/${uid}/${label}`];
+    let changed = ensureEntry(manifest, plistPath, content, unload);
+    if (changed) loader(['launchctl', 'bootstrap', `gui/${uid}`, plistPath]);
+    // Catch-up entry: login + hourly (macOS StartCalendarInterval misses power-off).
+    ensureCatchup(paths, manifest, loader, uid);
+    return { platform: 'launchd', changed };
+  }
+
+  if (process.platform === 'linux') {
+    if (!hasSystemd()) {
+      throw new WienerdogError(
+        'this Linux system does not run systemd — scheduling needs systemd user timers (non-systemd fallback is not yet supported)'
+      );
+    }
+    const unitBase = gen.systemdUnitBase(o.name);
+    const dir = gen.systemdUserDir(paths.home, process.env);
+    const timerPath = path.join(dir, `${unitBase}.timer`);
+    const servicePath = path.join(dir, `${unitBase}.service`);
+    const timerText = gen.systemdTimer(o);
+    const serviceText = gen.systemdService({ name: o.name, node, bin });
+    const timerUnload = ['systemctl', '--user', 'disable', '--now', `${unitBase}.timer`];
+    const timerChanged = ensureEntry(manifest, timerPath, timerText, timerUnload);
+    const serviceChanged = ensureEntry(manifest, servicePath, serviceText, null);
+    const changed = timerChanged || serviceChanged;
+    if (changed) {
+      loader(['systemctl', '--user', 'daemon-reload']);
+      loader(['systemctl', '--user', 'enable', '--now', `${unitBase}.timer`]);
+      // Best-effort: let timers fire when the user is logged out.
+      const user = process.env.USER || process.env.LOGNAME || '';
+      if (user) loader(['loginctl', 'enable-linger', user]);
+    }
+    return { platform: 'systemd', changed };
+  }
+
+  throw new WienerdogError(
+    `scheduling is not supported on ${process.platform} yet (macOS and systemd Linux only)`
+  );
+}
+
+/**
+ * schedule add <name> --at HH:MM (--skill <s> | --job <builtin>) [--timeout <min>]
+ * @param {string[]} argv
+ * @param {(argv:string[])=>{status:number}} loader
+ */
+function add(argv, loader) {
+  const { positionals, flags } = parseArgs(
+    argv,
+    new Set(['at', 'skill', 'job', 'timeout'])
+  );
+  const name = positionals[0];
+  if (!name) throw new WienerdogError('schedule add: missing job <name>');
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(name)) {
+    throw new WienerdogError(
+      `invalid job name ${JSON.stringify(name)} — use lowercase letters, digits and hyphens (must start alphanumeric)`
+    );
+  }
+  if (typeof flags.at !== 'string') throw new WienerdogError('schedule add: --at HH:MM is required');
+  const { hour, minute } = gen.parseAt(flags.at);
+
+  const hasSkill = typeof flags.skill === 'string';
+  const hasJob = typeof flags.job === 'string';
+  if (hasSkill === hasJob) {
+    throw new WienerdogError('schedule add: provide exactly one of --skill <name> or --job <builtin>');
+  }
+  const run = hasSkill ? `skill:${flags.skill}` : `builtin:${flags.job}`;
+
+  let timeoutMinutes;
+  if (typeof flags.timeout === 'string') {
+    timeoutMinutes = Number(flags.timeout);
+    if (!Number.isInteger(timeoutMinutes) || timeoutMinutes <= 0) {
+      throw new WienerdogError(`invalid --timeout ${JSON.stringify(flags.timeout)} — expected a positive integer (minutes)`);
+    }
+  } else {
+    timeoutMinutes = run === 'builtin:dream' ? 20 : 15;
+  }
+
+  const paths = getPaths();
+  const job = { name, at: flags.at, run, timeoutMinutes };
+  // Persist the job definition first (config write + manifest hash re-sync),
+  // then register OS entries on top of the up-to-date manifest.
+  jobsLib.saveJob(paths, job);
+
+  const manifest = manifestLib.load(paths);
+  const { platform, changed } = registerPlatform(paths, manifest, { name, hour, minute }, loader);
+  manifestLib.save(paths, manifest);
+
+  if (!changed) {
+    process.stdout.write(`wienerdog: "${name}" already scheduled at ${flags.at} — unchanged.\n`);
+    return;
+  }
+  const suffix = platform === 'launchd' && process.platform === 'darwin' ? '; catch-up ensured.' : '.';
+  process.stdout.write(`wienerdog: scheduled "${name}" (${run}) at ${flags.at} via ${platform}${suffix}\n`);
+}
+
+/**
+ * schedule remove <name>
+ * @param {string[]} argv
+ * @param {(argv:string[])=>{status:number}} loader  (unused; reverse runs the stored unload)
+ */
+function remove(argv, loader) {
+  const { positionals } = parseArgs(argv, new Set());
+  const name = positionals[0];
+  if (!name) throw new WienerdogError('schedule remove: missing job <name>');
+
+  const paths = getPaths();
+  const manifest = manifestLib.load(paths);
+  const basenames = new Set([
+    `${gen.launchdLabel(name)}.plist`,
+    `${gen.systemdUnitBase(name)}.timer`,
+    `${gen.systemdUnitBase(name)}.service`,
+  ]);
+  const matched = manifest.entries.filter(
+    (e) => e.kind === 'scheduler-entry' && basenames.has(path.basename(e.path))
+  );
+  const job = jobsLib.findJob(paths, name);
+
+  if (matched.length === 0 && !job) {
+    process.stdout.write(`wienerdog: no scheduled job named "${name}".\n`);
+    return;
+  }
+
+  const removed = [];
+  const skipped = [];
+  const removedSet = new Set();
+  for (const entry of matched) {
+    manifestLib.reverseSchedulerEntry(entry, false, removed, skipped, removedSet);
+  }
+  manifest.entries = manifest.entries.filter((e) => !matched.includes(e));
+  manifestLib.save(paths, manifest);
+  jobsLib.removeJob(paths, name);
+
+  process.stdout.write(`wienerdog: removed "${name}" (unloaded and deleted its schedule entry).\n`);
+}
+
+/**
+ * schedule list [--json]
+ * @param {string[]} argv
+ */
+function list(argv) {
+  const { flags } = parseArgs(argv, new Set());
+  const paths = getPaths();
+  const jobs = jobsLib.listJobs(paths);
+  const state = jobsLib.readScheduleState(paths);
+
+  const rows = jobs.map((j) => ({
+    name: j.name,
+    at: j.at,
+    run: j.run,
+    last_success: (state[j.name] && state[j.name].last_success) || null,
+    last_status: (state[j.name] && state[j.name].last_status) || null,
+  }));
+
+  if (flags.json) {
+    process.stdout.write(`${JSON.stringify(rows, null, 2)}\n`);
+    return;
+  }
+  if (rows.length === 0) {
+    process.stdout.write('wienerdog: no scheduled jobs.\n');
+    return;
+  }
+  for (const r of rows) {
+    const status = r.last_status ? `${r.last_status}${r.last_success ? ` @ ${r.last_success}` : ''}` : 'never run';
+    process.stdout.write(`  ${r.name}  ${r.at}  ${r.run}  (${status})\n`);
+  }
+}
+
+/**
+ * wienerdog schedule <add|remove|list> ...
+ * @param {string[]} argv
+ * @param {{loader?: (argv:string[])=>{status:number}}} [opts]
+ * @returns {Promise<void>}
+ */
+async function run(argv, { loader = defaultLoader } = {}) {
+  const sub = argv[0];
+  const rest = argv.slice(1);
+  switch (sub) {
+    case 'add':
+      add(rest, loader);
+      return;
+    case 'remove':
+      remove(rest, loader);
+      return;
+    case 'list':
+      list(rest);
+      return;
+    default:
+      throw new WienerdogError('usage: wienerdog schedule <add|remove|list> ...');
+  }
+}
+
+module.exports = { run, defaultLoader };

--- a/src/core/manifest.js
+++ b/src/core/manifest.js
@@ -3,6 +3,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const crypto = require('node:crypto');
+const { spawnSync } = require('node:child_process');
 
 /**
  * install-manifest.json shape:
@@ -20,8 +21,17 @@ const crypto = require('node:crypto');
  *                                                   — hook commands we merged into
  *                                                     a JSON settings file
  *
+ * Scheduler adds one more kind (WP-013):
+ *   {kind:'scheduler-entry', path, unload?:string[]} — an OS-native schedule file
+ *                                                     (launchd plist / systemd unit)
+ *                                                     whose reverse runs the stored
+ *                                                     `unload` argv (best-effort) then
+ *                                                     removes the file. `unload` is
+ *                                                     omitted/null when no OS
+ *                                                     unregistration is needed.
+ *
  * @typedef {{kind: string, path: string, hash?: string, createdFile?: boolean,
- *            commands?: string[]}} ManifestEntry
+ *            commands?: string[], unload?: string[]}} ManifestEntry
  * @typedef {{version: number, createdAt: string, entries: ManifestEntry[]}} Manifest
  */
 
@@ -168,6 +178,38 @@ function reverseSettingsEntry(entry, dryRun, removed, skipped, removedSet) {
 }
 
 /**
+ * Reverse a 'scheduler-entry' entry: run the stored `unload` argv best-effort to
+ * unregister the entry from the OS scheduler, then remove the file. Keeps
+ * manifest.js free of any launchd/systemd knowledge — the platform-specific
+ * `unload` argv is computed at add time (schedule.js) and stored on the entry.
+ * @param {ManifestEntry} entry
+ * @param {boolean} dryRun
+ * @param {string[]} removed @param {string[]} skipped @param {Set<string>} removedSet
+ */
+function reverseSchedulerEntry(entry, dryRun, removed, skipped, removedSet) {
+  if (Array.isArray(entry.unload) && entry.unload.length > 0) {
+    if (dryRun) {
+      process.stdout.write(`wienerdog: would run: ${entry.unload.join(' ')}\n`);
+    } else {
+      // Best-effort: the entry may already be unloaded. Ignore non-zero/errors;
+      // the goal is the file removal below.
+      try {
+        spawnSync(entry.unload[0], entry.unload.slice(1));
+      } catch {
+        /* ignore — unregistration is best-effort */
+      }
+    }
+  }
+  if (!isFile(entry.path)) {
+    skipped.push(entry.path);
+    return;
+  }
+  if (!dryRun) fs.rmSync(entry.path, { force: true });
+  removedSet.add(entry.path);
+  removed.push(entry.path);
+}
+
+/**
  * Load the install manifest. Returns a fresh empty manifest if none exists.
  * Throws (SyntaxError) if the file exists but is not valid JSON — callers that
  * need to distinguish "missing" from "corrupt" should check existence first.
@@ -273,6 +315,8 @@ function reverse(paths, manifest, { dryRun = false } = {}) {
       reverseManagedBlock(entry, dryRun, removed, skipped, removedSet);
     } else if (entry.kind === 'settings-entry') {
       reverseSettingsEntry(entry, dryRun, removed, skipped, removedSet);
+    } else if (entry.kind === 'scheduler-entry') {
+      reverseSchedulerEntry(entry, dryRun, removed, skipped, removedSet);
     } else {
       process.stderr.write(
         `wienerdog: skipping unknown manifest entry kind '${entry.kind}' (${entry.path})\n`
@@ -284,4 +328,4 @@ function reverse(paths, manifest, { dryRun = false } = {}) {
   return { removed, skipped };
 }
 
-module.exports = { load, record, save, reverse };
+module.exports = { load, record, save, reverse, reverseSchedulerEntry };

--- a/src/scheduler/generators.js
+++ b/src/scheduler/generators.js
@@ -1,0 +1,213 @@
+'use strict';
+
+const path = require('node:path');
+
+const { WienerdogError } = require('../core/errors');
+
+/**
+ * Pure text renderers and path helpers for the OS-native scheduler entries.
+ * Every path that lands in a generated plist/unit MUST be absolute — launchd
+ * does not expand `$HOME`, `~`, or `$PATH`, and systemd runs with no cwd. The
+ * absolute paths are computed here and passed into the renderers by the caller.
+ */
+
+/**
+ * Absolute path to the node binary that will run wienerdog under the scheduler.
+ * @returns {string} process.execPath (already absolute).
+ */
+function nodePath() {
+  return process.execPath;
+}
+
+/**
+ * Absolute path to this install's bin/wienerdog.js. Resolved from __dirname so
+ * it is never a relative path (launchd/systemd do not resolve cwd).
+ * @returns {string}
+ */
+function wienerdogBin() {
+  return path.resolve(__dirname, '..', '..', 'bin', 'wienerdog.js');
+}
+
+/**
+ * macOS LaunchAgents dir.
+ * @param {string} home
+ * @returns {string}
+ */
+function launchAgentsDir(home) {
+  return path.join(home, 'Library', 'LaunchAgents');
+}
+
+/**
+ * systemd user unit dir: $XDG_CONFIG_HOME/systemd/user, else ~/.config/systemd/user.
+ * @param {string} home
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {string}
+ */
+function systemdUserDir(home, env) {
+  const xdg = env && env.XDG_CONFIG_HOME;
+  const base = xdg && xdg !== '' ? xdg : path.join(home, '.config');
+  return path.join(base, 'systemd', 'user');
+}
+
+/**
+ * launchd Label for a job. 'daily-digest' → 'ai.wienerdog.daily-digest'.
+ * @param {string} name
+ * @returns {string}
+ */
+function launchdLabel(name) {
+  return `ai.wienerdog.${name}`;
+}
+
+/**
+ * systemd unit base for a job. 'daily-digest' → 'wienerdog-daily-digest'
+ * (the .timer / .service suffix is appended by the caller).
+ * @param {string} name
+ * @returns {string}
+ */
+function systemdUnitBase(name) {
+  return `wienerdog-${name}`;
+}
+
+/**
+ * Parse a 24-hour "HH:MM" clock string.
+ * @param {string} at
+ * @returns {{hour:number, minute:number}}
+ */
+function parseAt(at) {
+  if (typeof at !== 'string' || !/^([01]?\d|2[0-3]):[0-5]\d$/.test(at)) {
+    throw new WienerdogError(`invalid --at ${JSON.stringify(at)} — expected 24-hour HH:MM (00:00–23:59)`);
+  }
+  const [h, m] = at.split(':');
+  return { hour: Number(h), minute: Number(m) };
+}
+
+/**
+ * Render a per-job launchd plist. All paths ABSOLUTE (no $HOME/~).
+ * @param {{name:string, hour:number, minute:number, node:string, bin:string,
+ *          logDir:string}} o  logDir = <core>/logs/<name> (absolute)
+ * @returns {string} the full plist XML
+ */
+function launchdPlist(o) {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${launchdLabel(o.name)}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${o.node}</string>
+    <string>${o.bin}</string>
+    <string>run-job</string>
+    <string>${o.name}</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>${o.hour}</integer>
+    <key>Minute</key>
+    <integer>${o.minute}</integer>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>${path.join(o.logDir, 'launchd.out.log')}</string>
+  <key>StandardErrorPath</key>
+  <string>${path.join(o.logDir, 'launchd.err.log')}</string>
+  <key>ProcessType</key>
+  <string>Background</string>
+</dict>
+</plist>
+`;
+}
+
+/**
+ * Render the single macOS catch-up plist (login + hourly). It invokes
+ * `wienerdog run-job --catch-up` (WP-020). RunAtLoad true, plus hourly at :00.
+ * @param {{node:string, bin:string, logDir:string}} o  logDir = <core>/logs/catchup
+ * @returns {string} plist XML with Label 'ai.wienerdog.catchup'
+ */
+function catchupPlist(o) {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>ai.wienerdog.catchup</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${o.node}</string>
+    <string>${o.bin}</string>
+    <string>run-job</string>
+    <string>--catch-up</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>${path.join(o.logDir, 'launchd.out.log')}</string>
+  <key>StandardErrorPath</key>
+  <string>${path.join(o.logDir, 'launchd.err.log')}</string>
+  <key>ProcessType</key>
+  <string>Background</string>
+</dict>
+</plist>
+`;
+}
+
+/**
+ * @param {number} n
+ * @returns {string} zero-padded to two digits.
+ */
+function pad2(n) {
+  return String(n).padStart(2, '0');
+}
+
+/**
+ * Render a systemd .timer unit. Persistent=true gives native catch-up.
+ * @param {{name:string, hour:number, minute:number}} o
+ * @returns {string} .timer unit text
+ */
+function systemdTimer(o) {
+  return `[Unit]
+Description=Wienerdog job: ${o.name}
+
+[Timer]
+OnCalendar=*-*-* ${pad2(o.hour)}:${pad2(o.minute)}:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+`;
+}
+
+/**
+ * Render a systemd oneshot .service unit. All paths ABSOLUTE.
+ * @param {{name:string, node:string, bin:string}} o
+ * @returns {string} .service unit text
+ */
+function systemdService(o) {
+  return `[Unit]
+Description=Wienerdog job: ${o.name}
+
+[Service]
+Type=oneshot
+ExecStart=${o.node} ${o.bin} run-job ${o.name}
+`;
+}
+
+module.exports = {
+  nodePath,
+  wienerdogBin,
+  launchAgentsDir,
+  systemdUserDir,
+  launchdLabel,
+  systemdUnitBase,
+  parseAt,
+  launchdPlist,
+  catchupPlist,
+  systemdTimer,
+  systemdService,
+};

--- a/src/scheduler/jobs.js
+++ b/src/scheduler/jobs.js
@@ -1,0 +1,251 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const manifestLib = require('../core/manifest');
+
+/**
+ * Job definitions live in a managed `jobs:` section of config.yaml (stable
+ * config). Job run watermarks (last_success/last_status) live in
+ * state/schedule.json (frequently-changing machine state) so config.yaml's
+ * manifest hash does not churn on every run.
+ */
+
+const BEGIN =
+  '# --- wienerdog:jobs (managed by `wienerdog schedule`; do not edit by hand) ---';
+const END = '# --- end wienerdog:jobs ---';
+
+/** @param {string} content @returns {string} sha256 hex. */
+function sha256(content) {
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+/** @param {string} v @returns {string} value with one layer of surrounding quotes stripped. */
+function unquote(v) {
+  const t = v.trim();
+  if (
+    t.length >= 2 &&
+    ((t[0] === '"' && t[t.length - 1] === '"') || (t[0] === "'" && t[t.length - 1] === "'"))
+  ) {
+    return t.slice(1, -1);
+  }
+  return t;
+}
+
+/**
+ * Parse the jobs managed-section. Absent → []. Tolerant of the exact block this
+ * module writes; never parses arbitrary YAML.
+ * @param {string} configText
+ * @returns {Array<{name:string, at:string, run:string, timeoutMinutes:number}>}
+ */
+function parseJobs(configText) {
+  const begin = configText.indexOf(BEGIN);
+  if (begin === -1) return [];
+  const end = configText.indexOf(END, begin);
+  if (end === -1) return [];
+  const section = configText.slice(begin, end);
+  const lines = section.split('\n');
+  /** @type {Array<{name:string, at:string, run:string, timeoutMinutes:number}>} */
+  const jobs = [];
+  let cur = null;
+  for (const line of lines) {
+    const nameM = line.match(/^\s*-\s*name:\s*(.+)$/);
+    if (nameM) {
+      if (cur) jobs.push(cur);
+      cur = { name: unquote(nameM[1]), at: '', run: '', timeoutMinutes: 0 };
+      continue;
+    }
+    if (!cur) continue;
+    const atM = line.match(/^\s*at:\s*(.+)$/);
+    if (atM) {
+      cur.at = unquote(atM[1]);
+      continue;
+    }
+    const runM = line.match(/^\s*run:\s*(.+)$/);
+    if (runM) {
+      cur.run = unquote(runM[1]);
+      continue;
+    }
+    const toM = line.match(/^\s*timeout_minutes:\s*(\d+)\s*$/);
+    if (toM) cur.timeoutMinutes = Number(toM[1]);
+  }
+  if (cur) jobs.push(cur);
+  return jobs;
+}
+
+/**
+ * Render one job's YAML block (4-space nested under the `jobs:` list).
+ * @param {{name:string, at:string, run:string, timeoutMinutes:number}} job
+ * @returns {string}
+ */
+function renderJob(job) {
+  return (
+    `  - name: ${job.name}\n` +
+    `    at: "${job.at}"\n` +
+    `    run: ${job.run}\n` +
+    `    timeout_minutes: ${job.timeoutMinutes}\n`
+  );
+}
+
+/**
+ * Strip the jobs managed-section (and its one leading blank-line separator) from
+ * configText, preserving everything else byte-for-byte. Absent → unchanged.
+ * @param {string} configText
+ * @returns {string}
+ */
+function stripSection(configText) {
+  const begin = configText.indexOf(BEGIN);
+  if (begin === -1) return configText;
+  const end = configText.indexOf(END, begin);
+  if (end === -1) return configText;
+  // Advance past the end sentinel line (through its trailing newline).
+  let lineEnd = configText.indexOf('\n', end);
+  lineEnd = lineEnd === -1 ? configText.length : lineEnd + 1;
+  let before = configText.slice(0, begin);
+  const after = configText.slice(lineEnd);
+  // Remove the single blank-line separator our writer inserted before the block.
+  if (before.endsWith('\n')) before = before.slice(0, -1);
+  return before + after;
+}
+
+/**
+ * Return configText with the jobs section replaced by `jobs` (removed entirely
+ * if empty). Everything OUTSIDE the sentinels is preserved byte-for-byte; the
+ * section is (re)written just before EOF with exactly one blank line before it.
+ * @param {string} configText
+ * @param {Array<{name:string, at:string, run:string, timeoutMinutes:number}>} jobs
+ * @returns {string}
+ */
+function renderConfigWithJobs(configText, jobs) {
+  let base = stripSection(configText);
+  if (!jobs || jobs.length === 0) return base;
+  if (!base.endsWith('\n')) base += '\n';
+  const body = jobs.map(renderJob).join('');
+  const section = `${BEGIN}\njobs:\n${body}${END}\n`;
+  return `${base}\n${section}`;
+}
+
+/** @param {import('../core/paths').WienerdogPaths} paths @returns {string} */
+function readConfig(paths) {
+  return fs.readFileSync(paths.config, 'utf8');
+}
+
+/**
+ * Re-sync the manifest's recorded config.yaml hash to the freshly written
+ * content, so uninstall doesn't mistake our own edit for a user edit. Mirrors
+ * init.js. No-op if the manifest has no config entry.
+ * @param {import('../core/paths').WienerdogPaths} paths
+ * @param {string} content
+ */
+function resyncConfigHash(paths, content) {
+  const manifest = manifestLib.load(paths);
+  const entry = manifest.entries.find((e) => e.kind === 'file' && e.path === paths.config);
+  if (entry) {
+    entry.hash = sha256(content);
+    manifestLib.save(paths, manifest);
+  }
+}
+
+/**
+ * Upsert one job (add, or replace the job with the same name) and persist
+ * config.yaml, then re-sync the manifest hash.
+ * @param {import('../core/paths').WienerdogPaths} paths
+ * @param {{name:string, at:string, run:string, timeoutMinutes:number}} job
+ */
+function saveJob(paths, job) {
+  const configText = readConfig(paths);
+  const jobs = parseJobs(configText);
+  const idx = jobs.findIndex((j) => j.name === job.name);
+  if (idx === -1) jobs.push(job);
+  else jobs[idx] = job;
+  const next = renderConfigWithJobs(configText, jobs);
+  fs.writeFileSync(paths.config, next);
+  resyncConfigHash(paths, next);
+}
+
+/**
+ * Remove the job with this name from config.yaml (+ re-sync manifest hash).
+ * No-op if absent.
+ * @param {import('../core/paths').WienerdogPaths} paths
+ * @param {string} name
+ */
+function removeJob(paths, name) {
+  const configText = readConfig(paths);
+  const jobs = parseJobs(configText);
+  const next = jobs.filter((j) => j.name !== name);
+  if (next.length === jobs.length) return; // absent → no-op
+  const rendered = renderConfigWithJobs(configText, next);
+  fs.writeFileSync(paths.config, rendered);
+  resyncConfigHash(paths, rendered);
+}
+
+/**
+ * @param {import('../core/paths').WienerdogPaths} paths
+ * @param {string} name
+ * @returns {{name:string, at:string, run:string, timeoutMinutes:number}|null}
+ */
+function findJob(paths, name) {
+  return listJobs(paths).find((j) => j.name === name) || null;
+}
+
+/**
+ * All defined jobs.
+ * @param {import('../core/paths').WienerdogPaths} paths
+ * @returns {Array<{name:string, at:string, run:string, timeoutMinutes:number}>}
+ */
+function listJobs(paths) {
+  let configText;
+  try {
+    configText = readConfig(paths);
+  } catch {
+    return [];
+  }
+  return parseJobs(configText);
+}
+
+/** @param {import('../core/paths').WienerdogPaths} paths @returns {string} */
+function scheduleStatePath(paths) {
+  return path.join(paths.state, 'schedule.json');
+}
+
+/**
+ * Read state/schedule.json. Missing/corrupt → {}.
+ * @param {import('../core/paths').WienerdogPaths} paths
+ * @returns {Record<string,{last_success?:string,last_status?:string,last_error_at?:string}>}
+ */
+function readScheduleState(paths) {
+  try {
+    return JSON.parse(fs.readFileSync(scheduleStatePath(paths), 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Merge one job's watermark and write state/schedule.json atomically (temp+rename).
+ * @param {import('../core/paths').WienerdogPaths} paths
+ * @param {string} name
+ * @param {{last_success?:string,last_status?:string,last_error_at?:string}} patch
+ */
+function writeScheduleState(paths, name, patch) {
+  const state = readScheduleState(paths);
+  state[name] = { ...state[name], ...patch };
+  const file = scheduleStatePath(paths);
+  const tmp = `${file}.${process.pid}.tmp`;
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(tmp, `${JSON.stringify(state, null, 2)}\n`);
+  fs.renameSync(tmp, file);
+}
+
+module.exports = {
+  parseJobs,
+  renderConfigWithJobs,
+  saveJob,
+  removeJob,
+  findJob,
+  listJobs,
+  readScheduleState,
+  writeScheduleState,
+};

--- a/tests/unit/scheduler-generators.test.js
+++ b/tests/unit/scheduler-generators.test.js
@@ -1,0 +1,161 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const gen = require('../../src/scheduler/generators');
+const { WienerdogError } = require('../../src/core/errors');
+
+const EXPECTED_PLIST = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>ai.wienerdog.daily-digest</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/node</string>
+    <string>/opt/wienerdog/bin/wienerdog.js</string>
+    <string>run-job</string>
+    <string>daily-digest</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>7</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>/Users/ada/.wienerdog/logs/daily-digest/launchd.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/ada/.wienerdog/logs/daily-digest/launchd.err.log</string>
+  <key>ProcessType</key>
+  <string>Background</string>
+</dict>
+</plist>
+`;
+
+const EXPECTED_CATCHUP = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>ai.wienerdog.catchup</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/node</string>
+    <string>/opt/wienerdog/bin/wienerdog.js</string>
+    <string>run-job</string>
+    <string>--catch-up</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>/Users/ada/.wienerdog/logs/catchup/launchd.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/ada/.wienerdog/logs/catchup/launchd.err.log</string>
+  <key>ProcessType</key>
+  <string>Background</string>
+</dict>
+</plist>
+`;
+
+const EXPECTED_TIMER = `[Unit]
+Description=Wienerdog job: daily-digest
+
+[Timer]
+OnCalendar=*-*-* 07:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+`;
+
+const EXPECTED_SERVICE = `[Unit]
+Description=Wienerdog job: daily-digest
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/node /opt/wienerdog/bin/wienerdog.js run-job daily-digest
+`;
+
+test('scheduler-generators: launchdPlist matches the golden byte-for-byte', () => {
+  const out = gen.launchdPlist({
+    name: 'daily-digest',
+    hour: 7,
+    minute: 0,
+    node: '/usr/local/bin/node',
+    bin: '/opt/wienerdog/bin/wienerdog.js',
+    logDir: '/Users/ada/.wienerdog/logs/daily-digest',
+  });
+  assert.equal(out, EXPECTED_PLIST);
+});
+
+test('scheduler-generators: catchupPlist matches the golden byte-for-byte', () => {
+  const out = gen.catchupPlist({
+    node: '/usr/local/bin/node',
+    bin: '/opt/wienerdog/bin/wienerdog.js',
+    logDir: '/Users/ada/.wienerdog/logs/catchup',
+  });
+  assert.equal(out, EXPECTED_CATCHUP);
+});
+
+test('scheduler-generators: systemdTimer matches the golden byte-for-byte', () => {
+  assert.equal(gen.systemdTimer({ name: 'daily-digest', hour: 7, minute: 0 }), EXPECTED_TIMER);
+});
+
+test('scheduler-generators: systemdService matches the golden byte-for-byte', () => {
+  assert.equal(
+    gen.systemdService({
+      name: 'daily-digest',
+      node: '/usr/bin/node',
+      bin: '/opt/wienerdog/bin/wienerdog.js',
+    }),
+    EXPECTED_SERVICE
+  );
+});
+
+test('scheduler-generators: systemd OnCalendar zero-pads single-digit hour/minute', () => {
+  const timer = gen.systemdTimer({ name: 'x', hour: 3, minute: 5 });
+  assert.match(timer, /^OnCalendar=\*-\*-\* 03:05:00$/m);
+});
+
+test('scheduler-generators: parseAt maps HH:MM to hour/minute', () => {
+  assert.deepEqual(gen.parseAt('03:30'), { hour: 3, minute: 30 });
+  assert.deepEqual(gen.parseAt('00:00'), { hour: 0, minute: 0 });
+  assert.deepEqual(gen.parseAt('23:59'), { hour: 23, minute: 59 });
+  assert.deepEqual(gen.parseAt('7:00'), { hour: 7, minute: 0 });
+});
+
+test('scheduler-generators: parseAt throws WienerdogError on invalid input', () => {
+  for (const bad of ['24:00', '12:60', '7', '7:5', 'ab:cd', '', '25:00', '12:99']) {
+    assert.throws(() => gen.parseAt(bad), WienerdogError, `expected throw for ${JSON.stringify(bad)}`);
+  }
+});
+
+test('scheduler-generators: path/label helpers', () => {
+  assert.equal(gen.launchdLabel('daily-digest'), 'ai.wienerdog.daily-digest');
+  assert.equal(gen.systemdUnitBase('daily-digest'), 'wienerdog-daily-digest');
+  assert.equal(gen.launchAgentsDir('/home/ada'), '/home/ada/Library/LaunchAgents');
+  assert.equal(
+    gen.systemdUserDir('/home/ada', {}),
+    '/home/ada/.config/systemd/user'
+  );
+  assert.equal(
+    gen.systemdUserDir('/home/ada', { XDG_CONFIG_HOME: '/xdg' }),
+    '/xdg/systemd/user'
+  );
+});
+
+test('scheduler-generators: nodePath/wienerdogBin are absolute', () => {
+  const path = require('node:path');
+  assert.ok(path.isAbsolute(gen.nodePath()));
+  assert.ok(path.isAbsolute(gen.wienerdogBin()));
+  assert.ok(gen.wienerdogBin().endsWith(path.join('bin', 'wienerdog.js')));
+});

--- a/tests/unit/scheduler-schedule.test.js
+++ b/tests/unit/scheduler-schedule.test.js
@@ -1,0 +1,359 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { spawnSync } = require('node:child_process');
+
+const { getPaths } = require('../../src/core/paths');
+const manifestLib = require('../../src/core/manifest');
+const jobsLib = require('../../src/scheduler/jobs');
+const gen = require('../../src/scheduler/generators');
+const schedule = require('../../src/cli/schedule');
+
+/** @param {string} c @returns {string} */
+function sha256(c) {
+  return crypto.createHash('sha256').update(c).digest('hex');
+}
+
+const BASE_CONFIG = `# Wienerdog configuration
+version: 1
+vault: /Users/ada/wienerdog
+harnesses:
+  claude: true
+  codex: false
+memory_mode: standard
+`;
+
+/** Build an isolated temp core with a config + matching manifest. */
+function setup() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-sched-'));
+  const env = { HOME: root, WIENERDOG_HOME: path.join(root, 'wd') };
+  const paths = getPaths(env);
+  fs.mkdirSync(paths.core, { recursive: true });
+  fs.mkdirSync(paths.state, { recursive: true });
+  fs.mkdirSync(paths.logs, { recursive: true });
+  fs.writeFileSync(paths.config, BASE_CONFIG);
+  const manifest = {
+    version: 1,
+    createdAt: new Date().toISOString(),
+    entries: [
+      { kind: 'dir', path: paths.core },
+      { kind: 'file', path: paths.config, hash: sha256(BASE_CONFIG) },
+    ],
+  };
+  manifestLib.save(paths, manifest);
+  return { root, env, paths };
+}
+
+/**
+ * Run schedule.run with process.env pointed at the temp core (getPaths reads env).
+ * @param {{HOME:string, WIENERDOG_HOME:string}} env
+ * @param {string[]} argv
+ * @param {(a:string[])=>{status:number}} loader
+ */
+async function runSchedule(env, argv, loader) {
+  const saved = { HOME: process.env.HOME, WIENERDOG_HOME: process.env.WIENERDOG_HOME };
+  process.env.HOME = env.HOME;
+  process.env.WIENERDOG_HOME = env.WIENERDOG_HOME;
+  try {
+    await schedule.run(argv, { loader });
+  } finally {
+    process.env.HOME = saved.HOME;
+    process.env.WIENERDOG_HOME = saved.WIENERDOG_HOME;
+  }
+}
+
+// Whether `schedule add` can register on this host (skip integration otherwise).
+const SCHED_SUPPORTED =
+  process.platform === 'darwin' ||
+  (process.platform === 'linux' &&
+    (fs.existsSync('/run/systemd/system') || !spawnSync('systemctl', ['--version']).error));
+
+// -------------------------------------------------------------------------
+// jobs.js: parseJobs / renderConfigWithJobs round-trip + coexistence
+// -------------------------------------------------------------------------
+
+test('scheduler-schedule: renderConfigWithJobs round-trips through parseJobs', () => {
+  const jobs = [
+    { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 },
+    { name: 'daily-digest', at: '07:00', run: 'skill:wienerdog-daily-digest', timeoutMinutes: 15 },
+  ];
+  const withJobs = jobsLib.renderConfigWithJobs(BASE_CONFIG, jobs);
+  assert.deepEqual(jobsLib.parseJobs(withJobs), jobs);
+  // Exactly one blank line before the managed section.
+  assert.match(withJobs, /memory_mode: standard\n\n# --- wienerdog:jobs/);
+});
+
+test('scheduler-schedule: content outside the jobs sentinels is byte-identical (grants coexist)', () => {
+  const GRANTS = `# --- wienerdog:grants (managed) ---
+grants:
+  - gmail
+# --- end wienerdog:grants ---
+`;
+  const configWithGrants = `${BASE_CONFIG}\n${GRANTS}`;
+  const jobs = [{ name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 }];
+  const withJobs = jobsLib.renderConfigWithJobs(configWithGrants, jobs);
+  // Grants block survives verbatim.
+  assert.ok(withJobs.includes(GRANTS));
+  // Removing all jobs restores the exact input.
+  const back = jobsLib.renderConfigWithJobs(withJobs, []);
+  assert.equal(back, configWithGrants);
+});
+
+test('scheduler-schedule: removing all jobs removes the whole section', () => {
+  const jobs = [{ name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 }];
+  const withJobs = jobsLib.renderConfigWithJobs(BASE_CONFIG, jobs);
+  const back = jobsLib.renderConfigWithJobs(withJobs, []);
+  assert.equal(back, BASE_CONFIG);
+  assert.ok(!back.includes('wienerdog:jobs'));
+});
+
+test('scheduler-schedule: saveJob upserts and re-syncs the manifest hash', () => {
+  const { paths } = setup();
+  jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+  assert.deepEqual(jobsLib.findJob(paths, 'dream'), {
+    name: 'dream',
+    at: '03:30',
+    run: 'builtin:dream',
+    timeoutMinutes: 20,
+  });
+  // Upsert (replace) same name.
+  jobsLib.saveJob(paths, { name: 'dream', at: '04:00', run: 'builtin:dream', timeoutMinutes: 30 });
+  assert.equal(jobsLib.listJobs(paths).length, 1);
+  assert.equal(jobsLib.findJob(paths, 'dream').at, '04:00');
+  // Manifest hash re-synced → matches on-disk config.
+  const manifest = manifestLib.load(paths);
+  const entry = manifest.entries.find((e) => e.path === paths.config);
+  assert.equal(entry.hash, sha256(fs.readFileSync(paths.config, 'utf8')));
+});
+
+test('scheduler-schedule: removeJob is a no-op when the job is absent', () => {
+  const { paths } = setup();
+  const before = fs.readFileSync(paths.config, 'utf8');
+  jobsLib.removeJob(paths, 'ghost');
+  assert.equal(fs.readFileSync(paths.config, 'utf8'), before);
+});
+
+test('scheduler-schedule: schedule.json watermark read/write', () => {
+  const { paths } = setup();
+  assert.deepEqual(jobsLib.readScheduleState(paths), {});
+  jobsLib.writeScheduleState(paths, 'dream', { last_success: '2026-07-03T03:30:12.000Z', last_status: 'ok' });
+  jobsLib.writeScheduleState(paths, 'dream', { last_status: 'ok' });
+  const state = jobsLib.readScheduleState(paths);
+  assert.equal(state.dream.last_success, '2026-07-03T03:30:12.000Z');
+  assert.equal(state.dream.last_status, 'ok');
+});
+
+// -------------------------------------------------------------------------
+// manifest.js: scheduler-entry reverse (harmless marker command as the "spy")
+// -------------------------------------------------------------------------
+
+test('scheduler-schedule: reverseSchedulerEntry runs the stored unload then removes the file', () => {
+  const { root } = setup();
+  const file = path.join(root, 'ai.wienerdog.x.plist');
+  fs.writeFileSync(file, '<plist/>');
+  const marker = path.join(root, 'unload-ran');
+  const entry = {
+    kind: 'scheduler-entry',
+    path: file,
+    unload: [process.execPath, '-e', `require('fs').writeFileSync(${JSON.stringify(marker)}, 'ran')`],
+  };
+  const removed = [];
+  const skipped = [];
+  manifestLib.reverseSchedulerEntry(entry, false, removed, skipped, new Set());
+  assert.ok(fs.existsSync(marker), 'unload argv was executed');
+  assert.ok(!fs.existsSync(file), 'file removed');
+  assert.deepEqual(removed, [file]);
+});
+
+test('scheduler-schedule: reverseSchedulerEntry --dry-run runs nothing but reports', () => {
+  const { root } = setup();
+  const file = path.join(root, 'ai.wienerdog.y.plist');
+  fs.writeFileSync(file, '<plist/>');
+  const marker = path.join(root, 'dry-marker');
+  const entry = {
+    kind: 'scheduler-entry',
+    path: file,
+    unload: [process.execPath, '-e', `require('fs').writeFileSync(${JSON.stringify(marker)}, 'ran')`],
+  };
+  const removed = [];
+  manifestLib.reverseSchedulerEntry(entry, true, removed, [], new Set());
+  assert.ok(!fs.existsSync(marker), 'dry-run did not run the unload');
+  assert.ok(fs.existsSync(file), 'dry-run did not remove the file');
+  assert.deepEqual(removed, [file]);
+});
+
+test('scheduler-schedule: manifest.reverse handles scheduler-entry (unload + rm)', () => {
+  const { paths, root } = setup();
+  const file = path.join(root, 'ai.wienerdog.z.plist');
+  fs.writeFileSync(file, '<plist/>');
+  const marker = path.join(root, 'reverse-ran');
+  const manifest = manifestLib.load(paths);
+  manifestLib.record(manifest, {
+    kind: 'scheduler-entry',
+    path: file,
+    unload: [process.execPath, '-e', `require('fs').writeFileSync(${JSON.stringify(marker)}, 'ran')`],
+  });
+  manifestLib.save(paths, manifest);
+  const { removed } = manifestLib.reverse(paths, manifestLib.load(paths));
+  assert.ok(fs.existsSync(marker), 'reverse ran the stored unload');
+  assert.ok(!fs.existsSync(file), 'reverse removed the entry file');
+  assert.ok(removed.includes(file));
+});
+
+// -------------------------------------------------------------------------
+// schedule.js: add / list / remove with a stubbed loader
+// -------------------------------------------------------------------------
+
+test('scheduler-schedule: add validates name, --at, and exactly-one-of skill/job', async () => {
+  const { env } = setup();
+  const loader = () => ({ status: 0 });
+  await assert.rejects(runSchedule(env, ['add', 'Bad_Name', '--at', '07:00', '--job', 'dream'], loader));
+  await assert.rejects(runSchedule(env, ['add', 'dream', '--at', '99:99', '--job', 'dream'], loader));
+  await assert.rejects(runSchedule(env, ['add', 'dream', '--at', '07:00'], loader)); // neither skill nor job
+  await assert.rejects(
+    runSchedule(env, ['add', 'dream', '--at', '07:00', '--job', 'dream', '--skill', 's'], loader)
+  ); // both
+});
+
+test('scheduler-schedule: add registers the platform entry, records manifest, saves the job', { skip: !SCHED_SUPPORTED }, async () => {
+  const { env, paths } = setup();
+  /** @type {string[][]} */ const calls = [];
+  const loader = (argv) => {
+    calls.push(argv);
+    return { status: 0 };
+  };
+
+  await runSchedule(env, ['add', 'daily-digest', '--at', '07:00', '--skill', 'wienerdog-daily-digest'], loader);
+
+  // Job persisted with skill:<...> run and default timeout 15.
+  assert.deepEqual(jobsLib.findJob(paths, 'daily-digest'), {
+    name: 'daily-digest',
+    at: '07:00',
+    run: 'skill:wienerdog-daily-digest',
+    timeoutMinutes: 15,
+  });
+
+  const manifest = manifestLib.load(paths);
+  const schedEntries = manifest.entries.filter((e) => e.kind === 'scheduler-entry');
+  // Every recorded scheduler file exists on disk.
+  for (const e of schedEntries) assert.ok(fs.existsSync(e.path), `${e.path} exists`);
+  // At least one loader call happened (bootstrap / enable).
+  assert.ok(calls.length >= 1);
+
+  if (process.platform === 'darwin') {
+    const uid = process.getuid();
+    const label = 'ai.wienerdog.daily-digest';
+    const plistPath = path.join(paths.home, 'Library', 'LaunchAgents', `${label}.plist`);
+    const jobEntry = schedEntries.find((e) => e.path === plistPath);
+    assert.ok(jobEntry, 'per-job plist entry recorded');
+    assert.deepEqual(jobEntry.unload, ['launchctl', 'bootout', `gui/${uid}/${label}`]);
+    assert.deepEqual(calls[0], ['launchctl', 'bootstrap', `gui/${uid}`, plistPath]);
+    // Catch-up plist ensured once.
+    const catchPath = path.join(paths.home, 'Library', 'LaunchAgents', 'ai.wienerdog.catchup.plist');
+    assert.ok(schedEntries.some((e) => e.path === catchPath), 'catch-up entry recorded');
+    assert.ok(fs.readFileSync(plistPath, 'utf8').includes('<string>run-job</string>'));
+  } else {
+    const base = 'wienerdog-daily-digest';
+    const dir = gen.systemdUserDir(paths.home, process.env);
+    const timerPath = path.join(dir, `${base}.timer`);
+    const servicePath = path.join(dir, `${base}.service`);
+    const timerEntry = schedEntries.find((e) => e.path === timerPath);
+    const serviceEntry = schedEntries.find((e) => e.path === servicePath);
+    assert.ok(timerEntry && serviceEntry);
+    assert.deepEqual(timerEntry.unload, ['systemctl', '--user', 'disable', '--now', `${base}.timer`]);
+    assert.equal(serviceEntry.unload, undefined, 'the .service entry carries no unload');
+    assert.deepEqual(calls[0], ['systemctl', '--user', 'daemon-reload']);
+  }
+});
+
+test('scheduler-schedule: a second identical add is idempotent (no OS call)', { skip: !SCHED_SUPPORTED }, async () => {
+  const { env } = setup();
+  const calls1 = [];
+  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], (a) => (calls1.push(a), { status: 0 }));
+  assert.ok(calls1.length >= 1);
+  const calls2 = [];
+  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], (a) => (calls2.push(a), { status: 0 }));
+  assert.equal(calls2.length, 0, 'no loader calls on an unchanged re-add');
+});
+
+test('scheduler-schedule: add then manifest.reverse still removes config.yaml (hash re-synced)', { skip: !SCHED_SUPPORTED }, async () => {
+  const { env, paths } = setup();
+  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], () => ({ status: 0 }));
+  assert.ok(fs.existsSync(paths.config));
+  // Rewrite scheduler-entry unloads to harmless markers so reverse never calls launchctl/systemctl.
+  const manifest = manifestLib.load(paths);
+  for (const e of manifest.entries) {
+    if (e.kind === 'scheduler-entry') e.unload = [process.execPath, '-e', '0'];
+  }
+  manifestLib.save(paths, manifest);
+  manifestLib.reverse(paths, manifestLib.load(paths));
+  assert.ok(!fs.existsSync(paths.config), 'config.yaml removed — not mistaken for a user edit');
+});
+
+test('scheduler-schedule: remove runs the unload, deletes files, drops entries and the job', { skip: !SCHED_SUPPORTED }, async () => {
+  const { env, paths, root } = setup();
+  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], () => ({ status: 0 }));
+
+  // Replace the per-job entry's unload with a marker command (avoid real launchctl/systemctl).
+  const marker = path.join(root, 'remove-unload-ran');
+  const manifest = manifestLib.load(paths);
+  const jobBasenames = new Set([
+    'ai.wienerdog.dream.plist',
+    'wienerdog-dream.timer',
+    'wienerdog-dream.service',
+  ]);
+  const jobFiles = [];
+  for (const e of manifest.entries) {
+    if (e.kind === 'scheduler-entry' && jobBasenames.has(path.basename(e.path))) {
+      jobFiles.push(e.path);
+      if (e.unload) {
+        e.unload = [process.execPath, '-e', `require('fs').appendFileSync(${JSON.stringify(marker)}, 'x')`];
+      }
+    }
+  }
+  manifestLib.save(paths, manifest);
+
+  await runSchedule(env, ['remove', 'dream'], () => ({ status: 0 }));
+
+  assert.ok(fs.existsSync(marker), 'stored unload ran during remove');
+  for (const f of jobFiles) assert.ok(!fs.existsSync(f), `${f} deleted`);
+  assert.equal(jobsLib.findJob(paths, 'dream'), null, 'job dropped from config');
+  const after = manifestLib.load(paths);
+  const remainingJob = after.entries.filter(
+    (e) => e.kind === 'scheduler-entry' && jobBasenames.has(path.basename(e.path))
+  );
+  assert.equal(remainingJob.length, 0, 'per-job scheduler entries removed from manifest');
+});
+
+test('scheduler-schedule: remove of an unknown job is a no-op notice', async () => {
+  const { env } = setup();
+  await runSchedule(env, ['remove', 'nope'], () => ({ status: 0 })); // must not throw
+});
+
+test('scheduler-schedule: list --json reports jobs with watermarks', { skip: !SCHED_SUPPORTED }, async () => {
+  const { env, paths } = setup();
+  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], () => ({ status: 0 }));
+  await runSchedule(env, ['add', 'daily-digest', '--at', '07:00', '--skill', 'wienerdog-daily-digest'], () => ({ status: 0 }));
+  jobsLib.writeScheduleState(paths, 'dream', { last_success: '2026-07-03T03:30:12.000Z', last_status: 'ok' });
+
+  let out = '';
+  const orig = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (s) => ((out += s), true);
+  try {
+    await runSchedule(env, ['list', '--json'], () => ({ status: 0 }));
+  } finally {
+    process.stdout.write = orig;
+  }
+  const parsed = JSON.parse(out);
+  const dream = parsed.find((j) => j.name === 'dream');
+  const digest = parsed.find((j) => j.name === 'daily-digest');
+  assert.equal(dream.last_success, '2026-07-03T03:30:12.000Z');
+  assert.equal(dream.last_status, 'ok');
+  assert.equal(digest.last_success, null);
+  assert.equal(digest.last_status, null);
+});


### PR DESCRIPTION
Spec: docs/specs/WP-013-scheduler-generators.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

Created: `src/scheduler/generators.js`, `src/scheduler/jobs.js`, `src/cli/schedule.js`, `tests/unit/scheduler-generators.test.js`, `tests/unit/scheduler-schedule.test.js`. Modified: `src/core/manifest.js` (added `scheduler-entry` kind + exported `reverseSchedulerEntry`), `bin/wienerdog.js` (wired `schedule`). Also flipped the spec `status:` to In-Review per DoD item 4.

## Verification output

```
$ npm test -- --test-name-pattern scheduler-generators   (via node --test on both new files)
$ npm test -- --test-name-pattern scheduler-schedule
ℹ tests 25   ℹ pass 25   ℹ fail 0   ℹ skipped 0

$ npm test          (full suite)
ℹ tests 173  ℹ pass 173  ℹ fail 0

$ npm run lint
--- markdownlint ---   Summary: 0 error(s)
--- shellcheck ---
--- frontmatter check ---   frontmatter check passed: 12 spec(s), 4 agent(s)
lint passed

$ node -e "...g.launchdPlist({name:'demo',hour:7,minute:0,...})"
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
  <key>Label</key>
  <string>ai.wienerdog.demo</string>
  ... (absolute paths throughout; matches the spec golden shape)
</dict>
</plist>
```

Live launchctl/systemctl registration is manual-verify-at-M6; unit tests cover all generation, config/manifest bookkeeping, and reverse logic through the stubbed loader.

## Decisions made

- **`reverseSchedulerEntry` signature.** The spec sketched `reverseSchedulerEntry(entry, {dryRun}, ...)` but said "mirror the existing `reverse*` helpers", which take a plain boolean `dryRun`. Mirrored the existing helpers exactly: `(entry, dryRun, removed, skipped, removedSet)` with a boolean. `schedule remove` and the reverse-dispatch both call it with the boolean form.
- **Idempotency proxy for "already loaded".** launchd/systemd "loaded" state can't be read without an OS call. Used manifest-entry presence + byte-identical file content as the proxy: an identical re-add with an existing manifest entry makes no OS call and prints "unchanged".
- **Reload semantics on a changed re-add.** When a re-add changes a file, the loader is called with the spec's documented load argv (launchd `bootstrap` / systemd `daemon-reload`+`enable --now`). Did not add a bootout-then-bootstrap reload dance — the spec only specifies the load argv the tests assert, and real OS reload is manual-verify-at-M6.
- **Reverse "spy" in tests.** `manifest.reverseSchedulerEntry` calls `spawnSync` directly (no injectable loader by design — keeps launchd/systemd knowledge out of manifest.js). Tests assert the stored `unload` argv actually runs by using a harmless `node -e` marker-file command as the unload, so no real `launchctl`/`systemctl` is ever invoked on the test host.
- **Platform-conditional integration tests.** `add/remove/list` integration tests assert the current host's platform entries and are skipped on unsupported hosts (non-systemd Linux / Windows); the pure generator goldens cover both platforms unconditionally.
- **list non-JSON format.** Chose a compact `name  at  run  (status)` line; only `--json` shape is contract-fixed by the spec.

## Discovered issues (out of scope, not fixed)

none

---
Generated-by: claude-opus-4-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EA5BsHCfHRViJFXdovC86
