### PR TITLE
fix(gws): reconcile dispatch with verb-module contracts (WP-021)

### DIFF
--- a/docs/specs/WP-021-gws-dispatch-reconciliation.md
+++ b/docs/specs/WP-021-gws-dispatch-reconciliation.md
@@ -1,7 +1,7 @@
 ---
 id: WP-021
 title: Reconcile gws dispatch with verb-module contracts
-status: Ready
+status: In-Review
 model: sonnet
 size: S
 depends_on: [WP-018, WP-019]

--- a/src/gws/index.js
+++ b/src/gws/index.js
@@ -7,13 +7,21 @@ const { getServices } = require('./client');
 /**
  * Parse `gws` flags out of an argv tail, returning flags plus leftover
  * positionals. Supported: --json (bool), --max <n>, --to <s>, --subject <s>,
- * --body <s>, --client <path>.
+ * --body <s>, --client <path>, --routine <name>, --title <s>, --start <iso>,
+ * --end <iso>, --attendee <email> (repeatable), --from <iso>, --id <s>.
+ *
+ * `--title`/`--start`/`--end`/`--attendee`/`--from`/`--id` are cal/drive verb
+ * flags: they are captured here AND also left in `positionals` (their raw
+ * tokens) so the unmodified `calendar.js`/`drive.js` `run()` bridges — which
+ * independently re-parse those verb flags out of `positionals` — keep working.
  * @param {string[]} argv
  * @returns {{json:boolean, max?:number, to?:string, subject?:string,
- *   body?:string, client?:string, positionals:string[]}}
+ *   body?:string, client?:string, routine?:string, title?:string,
+ *   start?:string, end?:string, attendee:string[], from?:string, id?:string,
+ *   positionals:string[]}}
  */
 function parseFlags(argv) {
-  const flags = { json: false, positionals: [] };
+  const flags = { json: false, positionals: [], attendee: [] };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     switch (a) {
@@ -35,11 +43,51 @@ function parseFlags(argv) {
       case '--client':
         flags.client = argv[++i];
         break;
+      case '--routine':
+        flags.routine = argv[++i];
+        break;
+      case '--title':
+        flags.title = argv[++i];
+        flags.positionals.push(a, flags.title);
+        break;
+      case '--start':
+        flags.start = argv[++i];
+        flags.positionals.push(a, flags.start);
+        break;
+      case '--end':
+        flags.end = argv[++i];
+        flags.positionals.push(a, flags.end);
+        break;
+      case '--from':
+        flags.from = argv[++i];
+        flags.positionals.push(a, flags.from);
+        break;
+      case '--id':
+        flags.id = argv[++i];
+        flags.positionals.push(a, flags.id);
+        break;
+      case '--attendee': {
+        const v = argv[++i];
+        flags.attendee.push(v);
+        flags.positionals.push(a, v);
+        break;
+      }
       default:
         flags.positionals.push(a);
     }
   }
   return flags;
+}
+
+/**
+ * Resolve the routine for a `gmail send` grant lookup: `--routine` flag, else
+ * `WIENERDOG_JOB` env, else null. Never invents a routine — absent everywhere
+ * means null, which `gmail.send` treats as ungranted (degrade to draft).
+ * @param {{routine?:string}} flags
+ * @returns {string|null}
+ */
+function resolveRoutine(flags) {
+  return flags.routine ?? process.env.WIENERDOG_JOB ?? null;
 }
 
 /**
@@ -56,9 +104,9 @@ function require_(value, name) {
 }
 
 /**
- * The `<group> <verb>` dispatch table. Each handler lazily requires its module
- * so a group whose module is not shipped yet (WP-018/WP-019) fails only when
- * invoked, without touching this file.
+ * The `<group> <verb>` dispatch table. Each handler lazily requires its
+ * module so a group whose module is not shipped yet fails only when invoked,
+ * without touching this file.
  * @type {Record<string, (ctx:{paths:object, flags:object, services:()=>object})=>Promise<*>>}
  */
 const DISPATCH = {
@@ -79,11 +127,18 @@ const DISPATCH = {
       subject: require_(flags.subject, '--subject'),
       body: require_(flags.body, '--body'),
     }),
