### PR TITLE
feat(routines): catalog skill + daily-digest, inbox-triage, weekly-review (WP-014)

### DIFF
--- a/docs/specs/WP-014-routine-catalog.md
+++ b/docs/specs/WP-014-routine-catalog.md
@@ -1,7 +1,7 @@
 ---
 id: WP-014
 title: Author the routine catalog skill plus daily-digest, inbox-triage, and weekly-review routines
-status: Ready
+status: In-Review
 model: sonnet
 size: M
 depends_on: [WP-013, WP-018, WP-019]

--- a/skills/wienerdog-daily-digest/SKILL.md
+++ b/skills/wienerdog-daily-digest/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: wienerdog-daily-digest
+description: "Compose and email the user's morning digest (today's calendar, overnight inbox summary, latest memory report). Run headlessly by the daily-digest routine; not for interactive use."
+---
+
+# Wienerdog daily digest
+
+## Your role
+
+You are the daily-digest routine, running headless under the scheduler with
+no human present. Your job is to gather today's context and email a short,
+skimmable morning brief to the user. You have the normal harness tools plus
+the `wienerdog gws` and `wienerdog` CLIs. Keep the whole thing brief and
+factual — this is a brief, not a report.
+
+## Gather
+
+Read each of these, and degrade gracefully if any is empty or unavailable —
+never error out for a missing source:
+
+- **Today's calendar**: run `wienerdog gws cal list --max 20` and keep only
+  the events that fall today. No events today → say "nothing on the
+  calendar today".
+- **Overnight inbox**: run `wienerdog gws gmail search "in:inbox
+  newer_than:1d" --max 20`, then `wienerdog gws gmail read --id <id>` for any
+  message that looks important. Summarize senders and subjects in one line
+  each; do not quote private content verbatim beyond what a one-line summary
+  needs. Nothing found → say "no new mail overnight".
+- **Latest memory report**: find the vault path from the `vault:` line of
+  `~/.wienerdog/config.yaml`, then read the newest file in
+  `<vault>/reports/dreams/`. Missing → skip that section entirely; do not
+  error.
+
+## Compose
+
+Assemble a short brief with three clearly labeled sections: **Calendar**,
+**Inbox**, and **From your memory**. Plain language, skimmable, no filler.
+Put today's date in the subject line.
+
+## Send
+
+Send the brief to the user's own address with:
+
+```bash
+wienerdog gws gmail send --to <user's own address> --subject "Morning digest — <date>" --body "<brief>"
+```
+
+This routine can only send because the user separately granted send
+permission for `daily-digest` to their own address — a one-time step they
+did themselves, at the keyboard, before this routine ever ran. If no
+matching grant exists, this command returns a draft plus a notice instead of
+sending — that is expected and safe: the user will see the draft next time
+they check Gmail, not silence and not an unwanted send. When running under
+`run-job`, the routine name arrives via the `WIENERDOG_JOB` environment
+variable, so `--routine` may be omitted and the grant still matches. Never
+send to any address other than the user's own; never add recipients; never
+attempt to create or widen a grant — you have no way to, and you must not
+try: granting is gated to a separate interactive command this routine never
+runs.
+
+## If something is missing
+
+- No calendar events → say so in the Calendar section and keep going.
+- No overnight mail → say so in the Inbox section and keep going.
+- No dream report yet → skip the memory section entirely.
+- Google not connected at all (calendar and inbox both fail) → do nothing
+  and let the run fail loudly; do not send an empty shell of a brief.

--- a/skills/wienerdog-inbox-triage/SKILL.md
+++ b/skills/wienerdog-inbox-triage/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: wienerdog-inbox-triage
+description: "Each morning, triage recent inbox mail and leave draft replies where useful. Draft-only — never sends, so no send grant is needed. Run headlessly by the inbox-triage routine; not for interactive use."
+---
+
+# Wienerdog inbox triage
+
+## Your role
+
+You are the inbox-triage routine, running headless under the scheduler with
+no human present. Each morning you triage recent inbox mail and leave draft
+replies where useful. You have the normal harness tools plus the
+`wienerdog gws` CLI.
+
+## Gather
+
+Run `wienerdog gws gmail search "in:inbox newer_than:1d" --max 20`, then
+`wienerdog gws gmail read --id <id>` on any message that looks like it needs
+a reply.
+
+## Draft
+
+For mail that clearly warrants a reply, create a draft:
+
+```bash
+wienerdog gws gmail draft --to <sender> --subject "Re: <original subject>" --body "<suggested reply>"
+```
+
+Drafts only — the user reviews and sends each one manually. Do not draft a
+reply for mail that doesn't need one; leave it alone.
+
+## Never send
+
+This routine never runs `wienerdog gws gmail send` and never asks for a
+send grant. It only ever creates drafts with `wienerdog gws gmail draft` —
+sending is not something this routine does, by design.

--- a/skills/wienerdog-routines/SKILL.md
+++ b/skills/wienerdog-routines/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: wienerdog-routines
+description: "Browse and set up ready-made daily/weekly routines (morning digest, inbox triage, weekly review). Use when the user wants to set up an automatic routine, a scheduled job, or asks 'what can Wienerdog do for me?'."
+---
+
+# Wienerdog routines
+
+Your job is to walk the person through the routine catalog: a menu of
+ready-made routines they can turn on, one guided conversation at a time.
+
+## What routines are
+
+Routines are jobs Wienerdog runs for the person on a schedule, on their own
+computer, through their own AI subscription — there is no separate service
+and nothing runs anywhere else. Nothing is scheduled until they choose it
+here. This menu is also their settings panel for routines: run it again any
+time to add, remove, or change one.
+
+## The menu
+
+Present these three v1 routines. Be honest about what each needs — never
+undersell the access requirement.
+
+- **Daily digest** — a morning email to *you* with today's calendar, an
+  overnight inbox summary, and last night's memory report. Runs once a day.
+  Needs: Google connected, and your permission to email *you* (a one-time
+  grant to your own address).
+- **Inbox triage** — each morning, sorts recent inbox mail and leaves
+  **draft** replies where useful. Needs: Google connected. **Never sends** —
+  only drafts.
+- **Weekly review** — a weekly summary of what you worked on, saved to your
+  notes (and a draft you can send if you want). Needs: nothing beyond
+  Wienerdog. **Never sends.**
+
+## Setting up a routine
+
+Walk through one routine at a time:
+
+1. All three touch Google to some degree (digest and inbox triage need
+   Gmail and Calendar; weekly review only needs the vault, but check anyway
+   if unsure). If Google isn't connected yet, point the person to
+   `/wienerdog-google-setup` first and come back here after.
+2. Ask what time they want it to run. Default suggestions: daily digest
+   07:00, inbox triage 08:00, weekly review Monday 08:00 (weekly review is
+   still scheduled with a daily `--at` in v1 — the routine itself only acts
+   on its chosen weekday; see that routine's own skill for the note on this
+   limitation). Then run:
+   ```bash
+   wienerdog schedule add <name> --at HH:MM --skill <skill>
+   ```
+   using the routine's own name and skill, for example:
+   ```bash
+   wienerdog schedule add daily-digest --at 07:00 --skill wienerdog-daily-digest
+   ```
+3. **If the routine sends** — only the daily digest does — walk them through
+   granting send-to-self, before or right after scheduling. Show them the
+   command and explain what it does; do not run it for them:
+   ```bash
+   wienerdog grant send --routine daily-digest --to <their own email address>
+   ```
+   Tell them plainly what happens next: it will ask them to type the word
+   "grant" to confirm, and that this is deliberate — granting send access is
+   the one action a routine can never take on its own, so it always requires
+   them, in person, at the keyboard. `--to <their own address>` (send-to-self)
+   is the safe default; do not suggest third-party recipients. You must not
+   type "grant" or run this command for them — you can only show it and
+   explain it; they run it themselves.
+4. Confirm what is now scheduled with `wienerdog schedule list` and, for the
+   digest, that the grant exists. Tell them when the first run will happen.
+
+## Removing or changing a routine
+
+`wienerdog schedule remove <name>` unschedules a routine. To change its
+time, re-run this menu and run `schedule add` again — it overwrites.
+Removing a routine does not revoke a send grant; grants are managed
+separately with `wienerdog grant send`, so mention that to the person if
+they remove the daily digest.
+
+## Safety
+
+Routines run on their schedule through the person's own AI subscription, on
+their own computer — nothing leaves it that they didn't ask for. A routine
+can only *send* email if the person granted it, and only to the addresses
+they named; anything ungranted becomes a draft, never a surprise send. This
+catalog never grants anything itself — only the person, by typing "grant" at
+the keyboard, does.