-  'gmail send': ({ flags, services }) =>
-    require('./gmail').send(services(), flags), // WP-018; require throws until then
-  'cal': ({ flags, services }) => require('./calendar').run(services(), flags), // WP-019
-  'drive': ({ flags, services }) => require('./drive').run(services(), flags), // WP-019
-  '_alert': ({ paths, flags }) => require('./alert').run(paths, flags), // WP-018
+  'gmail send': ({ paths, flags, services }) =>
+    require('./gmail').send(services(), {
+      to: flags.to,
+      subject: flags.subject,
+      body: flags.body,
+      routine: resolveRoutine(flags),
+      paths,
+    }),
+  'cal': ({ flags, services }) => require('./calendar').run(services(), flags),
+  'drive': ({ flags, services }) => require('./drive').run(services(), flags),
+  '_alert': ({ flags, services }) =>
+    require('./alert').run(services(), { subject: flags.subject, body: flags.body }),
 };
 
 /**
@@ -151,4 +206,4 @@ async function run(argv) {
   render(key, result, flags.json);
 }
 
-module.exports = { run };
+module.exports = { run, resolveRoutine };

--- a/tests/unit/gws-dispatch.test.js
+++ b/tests/unit/gws-dispatch.test.js
@@ -1,0 +1,271 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { getPaths } = require('../../src/core/paths');
+const grant = require('../../src/gws/grant');
+const client = require('../../src/gws/client');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const bin = path.join(repoRoot, 'bin', 'wienerdog.js');
+
+/**
+ * The client seam: index.js's `run()` always calls the real `getServices`, so
+ * we monkeypatch that one export to hand back whatever stub the current test
+ * installed — zero network, no token/client-json files needed. This MUST
+ * happen before `../../src/gws/index` is first required, since it destructures
+ * `getServices` out of this module at load time.
+ */
+let currentServices;
+client.getServices = () => currentServices;
+
+const gwsIndex = require('../../src/gws/index');
+
+/** Isolated temp core with a real config.yaml (via `init`), no token needed. */
+function initPaths() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-dispatch-'));
+  const core = path.join(root, 'wd');
+  const env = {
+    ...process.env,
+    WIENERDOG_HOME: core,
+    WIENERDOG_VAULT: path.join(root, 'vault'),
+    CLAUDE_CONFIG_DIR: path.join(root, 'absent-claude'),
+    CODEX_HOME: path.join(root, 'absent-codex'),
+  };
+  execFileSync('node', [bin, 'init', '--yes'], { env, stdio: 'ignore' });
+  return { paths: getPaths(env), env };
+}
+
+/** Point index.js's bare `getPaths()` at a temp core for the duration of `fn`. */
+async function withEnv(env, fn) {
+  const keys = ['WIENERDOG_HOME', 'WIENERDOG_VAULT', 'CLAUDE_CONFIG_DIR', 'CODEX_HOME'];
+  const saved = {};
+  for (const k of keys) saved[k] = process.env[k];
+  for (const k of keys) process.env[k] = env[k];
+  try {
+    return await fn();
+  } finally {
+    for (const k of keys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  }
+}
+
+/** Capture everything written to stdout during `fn`. */
+async function captureStdout(fn) {
+  const chunks = [];
+  const original = process.stdout.write;
+  process.stdout.write = (chunk) => {
+    chunks.push(String(chunk));
+    return true;
+  };
+  try {
+    await fn();
+  } finally {
+    process.stdout.write = original;
+  }
+  return chunks.join('');
+}
+
+/** Stub Gmail service: spies for send/drafts/getProfile, no network. */
+function stubGmail(emailAddress = 'me@example.com') {
+  const calls = { send: [], drafts: [], profile: 0 };
+  const services = {
+    gmail: {
+      users: {
+        messages: {
+          send: async (args) => {
+            calls.send.push(args);
+            return { data: { id: 'sent-1' } };
+          },
+        },
+        drafts: {
+          create: async (args) => {
+            calls.drafts.push(args);
+            return { data: { id: 'r-9', message: { id: 'm-9' } } };
+          },
+        },
+        getProfile: async () => {
+          calls.profile++;
+          return { data: { emailAddress } };
+        },
+      },
+    },
+  };
+  return { calls, services };
+}
+
+/** Stub Calendar service: spy for events.insert, no network. */
+function stubCalendar() {
+  const calls = { insert: [] };
+  const services = {
+    calendar: {
+      events: {
+        insert: async (args) => {
+          calls.insert.push(args);
+          return { data: { id: 'evt-1', htmlLink: 'https://calendar.google.com/evt-1' } };
+        },
+      },
+    },
+  };
+  return { calls, services };
+}
+
+/** @param {string} raw @returns {string} */
+function decode(raw) {
+  return Buffer.from(raw, 'base64url').toString('utf8');
+}
+
+test('gws-dispatch: gmail send without a grant degrades to draft + verbatim notice', async () => {
+  const { paths, env } = initPaths();
+  const s = stubGmail();
+  currentServices = s.services;
+
+  const output = await captureStdout(() =>
+    withEnv(env, () =>
+      gwsIndex.run(['gmail', 'send', '--to', 'a@b.com', '--subject', 's', '--body', 'b'])
+    )
+  );
+
+  assert.equal(s.calls.send.length, 0);
+  assert.equal(s.calls.drafts.length, 1);
+  assert.match(output, /No matching send grant \(no send grant for this routine\)/);
+  assert.match(output, /saved a draft instead/);
+  assert.match(output, /wienerdog grant send --routine <name> --to <recipients>/);
+  void paths;
+});
+
+test('gws-dispatch: gmail send with a matching --routine grant sends for real', async () => {
+  const { paths, env } = initPaths();
+  grant.saveGrant(paths, { routine: 'daily-digest', to: ['a@b.com'] });
+  const s = stubGmail();
+  currentServices = s.services;
+
+  await captureStdout(() =>
+    withEnv(env, () =>
+      gwsIndex.run([
+        'gmail',
+        'send',
+        '--to',
+        'a@b.com',
+        '--subject',
+        's',
+        '--body',
+        'b',
+        '--routine',
+        'daily-digest',
+      ])
+    )
+  );
+
+  assert.equal(s.calls.send.length, 1);
+  assert.equal(s.calls.drafts.length, 0);
+  assert.match(decode(s.calls.send[0].requestBody.raw), /To: a@b\.com/);
+});
+
+test('gws-dispatch: WIENERDOG_JOB env supplies the routine when --routine is absent', async () => {
+  const { paths, env } = initPaths();
+  grant.saveGrant(paths, { routine: 'daily-digest', to: ['a@b.com'] });
+  const s = stubGmail();
+  currentServices = s.services;
+
+  const savedJob = process.env.WIENERDOG_JOB;
+  process.env.WIENERDOG_JOB = 'daily-digest';
+  try {
+    await captureStdout(() =>
+      withEnv(env, () =>
+        gwsIndex.run(['gmail', 'send', '--to', 'a@b.com', '--subject', 's', '--body', 'b'])
+      )
+    );
+  } finally {
+    if (savedJob === undefined) delete process.env.WIENERDOG_JOB;
+    else process.env.WIENERDOG_JOB = savedJob;
+  }
+
+  assert.equal(s.calls.send.length, 1);
+  assert.equal(s.calls.drafts.length, 0);
+});
+
+test('gws-dispatch: _alert is invoked with exactly {subject, body}', async () => {
+  const { env } = initPaths();
+  const s = stubGmail('owner@example.com');
+  currentServices = s.services;
+
+  await captureStdout(() =>
+    withEnv(env, () =>
+      gwsIndex.run(['_alert', '--subject', 'watchdog failed', '--body', 'job X crashed'])
+    )
+  );
+
+  assert.equal(s.calls.send.length, 1);
+  const decoded = decode(s.calls.send[0].requestBody.raw);
+  assert.match(decoded, /To: owner@example\.com/);
+  assert.match(decoded, /Subject: \[wienerdog alert\] watchdog failed/);
+  assert.match(decoded, /job X crashed/);
+});
+
+test('gws-dispatch: cal draft-event still works through the run() bridge', async () => {
+  const { env } = initPaths();
+  const s = stubCalendar();
+  currentServices = s.services;
+
+  await captureStdout(() =>
+    withEnv(env, () =>
+      gwsIndex.run([
+        'cal',
+        'draft-event',
+        '--title',
+        't',
+        '--start',
+        '2026-07-03T09:00:00Z',
+        '--end',
+        '2026-07-03T09:15:00Z',
+      ])
+    )
+  );
+
+  assert.equal(s.calls.insert.length, 1);
+  const seen = s.calls.insert[0];
+  assert.equal(seen.calendarId, 'primary');
+  assert.equal(seen.sendUpdates, 'none');
+  assert.equal(seen.requestBody.summary, 't');
+  assert.deepEqual(seen.requestBody.start, { dateTime: '2026-07-03T09:00:00Z' });
+  assert.deepEqual(seen.requestBody.end, { dateTime: '2026-07-03T09:15:00Z' });
+});
+
+test('gws-dispatch: repeatable --attendee accumulates through to cal draft-event', async () => {
+  const { env } = initPaths();
+  const s = stubCalendar();
+  currentServices = s.services;
+
+  await captureStdout(() =>
+    withEnv(env, () =>
+      gwsIndex.run([
+        'cal',
+        'draft-event',
+        '--title',
+        't',
+        '--start',
+        '2026-07-03T09:00:00Z',
+        '--end',
+        '2026-07-03T09:15:00Z',
+        '--attendee',
+        'a@x.com',
+        '--attendee',
+        'c@x.com',
+      ])
+    )
+  );
+
+  assert.equal(s.calls.insert.length, 1);
+  assert.deepEqual(s.calls.insert[0].requestBody.attendees, [
+    { email: 'a@x.com' },
+    { email: 'c@x.com' },
+  ]);
+});


### PR DESCRIPTION
Spec: docs/specs/WP-021-gws-dispatch-reconciliation.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

## Verification output

```
$ npm test
...
ℹ tests 171
ℹ suites 0
ℹ pass 171
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0

$ npm run lint
--- markdownlint ---
markdownlint-cli2 v0.23.0 (markdownlint v0.41.0)
Finding: docs/**/*.md skills/**/*.md templates/**/*.md *.md
Linting: 65 file(s)
Summary: 0 error(s)
--- shellcheck ---
--- frontmatter check ---
frontmatter check passed: 12 spec(s), 4 agent(s)
lint passed

$ npm test -- --test-name-pattern gws-dispatch
✔ gws-dispatch: gmail send without a grant degrades to draft + verbatim notice
✔ gws-dispatch: gmail send with a matching --routine grant sends for real
✔ gws-dispatch: WIENERDOG_JOB env supplies the routine when --routine is absent
✔ gws-dispatch: _alert is invoked with exactly {subject, body}
✔ gws-dispatch: cal draft-event still works through the run() bridge
✔ gws-dispatch: repeatable --attendee accumulates through to cal draft-event
ℹ tests 29
ℹ pass 29
ℹ fail 0
```

### Manual granted/ungranted send transcript (stub via the client seam, zero network)

Ran `gws gmail send --to a@b.com --subject s --body b` through `gwsIndex.run()`
in-process with `src/gws/client.js`'s `getServices` monkeypatched to a stub
factory (the same seam `opts.factory` uses) — no real googleapis, no network:

```
=== gws gmail send (UNGRANTED, no --routine, no WIENERDOG_JOB) ===
{
  "sent": false,
  "degraded": true,
  "draftId": "r-9",
  "messageId": "m-9",
  "notice": "No matching send grant (no send grant for this routine); saved a draft instead. Run: wienerdog grant send --routine <name> --to <recipients>"
}
(stub) messages.send calls: 0
(stub) drafts.create calls: 1

=== gws gmail send (GRANTED, --routine daily-digest matches a saved grant) ===
{
  "sent": true,
  "degraded": false,
  "messageId": "sent-1"
}
(stub) messages.send calls: 1
(stub) drafts.create calls: 0
```

## Decisions made

- **Verb flags are both parsed structurally AND left in `positionals`.** The
  spec asks `parseFlags` to recognize `--title/--start/--end/--attendee/--from/--id`
  while also requiring `calendar.js`/`drive.js`'s unmodified `run()` bridges
  (which independently re-parse those exact flags out of `flags.positionals`)
  to keep working. Since those two requirements only stack — recognizing a
  flag structurally has no way to also leave it in `positionals` unless done
  explicitly — I made each of these cases both set the structured field
  (`flags.title`, etc.) and re-push the raw `--flag`/value token pair onto
  `positionals`, so nothing downstream regresses. `--routine` is the one new
  flag actually consumed at the dispatch layer, so it is not duplicated into
  `positionals`.
- **No `require_` validation added to `gmail send`/`_alert` dispatch rows.**
  The spec's "Exact contracts" section gives the literal object shape to pass
  through (`{to: flags.to, ...}` / `{subject: flags.subject, body: flags.body}`)
  without required-flag checks, unlike the pre-existing `gmail draft`/`auth`
  rows. Kept it exactly as specified rather than adding validation gmail.js
  doesn't ask for (out of scope, and gmail.js/alert.js are not in Deliverables).
- **Dispatch test file uses the client seam via in-test monkeypatching**, not
  `execFileSync`ing the real CLI, since a real child process can't be handed a
  JS stub factory across process boundaries. `client.getServices` is
  reassigned to a wrapper reading a per-test closure variable, patched before
  `src/gws/index.js` is first required (its `getServices` destructure is
  captured at module-load time). Each test still uses a real temp
  `~/.wienerdog` core (via `wienerdog init`) for `config.yaml`/grants, so
  grant read/write logic is exercised for real; only the Google service calls
  are stubbed.
- **Removed two now-stale `// WP-018`/`// WP-019` comments** on the `cal`/
  `drive`/`gmail send`/`_alert` dispatch rows and the one in the `DISPATCH`
  JSDoc — they described those verbs as not-yet-implemented, which this WP's
  entire purpose is to fix, and I was already rewriting the adjacent lines.

## Discovered issues (out of scope, not fixed)

- none

---
Generated-by: claude-sonnet-5