--- a/skills/wienerdog-weekly-review/SKILL.md
+++ b/skills/wienerdog-weekly-review/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: wienerdog-weekly-review
+description: "Summarize the past week into a vault note, with an optional email draft. Draft-only — never sends, so no send grant is needed. Run headlessly by the weekly-review routine; not for interactive use."
+---
+
+# Wienerdog weekly review
+
+## Your role
+
+You are the weekly-review routine, running headless under the scheduler
+with no human present. Once a week you summarize what the user worked on
+and save it to their notes.
+
+## Gather
+
+Read the past week's daily logs in `<vault>/07-Daily/*.md` and the past
+week's dream reports in `<vault>/reports/dreams/`.
+
+## Write the review
+
+Write a summary note into the vault: a dated note under `03-Resources/`
+(the simpler choice for v1 — see Decisions made). Give it proper provenance
+frontmatter (`origin: routine`). Optionally, if the user might want to send
+a copy, also create an email draft:
+
+```bash
+wienerdog gws gmail draft --to <user's own address> --subject "Weekly review — <date>" --body "<summary>"
+```
+
+## Never send
+
+This routine never runs `wienerdog gws gmail send` and never asks for a
+send grant. Scheduling in v1 is daily (`--at`) only — there is no weekly
+primitive yet — so this routine is scheduled to run every day but only acts
+on its chosen weekday (for example, only produces a review on Monday and
+does nothing the other six days).

--- a/tests/unit/routines-skill-structure.test.js
+++ b/tests/unit/routines-skill-structure.test.js
@@ -1,0 +1,168 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.join(__dirname, '..', '..');
+
+/** @param {string} name @returns {string} */
+function skillPath(name) {
+  return path.join(repoRoot, 'skills', name, 'SKILL.md');
+}
+
+/**
+ * Read a SKILL.md and return both its raw text and a whitespace-flattened
+ * version (all runs of whitespace, including newlines from prose line-wrap,
+ * collapsed to a single space). Headings are checked against `text` (they
+ * live on their own line); multi-line prose phrases are checked against
+ * `flat` so line-wrapping in the source doesn't break a substring match.
+ * @param {string} name
+ * @returns {{text:string, flat:string}}
+ */
+function read(name) {
+  const text = fs.readFileSync(skillPath(name), 'utf8');
+  const flat = text.replace(/\s+/g, ' ');
+  return { text, flat };
+}
+
+const routines = read('wienerdog-routines');
+const dailyDigest = read('wienerdog-daily-digest');
+const inboxTriage = read('wienerdog-inbox-triage');
+const weeklyReview = read('wienerdog-weekly-review');
+
+/**
+ * @param {string} text
+ * @param {string} name
+ */
+function assertFrontmatter(text, name) {
+  assert.match(
+    text,
+    new RegExp(`^---\\n[\\s\\S]*?\\bname:\\s*${name}\\b[\\s\\S]*?\\n---`, 'm'),
+    `${name}: frontmatter name: field`
+  );
+  const desc = text.match(/^description:\s*(.+)$/m);
+  assert.ok(desc, `${name}: description: key is present`);
+  assert.ok(desc[1].trim().length > 0, `${name}: description is non-empty`);
+}
+
+test('all four routine skills: frontmatter has correct name and a non-empty description', () => {
+  assertFrontmatter(routines.text, 'wienerdog-routines');
+  assertFrontmatter(dailyDigest.text, 'wienerdog-daily-digest');
+  assertFrontmatter(inboxTriage.text, 'wienerdog-inbox-triage');
+  assertFrontmatter(weeklyReview.text, 'wienerdog-weekly-review');
+});
+
+test('wienerdog-routines: all five mandatory ## headings are present verbatim', () => {
+  const headings = [
+    '## What routines are',
+    '## The menu',
+    '## Setting up a routine',
+    '## Removing or changing a routine',
+    '## Safety',
+  ];
+  for (const h of headings) {
+    assert.ok(routines.text.includes(h), `missing heading: ${h}`);
+  }
+});
+
+test('wienerdog-routines: mentions all three routine display names', () => {
+  for (const name of ['Daily digest', 'Inbox triage', 'Weekly review']) {
+    assert.ok(routines.text.includes(name), `missing routine display name: ${name}`);
+  }
+});
+
+test('wienerdog-routines: contains the exact grant command form', () => {
+  assert.ok(
+    routines.text.includes('wienerdog grant send --routine daily-digest --to'),
+    'exact grant command form missing'
+  );
+});
+
+test('wienerdog-routines: states the model must not run the grant for the user', () => {
+  assert.ok(routines.flat.includes('type the word "grant"'), 'missing: type the word "grant"');
+  assert.ok(
+    routines.flat.includes('they run it themselves'),
+    'missing a "you run it yourself"-style phrase'
+  );
+});
+
+test('wienerdog-routines: states nothing is scheduled by default, and that triage/weekly-review never send', () => {
+  assert.ok(
+    routines.flat.toLowerCase().includes('nothing is scheduled'),
+    'missing "nothing is scheduled" phrasing'
+  );
+  assert.ok(routines.text.includes('Never sends'), 'missing "Never sends" for the draft-only routines');
+});
+
+test('wienerdog-daily-digest: all mandatory ## headings are present verbatim', () => {
+  const headings = ['## Your role', '## Gather', '## Compose', '## Send', '## If something is missing'];
+  for (const h of headings) {
+    assert.ok(dailyDigest.text.includes(h), `missing heading: ${h}`);
+  }
+});
+
+test('wienerdog-daily-digest: references the exact gws/vault reads and the send command', () => {
+  assert.ok(dailyDigest.text.includes('wienerdog gws cal list'), 'missing wienerdog gws cal list');
+  assert.ok(dailyDigest.text.includes('wienerdog gws gmail search'), 'missing wienerdog gws gmail search');
+  assert.ok(dailyDigest.text.includes('reports/dreams/'), 'missing reports/dreams/');
+  assert.ok(dailyDigest.text.includes('wienerdog gws gmail send'), 'missing wienerdog gws gmail send');
+});
+
+test('wienerdog-daily-digest: states ungranted-send-degrades-to-draft and references WIENERDOG_JOB', () => {
+  assert.ok(dailyDigest.flat.includes('WIENERDOG_JOB'), 'missing WIENERDOG_JOB');
+  const grantIdx = dailyDigest.flat.indexOf('granted send');
+  assert.ok(grantIdx !== -1, 'missing mention of the send grant');
+  const draftIdx = dailyDigest.flat.indexOf('draft', grantIdx);
+  assert.ok(
+    draftIdx !== -1 && draftIdx - grantIdx < 400,
+    '"draft" does not appear near the grant explanation'
+  );
+});
+
+test('wienerdog-daily-digest: states it only sends to the user\'s own address and never creates/widens a grant', () => {
+  assert.ok(
+    dailyDigest.flat.includes("Never send to any address other than the user's own"),
+    'missing send-to-self-only statement'
+  );
+  assert.ok(
+    dailyDigest.flat.includes('never attempt to create or widen a grant'),
+    'missing never-create-or-widen-a-grant statement'
+  );
+});
+
+test('wienerdog-inbox-triage: all mandatory ## headings are present verbatim', () => {
+  const headings = ['## Your role', '## Gather', '## Draft', '## Never send'];
+  for (const h of headings) {
+    assert.ok(inboxTriage.text.includes(h), `missing heading: ${h}`);
+  }
+});
+
+test('wienerdog-inbox-triage: references gws gmail draft and states it never sends', () => {
+  assert.ok(inboxTriage.text.includes('wienerdog gws gmail draft'), 'missing wienerdog gws gmail draft');
+  const neverSendIdx = inboxTriage.text.indexOf('## Never send');
+  const section = inboxTriage.text.slice(neverSendIdx);
+  assert.ok(section.includes('never runs `wienerdog gws gmail send`'), 'missing never-runs-send statement');
+  assert.ok(section.toLowerCase().includes('send grant'), 'missing send grant mention');
+});
+
+test('wienerdog-weekly-review: all mandatory ## headings are present verbatim', () => {
+  const headings = ['## Your role', '## Gather', '## Write the review', '## Never send'];
+  for (const h of headings) {
+    assert.ok(weeklyReview.text.includes(h), `missing heading: ${h}`);
+  }
+});
+
+test('wienerdog-weekly-review: references reading 07-Daily/ and states it never sends', () => {
+  assert.ok(weeklyReview.text.includes('07-Daily/'), 'missing 07-Daily/');
+  const neverSendIdx = weeklyReview.text.indexOf('## Never send');
+  const section = weeklyReview.text.slice(neverSendIdx);
+  assert.ok(section.includes('never runs `wienerdog gws gmail send`'), 'missing never-runs-send statement');
+});
+
+test('only wienerdog-routines mentions the grant command; the headless routines never invoke it', () => {
+  assert.ok(!dailyDigest.text.includes('wienerdog grant send'), 'daily-digest must not contain wienerdog grant send');
+  assert.ok(!inboxTriage.text.includes('wienerdog grant send'), 'inbox-triage must not contain wienerdog grant send');
+  assert.ok(!weeklyReview.text.includes('wienerdog grant send'), 'weekly-review must not contain wienerdog grant send');
+});


### PR DESCRIPTION
Spec: docs/specs/WP-014-routine-catalog.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table (plus the spec's own `status:` flip, per this WP's Definition of done)
- [x] Spec status flipped to In-Review

## Verification output

```
$ npm test -- --test-name-pattern routines-skill
...
✔ tests/unit/routines-skill-structure.test.js (81.114125ms)
ℹ tests 28
ℹ pass 28
ℹ fail 0

$ npm test
...
ℹ tests 219
ℹ pass 219
ℹ fail 0

$ npm run lint
--- markdownlint ---
Linting: 70 file(s)
Summary: 0 error(s)
--- shellcheck ---
--- frontmatter check ---
frontmatter check passed: 12 spec(s), 4 agent(s)
lint passed
```

**Manual end-to-end (schedule digest, grant send-to-self, let it fire, arrives by email)**: NOT done — this is called out in the spec as manual-verify-at-M6, out of scope for this WP's automated checks.

## Decisions made

- `wienerdog-weekly-review` writes its dated summary note under `03-Resources/` rather than appending to the current daily log — the simpler of the two options the spec offered, and it keeps the routine's provenance-framed output as its own note rather than mutating the daily log another process (dreaming) also touches.
- The structural test normalizes whitespace (`text.replace(/\s+/g, ' ')`) before asserting on multi-word prose phrases, so natural line-wrapping in the skill prose doesn't break a substring match; heading checks still use the raw text since headings live on their own line. This mirrors the intent of WP-009's `dream-skill-structure.test.js` approach while being robust to how the prose is wrapped.
- Chose exact self-authored substrings for the "model must not run the grant" and "never widen a grant" assertions (the spec left the exact wording to the implementer): `type the word "grant"` / `they run it themselves` in `wienerdog-routines`, and `Never send to any address other than the user's own` / `never attempt to create or widen a grant` in `wienerdog-daily-digest`.

## Discovered issues (out of scope, not fixed)

- none

---
Generated-by: claude-sonnet-5
