### PR TITLE
feat(scheduler): implement run-job wrapper with TCC-guard and fail-loud (WP-020)

### DIFF
--- a/bin/wienerdog.js
+++ b/bin/wienerdog.js
@@ -12,6 +12,7 @@ Commands:
   sync        Re-render the session digest from your vault's identity notes
   dream       Consolidate recent sessions into vault memory (one commit)
   schedule    Add, remove, or list scheduled jobs (dream, routines)
+  run-job     Run a scheduled job now (used by the OS scheduler)
   doctor      Check an existing install for problems
   uninstall   Remove everything Wienerdog created (reverses the install)
   gws         Read Gmail/Calendar/Drive and draft mail (Google Workspace)
@@ -39,6 +40,7 @@ async function main() {
     sync: () => require('../src/cli/sync'),
     dream: () => require('../src/cli/dream'),
     schedule: () => require('../src/cli/schedule'),
+    'run-job': () => require('../src/cli/run-job'),
     doctor: () => require('../src/cli/doctor'),
     uninstall: () => require('../src/cli/uninstall'),
     gws: () => require('../src/gws/index'),

--- a/docs/specs/WP-020-run-job-wrapper.md
+++ b/docs/specs/WP-020-run-job-wrapper.md
@@ -1,7 +1,7 @@
 ---
 id: WP-020
 title: Implement the run-job wrapper (clean env, TCC-guard, watchdog, logs, fail-loud, catch-up)
-status: Ready
+status: In-Review
 model: opus
 size: M
 depends_on: [WP-013]

--- a/src/cli/run-job.js
+++ b/src/cli/run-job.js
@@ -1,0 +1,413 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawn, spawnSync } = require('node:child_process');
+
+const { getPaths } = require('../core/paths');
+const { WienerdogError } = require('../core/errors');
+const { readDreamConfig } = require('../core/dream/config');
+const jobsLib = require('../scheduler/jobs');
+const gen = require('../scheduler/generators');
+const tccguard = require('../scheduler/tccguard');
+
+/**
+ * `wienerdog run-job <name>` is the short-lived wrapper the OS scheduler launches
+ * (WP-013's launchd plist / systemd unit). It turns a raw scheduled fire into a
+ * safe job run: explicit clean env, macOS TCC-guard, a hard kill-tree watchdog,
+ * teed+rotated logs, a fail-loud alert, and a `last_success` watermark. Nothing
+ * it starts outlives the job (ADR-0004).
+ */
+
+/** How many per-run *.log files to keep in a job's log dir. */
+const LOG_KEEP = 14;
+/** Bytes of the run log to attach to a fail-loud alert. */
+const LOG_TAIL_BYTES = 2048;
+/** Env vars carried through from the launching env into the clean job env. */
+const ENV_PASSTHROUGH = [
+  'WIENERDOG_HOME',
+  'WIENERDOG_VAULT',
+  'CLAUDE_CONFIG_DIR',
+  'CODEX_HOME',
+  'ANTHROPIC_API_KEY',
+];
+
+/** @returns {string} ISO timestamp for right now. */
+function nowIso() {
+  return new Date().toISOString();
+}
+
+/** @param {Date} [d] @returns {string} filesystem-safe run stamp, e.g. 2026-07-03T14-05-09-123Z. */
+function runStamp(d = new Date()) {
+  return d.toISOString().replace(/[:.]/g, '-');
+}
+
+/** Display an absolute path under home as ~/... .
+ *  @param {string} home @param {string} p @returns {string} */
+function tilde(home, p) {
+  if (p === home) return '~';
+  if (p.startsWith(home + path.sep)) return `~${p.slice(home.length)}`;
+  return p;
+}
+
+/**
+ * Build the explicit clean env for a job child. launchd/systemd children inherit
+ * almost nothing, so we construct PATH (node + common claude/codex dirs) and HOME
+ * from scratch and carry through only a small allowlist (claude-os L5/L6 lesson).
+ * @param {import('../core/paths').WienerdogPaths} paths
+ * @param {string} name
+ * @returns {NodeJS.ProcessEnv}
+ */
+function buildCleanEnv(paths, name) {
+  /** @type {NodeJS.ProcessEnv} */
+  const env = {
+    HOME: paths.home,
+    PATH: [
+      path.dirname(process.execPath), // node
+      '/opt/homebrew/bin',
+      '/usr/local/bin', // common claude/codex install dirs
+      '/usr/bin',
+      '/bin',
+      '/usr/sbin',
+      '/sbin',
+    ].join(':'),
+    WIENERDOG_JOB: name, // WP-018's send resolves the routine from this
+  };
+  for (const k of ENV_PASSTHROUGH) {
+    if (process.env[k]) env[k] = process.env[k];
+  }
+  return env;
+}
+
+/**
+ * Resolve the child command + args from a job's `run` field. A test may replace
+ * the resolved command with WIENERDOG_RUNJOB_CMD (mirrors WP-017's DREAM_CMD).
+ * @param {{name:string, run:string}} job
+ * @returns {{command:string, args:string[], shell:boolean}}
+ */
+function resolveCommand(job) {
+  const fake = process.env.WIENERDOG_RUNJOB_CMD;
+  if (fake) return { command: fake, args: [], shell: true };
+
+  const sep = job.run.indexOf(':');
+  const kind = sep === -1 ? job.run : job.run.slice(0, sep);
+  const rest = sep === -1 ? '' : job.run.slice(sep + 1);
+  if (kind === 'builtin') {
+    if (rest === 'dream') {
+      return { command: gen.nodePath(), args: [gen.wienerdogBin(), 'dream', '--yes'], shell: false };
+    }
+    throw new WienerdogError(`unknown builtin job: ${rest}`);
+  }
+  if (kind === 'skill') {
+    // Claude is the v1 default headless brain for routine skills.
+    return { command: 'claude', args: ['-p', `/${rest}`], shell: false };
+  }
+  throw new WienerdogError(`unknown job run kind in "${job.run}"`);
+}
+
+/** Resolve the watchdog timeout in ms (WIENERDOG_RUNJOB_TIMEOUT_MS is a test seam).
+ *  @param {{timeoutMinutes:number}} job @returns {number} */
+function resolveTimeoutMs(job) {
+  const override = Number(process.env.WIENERDOG_RUNJOB_TIMEOUT_MS);
+  if (Number.isFinite(override) && override > 0) return override;
+  const min = job.timeoutMinutes > 0 ? job.timeoutMinutes : 15;
+  return min * 60_000;
+}
+
+/** Keep only the newest LOG_KEEP *.log files in `dir` (ISO stamps sort lexically).
+ *  @param {string} dir */
+function rotateLogs(dir) {
+  let files;
+  try {
+    files = fs.readdirSync(dir).filter((f) => f.endsWith('.log'));
+  } catch {
+    return;
+  }
+  files.sort().reverse(); // newest run stamp first
+  for (const f of files.slice(LOG_KEEP)) {
+    try {
+      fs.rmSync(path.join(dir, f), { force: true });
+    } catch {
+      // best-effort rotation
+    }
+  }
+}
+
+/** @param {string} file @returns {string} the last ~2 KB of a log file, or ''. */
+function readLogTail(file) {
+  try {
+    const buf = fs.readFileSync(file);
+    return buf.slice(Math.max(0, buf.length - LOG_TAIL_BYTES)).toString('utf8');
+  } catch {
+    return '';
+  }
+}
+
+/** Close a write stream and wait for its flush.
+ *  @param {NodeJS.WritableStream} stream @returns {Promise<void>} */
+function endStream(stream) {
+  return new Promise((resolve) => stream.end(resolve));
+}
+
+/**
+ * Default fail-loud email: a best-effort `wienerdog gws _alert` subprocess. Works
+ * only when Google is configured (WP-018). Tests inject a stub via opts.sendAlert
+ * so they never spawn the real command.
+ * @param {import('../core/paths').WienerdogPaths} paths
+ * @param {string} name @param {string} subject @param {string} body
+ * @returns {{status:number}}
+ */
+function defaultSendAlert(paths, name, subject, body) {
+  const env = buildCleanEnv(paths, name);
+  const r = spawnSync(
+    gen.nodePath(),
+    [gen.wienerdogBin(), 'gws', '_alert', '--subject', subject, '--body', body],
+    { env }
+  );
+  return { status: r.status == null ? 1 : r.status };
+}
+
+/**
+ * Prepend a transient failure banner to the injected session digest so the next
+ * session surfaces it. Creates state/digest.md if absent (atomic temp+rename).
+ * @param {import('../core/paths').WienerdogPaths} paths @param {string} name @param {string} reason
+ */
+function writeDigestBanner(paths, name, reason) {
+  const logHint = `${tilde(paths.home, path.join(paths.logs, name))}/`;
+  const banner = `> [!warning] Wienerdog job "${name}" failed at ${nowIso()} — ${reason}. See ${logHint}.`;
+  fs.mkdirSync(paths.state, { recursive: true });
+  const dest = path.join(paths.state, 'digest.md');
+  let existing = '';
+  try {
+    existing = fs.readFileSync(dest, 'utf8');
+  } catch {
+    existing = '';
+  }
+  const next = existing ? `${banner}\n${existing}` : `${banner}\n`;
+  const tmp = `${dest}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, next);
+  fs.renameSync(tmp, dest);
+}
+
+/**
+ * Fail loud: try the email alert; on any failure fall back to the digest banner.
+ * Wrapped so it can NEVER throw — the original job failure must stay surfaced.
+ * @param {import('../core/paths').WienerdogPaths} paths
+ * @param {string} name @param {string} reason @param {string} logTail
+ * @param {{sendAlert?: typeof defaultSendAlert}} opts
+ * @returns {Promise<void>}
+ */
+async function failLoud(paths, name, reason, logTail, opts = {}) {
+  try {
+    const send = opts.sendAlert || defaultSendAlert;
+    const subject = `job ${name} failed`;
+    const body = `${reason}\n\n${logTail || ''}`.trim();
+    let sent = false;
+    try {
+      const r = send(paths, name, subject, body);
+      sent = !!(r && r.status === 0);
+    } catch {
+      sent = false;
+    }
+    if (sent) return;
+    writeDigestBanner(paths, name, reason);
+  } catch {
+    // Fail-loud is best-effort; never mask the original failure.
+  }
+}
+
+/**
+ * Run ONE job now: clean env, TCC-guard, watchdog, teed+rotated logs, fail-loud,
+ * watermark. Throws WienerdogError (→ exit 1) on failure/timeout/guard-refusal.
+ * @param {import('../core/paths').WienerdogPaths} paths
+ * @param {{name:string, at:string, run:string, timeoutMinutes:number}} job
+ * @param {{sendAlert?: typeof defaultSendAlert, loader?: (argv:string[])=>{status:number},
+ *          platform?: NodeJS.Platform}} [opts]
+ * @returns {Promise<void>}
+ */
+async function runJob(paths, job, opts = {}) {
+  const name = job.name;
+  const vaultDir = readDreamConfig(paths.config).vault; // throws if no vault configured
+  const cwd = vaultDir;
+
+  // 1. TCC-guard: refuse (fail-loud) rather than hang on a protected folder.
+  const g = tccguard.guard([vaultDir, cwd], paths.home, opts.platform);
+  if (!g.ok) {
+    const reason =
+      `refused: ${g.offending} is under a macOS protected folder (${g.prefix}) — ` +
+      'move the vault to ~/wienerdog';
+    jobsLib.writeScheduleState(paths, name, { last_status: 'error', last_error_at: nowIso() });
+    await failLoud(paths, name, reason, '', opts);
+    throw new WienerdogError(`job "${name}" ${reason}`);
+  }
+
+  // 2. Clean env + command.
+  const env = buildCleanEnv(paths, name);
+  const { command, args, shell } = resolveCommand(job);
+
+  // 3. Per-run log file (mkdir -p the job's log dir).
+  const logDir = path.join(paths.logs, name);
+  fs.mkdirSync(logDir, { recursive: true });
+  const logFile = path.join(logDir, `${runStamp()}.log`);
+  const logStream = fs.createWriteStream(logFile);
+
+  // 4. Watchdog: detached child (own process group), race exit vs timeout, kill
+  //    the whole tree on timeout, always clear the timer (reuse dream.js's shape).
+  const timeoutMs = resolveTimeoutMs(job);
+  const started = Date.now();
+  let code = null;
+  let failure = null;
+  try {
+    const child = spawn(command, args, {
+      cwd,
+      detached: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env,
+      shell,
+    });
+    if (child.stdout) child.stdout.pipe(logStream, { end: false });
+    if (child.stderr) child.stderr.pipe(logStream, { end: false });
+
+    const done = new Promise((resolve, reject) => {
+      child.on('error', reject);
+      child.on('close', (c) => resolve(c));
+    });
+    let timer = null;
+    const watchdog = new Promise((_resolve, reject) => {
+      timer = setTimeout(() => {
+        try {
+          process.kill(-child.pid, 'SIGKILL'); // kill the process GROUP → whole tree
+        } catch {
+          // already gone
+        }
+        reject(new WienerdogError(`job "${name}" timed out after ${job.timeoutMinutes} min`));
+      }, timeoutMs);
+    });
+    try {
+      code = await Promise.race([done, watchdog]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  } catch (err) {
+    failure = err;
+  } finally {
+    await endStream(logStream);
+  }
+
+  // 5. Rotate logs after the run.
+  rotateLogs(logDir);
+
+  const secs = Math.round((Date.now() - started) / 1000);
+
+  // 6. Success → watermark + (darwin) ensure the catch-up entry exists.
+  if (!failure && code === 0) {
+    jobsLib.writeScheduleState(paths, name, { last_success: nowIso(), last_status: 'ok' });
+    if (process.platform === 'darwin') {
+      try {
+        gen.ensureCatchup(paths, { loader: opts.loader });
+      } catch {
+        // Non-fatal: the primary installer of the catch-up entry is `schedule add`.
+      }
+    }
+    process.stdout.write(
+      `wienerdog: job "${name}" ok (${job.run}) in ${secs}s; logged to ${tilde(paths.home, logDir)}/.\n`
+    );
+    return;
+  }
+
+  // 7. Failure/timeout → watermark, fail-loud, throw.
+  const reason = failure
+    ? failure instanceof WienerdogError
+      ? failure.message
+      : `job "${name}" failed: ${failure.message}`
+    : `job "${name}" exited ${code}`;
+  jobsLib.writeScheduleState(paths, name, { last_status: 'error', last_error_at: nowIso() });
+  await failLoud(paths, name, reason, readLogTail(logFile), opts);
+  throw new WienerdogError(reason);
+}
+
+/** Today's scheduled fire time for a job (local).
+ *  @param {string} at HH:MM @param {Date} now @returns {Date} */
+function todaysFire(at, now) {
+  const [h, m] = at.split(':').map(Number);
+  const fire = new Date(now);
+  fire.setHours(h, m, 0, 0);
+  return fire;
+}
+
+/**
+ * run-job --catch-up: run every job overdue vs today's fire time (machine was
+ * off when it should have fired). A single job's failure does not abort the rest.
+ * @param {import('../core/paths').WienerdogPaths} paths
+ * @param {{now?:Date, sendAlert?: typeof defaultSendAlert,
+ *          loader?: (argv:string[])=>{status:number}, platform?: NodeJS.Platform}} [opts]
+ * @returns {Promise<void>}
+ */
+async function catchUp(paths, opts = {}) {
+  const now = opts.now || new Date();
+  const jobs = jobsLib.listJobs(paths);
+  const state = jobsLib.readScheduleState(paths);
+  /** @type {string[]} */ const ran = [];
+  /** @type {string[]} */ const notOverdue = [];
+
+  for (const job of jobs) {
+    const fire = todaysFire(job.at, now);
+    const last = state[job.name] && state[job.name].last_success;
+    const overdue = now >= fire && (!last || new Date(last) < fire);
+    if (!overdue) {
+      notOverdue.push(job.name);
+      continue;
+    }
+    try {
+      await runJob(paths, job, opts);
+      ran.push(`${job.name} (ok)`);
+    } catch {
+      // runJob already recorded the error watermark and failed loud.
+      ran.push(`${job.name} (failed)`);
+    }
+  }
+
+  if (ran.length === 0) {
+    process.stdout.write('wienerdog: catch-up — nothing overdue.\n');
+    return;
+  }
+  const tail = notOverdue.length ? ` ${notOverdue.join(', ')} not overdue.` : '';
+  const plural = ran.length === 1 ? '' : 's';
+  process.stdout.write(`wienerdog: catch-up ran ${ran.length} overdue job${plural}: ${ran.join(', ')}.${tail}\n`);
+}
+
+/** wienerdog run-job <name>        run one job now
+ *  wienerdog run-job --catch-up    run every job overdue vs its schedule
+ *  Exit 0 = success or "nothing overdue". Exit 1 = the job failed / timed out /
+ *           was refused by the TCC-guard (WienerdogError, after fail-loud).
+ *  @param {string[]} argv
+ *  @param {{sendAlert?: typeof defaultSendAlert, loader?: (argv:string[])=>{status:number},
+ *           platform?: NodeJS.Platform, now?: Date}} [opts]
+ *  @returns {Promise<void>} */
+async function run(argv, opts = {}) {
+  const paths = getPaths();
+  if (argv[0] === '--catch-up') {
+    await catchUp(paths, opts);
+    return;
+  }
+  const name = argv[0];
+  if (!name) {
+    throw new WienerdogError('usage: wienerdog run-job <name> | wienerdog run-job --catch-up');
+  }
+  const job = jobsLib.findJob(paths, name);
+  if (!job) throw new WienerdogError(`unknown job: ${name}`);
+  await runJob(paths, job, opts);
+}
+
+module.exports = {
+  run,
+  runJob,
+  catchUp,
+  buildCleanEnv,
+  resolveCommand,
+  rotateLogs,
+  readLogTail,
+  failLoud,
+  writeDigestBanner,
+  todaysFire,
+};

--- a/src/scheduler/generators.js
+++ b/src/scheduler/generators.js
@@ -1,8 +1,11 @@
 'use strict';
 
+const fs = require('node:fs');
 const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 
 const { WienerdogError } = require('../core/errors');
+const manifestLib = require('../core/manifest');
 
 /**
  * Pure text renderers and path helpers for the OS-native scheduler entries.
@@ -198,6 +201,65 @@ ExecStart=${o.node} ${o.bin} run-job ${o.name}
 `;
 }
 
+/** @param {string} p @returns {boolean} */
+function isFile(p) {
+  try {
+    return fs.statSync(p).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Default loader: register the catch-up plist with real launchd. Tests inject a
+ * spy via opts.loader so they never touch the real scheduler.
+ * @param {string[]} argv
+ * @returns {{status:number}}
+ */
+function defaultCatchupLoader(argv) {
+  const r = spawnSync(argv[0], argv.slice(1));
+  return { status: r.status == null ? 1 : r.status };
+}
+
+/**
+ * Ensure the macOS catch-up plist exists and is registered. Idempotent: if the
+ * plist file already exists with identical content AND a manifest entry tracks
+ * it, nothing is written or loaded. Darwin only (no-op on other platforms).
+ * Records a `scheduler-entry` manifest entry (with the catch-up unload argv) the
+ * first time it writes the file, mirroring schedule.js. This is a runtime
+ * backstop invoked by run-job after a job succeeds; the primary installer of the
+ * entry is WP-013's `schedule add`.
+ * @param {import('../core/paths').WienerdogPaths} paths
+ * @param {{loader?: (argv:string[])=>{status:number}}} opts
+ * @returns {{changed:boolean}}
+ */
+function ensureCatchup(paths, opts = {}) {
+  if (process.platform !== 'darwin') return { changed: false };
+  const loader = opts.loader || defaultCatchupLoader;
+  const uid = process.getuid();
+  const logDir = path.join(paths.logs, 'catchup');
+  const content = catchupPlist({ node: nodePath(), bin: wienerdogBin(), logDir });
+  const label = 'ai.wienerdog.catchup';
+  const plistPath = path.join(launchAgentsDir(paths.home), `${label}.plist`);
+  const unload = ['launchctl', 'bootout', `gui/${uid}/${label}`];
+
+  const manifest = manifestLib.load(paths);
+  const identical = isFile(plistPath) && fs.readFileSync(plistPath, 'utf8') === content;
+  const hasEntry = manifest.entries.some(
+    (e) => e.kind === 'scheduler-entry' && e.path === plistPath
+  );
+  if (identical && hasEntry) return { changed: false };
+
+  fs.mkdirSync(path.dirname(plistPath), { recursive: true });
+  fs.writeFileSync(plistPath, content);
+  if (!hasEntry) {
+    manifestLib.record(manifest, { kind: 'scheduler-entry', path: plistPath, unload });
+    manifestLib.save(paths, manifest);
+  }
+  loader(['launchctl', 'bootstrap', `gui/${uid}`, plistPath]);
+  return { changed: true };
+}
+
 module.exports = {
   nodePath,
   wienerdogBin,
@@ -210,4 +272,5 @@ module.exports = {
   catchupPlist,
   systemdTimer,
   systemdService,
+  ensureCatchup,
 };

--- a/src/scheduler/tccguard.js
+++ b/src/scheduler/tccguard.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const path = require('node:path');
+
+/**
+ * macOS TCC (Transparency, Consent, and Control) protects a handful of
+ * home-relative folders behind an interactive permission prompt. An unattended
+ * launchd job that reads one of them blocks forever on a prompt no one can
+ * answer (the "4-hour hang"). `run-job` refuses such jobs up front — a loud
+ * failure beats an invisible hang.
+ */
+
+/** macOS TCC-protected home-relative prefixes that hang unattended jobs.
+ *  Exported so tests and doctor can reference the same list. */
+const TCC_PREFIXES = ['Desktop', 'Documents', 'Downloads', 'Library/Mobile Documents']; // last = iCloud Drive root
+
+/** Is `p` inside a TCC-protected location (macOS only)?
+ *  @param {string} p           an absolute path (realpath-resolved by caller if a symlink)
+ *  @param {string} home        the user's home dir
+ *  @param {NodeJS.Platform} [platform=process.platform]
+ *  @returns {{protected:boolean, prefix:string|null}}
+ *  Non-darwin platforms are never protected → {protected:false, prefix:null}.
+ *  On darwin: protected iff `p` equals or is under home/<one of TCC_PREFIXES>
+ *  (compare on path segments, not string prefix — 'Documents' must not match
+ *  'DocumentsArchive'). */
+function checkPath(p, home, platform = process.platform) {
+  if (platform !== 'darwin') return { protected: false, prefix: null };
+  const rel = path.relative(home, p);
+  // rel === '' → p is home itself; a '..' prefix or absolute rel → p is outside home.
+  if (rel === '' || rel === '..' || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)) {
+    return { protected: false, prefix: null };
+  }
+  const segs = rel.split(path.sep);
+  for (const prefix of TCC_PREFIXES) {
+    const pSegs = prefix.split('/');
+    if (segs.length >= pSegs.length && pSegs.every((s, i) => s === segs[i])) {
+      return { protected: true, prefix };
+    }
+  }
+  return { protected: false, prefix: null };
+}
+
+/** Guard a set of paths a job will touch. Returns the first offender or ok.
+ *  @param {string[]} paths @param {string} home @param {NodeJS.Platform} [platform]
+ *  @returns {{ok:boolean, offending:string|null, prefix:string|null}} */
+function guard(paths, home, platform = process.platform) {
+  for (const p of paths) {
+    const c = checkPath(p, home, platform);
+    if (c.protected) return { ok: false, offending: p, prefix: c.prefix };
+  }
+  return { ok: true, offending: null, prefix: null };
+}
+
+module.exports = { TCC_PREFIXES, checkPath, guard };

--- a/tests/unit/scheduler-runjob.test.js
+++ b/tests/unit/scheduler-runjob.test.js
@@ -1,0 +1,358 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const { getPaths } = require('../../src/core/paths');
+const manifestLib = require('../../src/core/manifest');
+const jobsLib = require('../../src/scheduler/jobs');
+const runjob = require('../../src/cli/run-job');
+
+/** @param {string} c @returns {string} */
+function sha256(c) {
+  return crypto.createHash('sha256').update(c).digest('hex');
+}
+
+/** Build an isolated temp core with a config (vault under $HOME → TCC-safe) + manifest.
+ *  @param {string} [vaultRel] relative-to-home vault dir (default 'wienerdog'). */
+function setup(vaultRel = 'wienerdog') {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-runjob-'));
+  const env = { HOME: root, WIENERDOG_HOME: path.join(root, 'wd') };
+  const paths = getPaths(env);
+  const vault = path.join(root, vaultRel);
+  fs.mkdirSync(paths.core, { recursive: true });
+  fs.mkdirSync(paths.state, { recursive: true });
+  fs.mkdirSync(paths.logs, { recursive: true });
+  fs.mkdirSync(vault, { recursive: true });
+  const config = `# Wienerdog configuration
+version: 1
+vault: ${vault}
+`;
+  fs.writeFileSync(paths.config, config);
+  manifestLib.save(paths, {
+    version: 1,
+    createdAt: new Date().toISOString(),
+    entries: [
+      { kind: 'dir', path: paths.core },
+      { kind: 'file', path: paths.config, hash: sha256(config) },
+    ],
+  });
+  return { root, env, paths, vault };
+}
+
+/** Write an executable shell script and return its path. */
+function writeScript(dir, name, lines) {
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, `${lines.join('\n')}\n`);
+  fs.chmodSync(p, 0o755);
+  return p;
+}
+
+/** Run runjob.run with process.env pointed at the temp core + seam overrides.
+ *  @param {Record<string,string|undefined>} envOverrides
+ *  @param {string[]} argv @param {object} opts */
+async function withRun(env, envOverrides, argv, opts) {
+  const keys = ['HOME', 'WIENERDOG_HOME', 'WIENERDOG_RUNJOB_CMD', 'WIENERDOG_RUNJOB_TIMEOUT_MS', 'WIENERDOG_SECRET_TEST'];
+  const saved = {};
+  for (const k of keys) saved[k] = process.env[k];
+  const all = { HOME: env.HOME, WIENERDOG_HOME: env.WIENERDOG_HOME, ...envOverrides };
+  for (const k of keys) {
+    if (all[k] === undefined) delete process.env[k];
+    else process.env[k] = all[k];
+  }
+  try {
+    await runjob.run(argv, opts);
+  } finally {
+    for (const k of keys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  }
+}
+
+const noopLoader = () => ({ status: 0 });
+
+// -------------------------------------------------------------------------
+// buildCleanEnv (pure)
+// -------------------------------------------------------------------------
+
+test('scheduler-runjob: buildCleanEnv has absolute PATH+node dir, HOME, WIENERDOG_JOB, no leaks', () => {
+  const { env, paths } = setup();
+  const saved = {
+    WIENERDOG_SECRET_TEST: process.env.WIENERDOG_SECRET_TEST,
+    WIENERDOG_HOME: process.env.WIENERDOG_HOME,
+  };
+  process.env.WIENERDOG_SECRET_TEST = 'leak-me';
+  process.env.WIENERDOG_HOME = env.WIENERDOG_HOME; // buildCleanEnv reads process.env for the allowlist
+  try {
+    const clean = runjob.buildCleanEnv(paths, 'dream');
+    assert.equal(clean.HOME, paths.home);
+    assert.equal(clean.WIENERDOG_JOB, 'dream');
+    assert.ok(path.isAbsolute(clean.PATH.split(':')[0]));
+    assert.ok(clean.PATH.split(':').includes(path.dirname(process.execPath)), 'PATH includes the node dir');
+    assert.equal(clean.WIENERDOG_SECRET_TEST, undefined, 'non-allowlisted vars are not carried through');
+    assert.equal(clean.WIENERDOG_HOME, env.WIENERDOG_HOME, 'allowlisted overrides pass through');
+  } finally {
+    for (const k of ['WIENERDOG_SECRET_TEST', 'WIENERDOG_HOME']) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  }
+});
+
+// -------------------------------------------------------------------------
+// resolveCommand
+// -------------------------------------------------------------------------
+
+test('scheduler-runjob: resolveCommand maps builtin:dream, skill:*, and rejects unknown', () => {
+  const savedCmd = process.env.WIENERDOG_RUNJOB_CMD;
+  delete process.env.WIENERDOG_RUNJOB_CMD;
+  try {
+    const d = runjob.resolveCommand({ name: 'dream', run: 'builtin:dream' });
+    assert.deepEqual(d.args.slice(1), ['dream', '--yes']);
+    const s = runjob.resolveCommand({ name: 'x', run: 'skill:wienerdog-daily-digest' });
+    assert.equal(s.command, 'claude');
+    assert.deepEqual(s.args, ['-p', '/wienerdog-daily-digest']);
+    assert.throws(() => runjob.resolveCommand({ name: 'x', run: 'builtin:frobnicate' }), /unknown builtin/);
+    assert.throws(() => runjob.resolveCommand({ name: 'x', run: 'weird:thing' }), /unknown job run kind/);
+  } finally {
+    if (savedCmd === undefined) delete process.env.WIENERDOG_RUNJOB_CMD;
+    else process.env.WIENERDOG_RUNJOB_CMD = savedCmd;
+  }
+});
+
+// -------------------------------------------------------------------------
+// run-job <name> — success
+// -------------------------------------------------------------------------
+
+test('scheduler-runjob: a successful job writes last_success, tees a log, exits 0', async () => {
+  const { root, env, paths } = setup();
+  jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+  const marker = path.join(root, 'env-dump.txt');
+  const fake = writeScript(root, 'ok.sh', [
+    '#!/bin/sh',
+    `printf '%s\\n%s\\n%s\\n%s\\n' "$PATH" "$HOME" "$WIENERDOG_JOB" "$WIENERDOG_SECRET_TEST" > ${JSON.stringify(marker)}`,
+    'exit 0',
+  ]);
+
+  await withRun(env, { WIENERDOG_RUNJOB_CMD: fake, WIENERDOG_SECRET_TEST: 'leak' }, ['dream'], {
+    loader: noopLoader,
+  });
+
+  const state = jobsLib.readScheduleState(paths);
+  assert.equal(state.dream.last_status, 'ok');
+  assert.ok(state.dream.last_success, 'last_success watermark set');
+
+  const logDir = path.join(paths.logs, 'dream');
+  const logs = fs.readdirSync(logDir).filter((f) => f.endsWith('.log'));
+  assert.equal(logs.length, 1, 'one per-run log file written');
+
+  // The child ran under the clean env: WIENERDOG_JOB set, the secret NOT leaked.
+  const [gotPath, gotHome, gotJob, gotSecret] = fs.readFileSync(marker, 'utf8').split('\n');
+  assert.ok(gotPath.split(':').includes(path.dirname(process.execPath)));
+  assert.equal(gotHome, paths.home);
+  assert.equal(gotJob, 'dream');
+  assert.equal(gotSecret, '', 'the non-allowlisted secret did not reach the child');
+});
+
+// -------------------------------------------------------------------------
+// run-job <name> — non-zero exit
+// -------------------------------------------------------------------------
+
+test('scheduler-runjob: a non-zero exit records error, fails loud, throws', async () => {
+  const { root, env, paths } = setup();
+  jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+  const fake = writeScript(root, 'fail.sh', ['#!/bin/sh', 'exit 3']);
+  /** @type {any[]} */ const alerts = [];
+  const sendAlert = (_p, _n, subject) => (alerts.push(subject), { status: 0 });
+
+  await assert.rejects(
+    withRun(env, { WIENERDOG_RUNJOB_CMD: fake }, ['dream'], { sendAlert, loader: noopLoader }),
+    /exited 3/
+  );
+
+  const state = jobsLib.readScheduleState(paths);
+  assert.equal(state.dream.last_status, 'error');
+  assert.ok(state.dream.last_error_at);
+  assert.deepEqual(alerts, ['job dream failed'], 'fail-loud email attempted');
+});
+
+// -------------------------------------------------------------------------
+// run-job <name> — hang → watchdog kill-tree
+// -------------------------------------------------------------------------
+
+test('scheduler-runjob: a hanging job hits the watchdog, kills the tree, records error', async () => {
+  const { root, env, paths } = setup();
+  jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+  const pidFile = path.join(root, 'child.pid');
+  const fake = writeScript(root, 'hang.sh', [
+    '#!/bin/sh',
+    `echo $$ > ${JSON.stringify(pidFile)}`,
+    'sleep 30',
+  ]);
+  const sendAlert = () => ({ status: 0 });
+
+  await assert.rejects(
+    withRun(env, { WIENERDOG_RUNJOB_CMD: fake, WIENERDOG_RUNJOB_TIMEOUT_MS: '2000' }, ['dream'], {
+      sendAlert,
+      loader: noopLoader,
+    }),
+    /timed out/
+  );
+
+  const state = jobsLib.readScheduleState(paths);
+  assert.equal(state.dream.last_status, 'error');
+
+  // The child process group was killed — its pid is gone.
+  const pid = Number(fs.readFileSync(pidFile, 'utf8').trim());
+  assert.ok(Number.isInteger(pid) && pid > 0, 'child recorded its pid');
+  await new Promise((r) => setTimeout(r, 100)); // let SIGKILL land
+  let alive;
+  try {
+    process.kill(pid, 0);
+    alive = true; // no error → the process still exists
+  } catch (e) {
+    alive = e.code === 'EPERM'; // EPERM → exists but not ours; ESRCH → gone
+  }
+  assert.equal(alive, false, 'no child survives the watchdog timeout');
+});
+
+// -------------------------------------------------------------------------
+// TCC-guard refusal
+// -------------------------------------------------------------------------
+
+test('scheduler-runjob: a vault under a protected folder is refused before spawning', async () => {
+  const { env, paths } = setup(path.join('Documents', 'vault'));
+  jobsLib.saveJob(paths, { name: 'digest', at: '07:00', run: 'skill:wienerdog-daily-digest', timeoutMinutes: 15 });
+  /** @type {any[]} */ const alerts = [];
+  const sendAlert = (_p, _n, subject) => (alerts.push(subject), { status: 0 });
+
+  await assert.rejects(
+    withRun(env, {}, ['digest'], { platform: 'darwin', sendAlert, loader: noopLoader }),
+    /macOS protected folder \(Documents\)/
+  );
+
+  const state = jobsLib.readScheduleState(paths);
+  assert.equal(state.digest.last_status, 'error');
+  assert.deepEqual(alerts, ['job digest failed'], 'refusal fails loud');
+  // No brain was spawned → no per-job log dir was created.
+  assert.ok(!fs.existsSync(path.join(paths.logs, 'digest')), 'the job never spawned');
+});
+
+// -------------------------------------------------------------------------
+// Fail-loud banner fallback
+// -------------------------------------------------------------------------
+
+test('scheduler-runjob: failLoud with no email prepends a banner to digest.md and never throws', async () => {
+  const { paths } = setup();
+  const digest = path.join(paths.state, 'digest.md');
+
+  // Email fails → banner is created.
+  await runjob.failLoud(paths, 'dream', 'brain exploded', 'tail...', { sendAlert: () => ({ status: 1 }) });
+  let body = fs.readFileSync(digest, 'utf8');
+  assert.match(body, /^> \[!warning\] Wienerdog job "dream" failed at .* — brain exploded\./);
+  assert.match(body, /logs\/dream\/\.$/m);
+
+  // A second failure prepends above the first (existing content preserved).
+  fs.writeFileSync(digest, '# Existing digest\n');
+  await runjob.failLoud(paths, 'dream', 'again', '', { sendAlert: () => ({ status: 1 }) });
+  body = fs.readFileSync(digest, 'utf8');
+  assert.match(body.split('\n')[0], /Wienerdog job "dream" failed/);
+  assert.ok(body.includes('# Existing digest'), 'existing digest content preserved below the banner');
+
+  // A throwing sendAlert must not escape failLoud (still falls back to banner).
+  fs.rmSync(digest, { force: true });
+  await runjob.failLoud(paths, 'dream', 'boom', '', {
+    sendAlert: () => {
+      throw new Error('alert crashed');
+    },
+  });
+  assert.ok(fs.existsSync(digest), 'banner still written when the alert throws');
+});
+
+// -------------------------------------------------------------------------
+// Log rotation
+// -------------------------------------------------------------------------
+
+test('scheduler-runjob: rotateLogs keeps only the newest 14 *.log files', () => {
+  const { root } = setup();
+  const dir = path.join(root, 'logdir');
+  fs.mkdirSync(dir);
+  const names = [];
+  for (let i = 0; i < 20; i++) {
+    const n = `2026-07-03T00-00-${String(i).padStart(2, '0')}-000Z.log`;
+    names.push(n);
+    fs.writeFileSync(path.join(dir, n), 'x');
+  }
+  fs.writeFileSync(path.join(dir, 'launchd.out.log'), 'keep-counts-too'); // 21 total *.log
+  runjob.rotateLogs(dir);
+
+  const remaining = fs.readdirSync(dir).filter((f) => f.endsWith('.log'));
+  assert.equal(remaining.length, 14);
+  // The newest by name are kept; the oldest are gone.
+  assert.ok(remaining.includes(names[19]), 'newest kept');
+  assert.ok(!remaining.includes(names[0]), 'oldest deleted');
+});
+
+// -------------------------------------------------------------------------
+// run-job --catch-up
+// -------------------------------------------------------------------------
+
+test('scheduler-runjob: --catch-up runs overdue jobs, skips fresh ones, updates watermarks', async () => {
+  const { root, env, paths } = setup();
+  jobsLib.saveJob(paths, { name: 'a', at: '09:00', run: 'builtin:dream', timeoutMinutes: 20 });
+  jobsLib.saveJob(paths, { name: 'b', at: '09:00', run: 'skill:wienerdog-daily-digest', timeoutMinutes: 15 });
+
+  const now = new Date();
+  now.setHours(10, 0, 0, 0); // after both 09:00 fires
+  const yesterday = new Date(now);
+  yesterday.setDate(now.getDate() - 1);
+  const todayAfterFire = new Date(now);
+  todayAfterFire.setHours(9, 30, 0, 0);
+
+  // a: last success yesterday → overdue. b: last success today 09:30 → NOT overdue.
+  jobsLib.writeScheduleState(paths, 'a', { last_success: yesterday.toISOString(), last_status: 'ok' });
+  jobsLib.writeScheduleState(paths, 'b', { last_success: todayAfterFire.toISOString(), last_status: 'ok' });
+
+  const fake = writeScript(root, 'ok.sh', ['#!/bin/sh', 'exit 0']);
+  await withRun(env, { WIENERDOG_RUNJOB_CMD: fake }, ['--catch-up'], {
+    now,
+    loader: noopLoader,
+    sendAlert: () => ({ status: 0 }),
+  });
+
+  const state = jobsLib.readScheduleState(paths);
+  // a re-ran: its watermark advanced past yesterday.
+  assert.ok(new Date(state.a.last_success) > yesterday, 'overdue job a re-ran');
+  assert.equal(state.a.last_status, 'ok');
+  // b untouched: its watermark is still today 09:30.
+  assert.equal(state.b.last_success, todayAfterFire.toISOString(), 'fresh job b was skipped');
+});
+
+test('scheduler-runjob: --catch-up does not abort the batch on a single job failure', async () => {
+  const { root, env, paths } = setup();
+  jobsLib.saveJob(paths, { name: 'a', at: '09:00', run: 'builtin:dream', timeoutMinutes: 20 });
+  const now = new Date();
+  now.setHours(10, 0, 0, 0);
+  // No watermark → overdue.
+  const fake = writeScript(root, 'fail.sh', ['#!/bin/sh', 'exit 5']);
+
+  // catchUp must resolve (not throw) even though the job fails.
+  await withRun(env, { WIENERDOG_RUNJOB_CMD: fake }, ['--catch-up'], {
+    now,
+    loader: noopLoader,
+    sendAlert: () => ({ status: 0 }),
+  });
+
+  const state = jobsLib.readScheduleState(paths);
+  assert.equal(state.a.last_status, 'error', 'the failing job recorded its own error');
+});
+
+test('scheduler-runjob: run rejects an unknown job name', async () => {
+  const { env } = setup();
+  await assert.rejects(withRun(env, {}, ['ghost'], {}), /unknown job: ghost/);
+});

--- a/tests/unit/scheduler-tccguard.test.js
+++ b/tests/unit/scheduler-tccguard.test.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const { TCC_PREFIXES, checkPath, guard } = require('../../src/scheduler/tccguard');
+
+const HOME = '/Users/ada';
+
+test('scheduler-tccguard: protected prefixes are refused on darwin', () => {
+  for (const prefix of TCC_PREFIXES) {
+    const p = path.join(HOME, prefix, 'vault');
+    const c = checkPath(p, HOME, 'darwin');
+    assert.equal(c.protected, true, `${p} should be protected`);
+    assert.equal(c.prefix, prefix);
+  }
+});
+
+test('scheduler-tccguard: the protected folder itself (no subpath) is refused', () => {
+  const c = checkPath(path.join(HOME, 'Documents'), HOME, 'darwin');
+  assert.equal(c.protected, true);
+  assert.equal(c.prefix, 'Documents');
+});
+
+test('scheduler-tccguard: iCloud Drive root (Library/Mobile Documents) is refused', () => {
+  const p = path.join(HOME, 'Library', 'Mobile Documents', 'com~apple~CloudDocs', 'vault');
+  const c = checkPath(p, HOME, 'darwin');
+  assert.equal(c.protected, true);
+  assert.equal(c.prefix, 'Library/Mobile Documents');
+});
+
+test('scheduler-tccguard: ~/wienerdog (home root) is allowed on darwin', () => {
+  const c = checkPath(path.join(HOME, 'wienerdog'), HOME, 'darwin');
+  assert.equal(c.protected, false);
+  assert.equal(c.prefix, null);
+});
+
+test('scheduler-tccguard: ~/.wienerdog core is allowed on darwin', () => {
+  const c = checkPath(path.join(HOME, '.wienerdog'), HOME, 'darwin');
+  assert.equal(c.protected, false);
+});
+
+test('scheduler-tccguard: segment comparison — DocumentsArchive is NOT protected', () => {
+  const c = checkPath(path.join(HOME, 'DocumentsArchive', 'vault'), HOME, 'darwin');
+  assert.equal(c.protected, false, 'string-prefix match would wrongly flag this');
+  assert.equal(c.prefix, null);
+});
+
+test('scheduler-tccguard: a sibling of Library (LibraryX) is NOT protected', () => {
+  const c = checkPath(path.join(HOME, 'LibraryX', 'Mobile Documents'), HOME, 'darwin');
+  assert.equal(c.protected, false);
+});
+
+test('scheduler-tccguard: paths outside home are not protected', () => {
+  const c = checkPath('/opt/data/Documents/vault', HOME, 'darwin');
+  assert.equal(c.protected, false);
+});
+
+test('scheduler-tccguard: home itself is not protected', () => {
+  assert.equal(checkPath(HOME, HOME, 'darwin').protected, false);
+});
+
+test('scheduler-tccguard: non-darwin platforms are never protected', () => {
+  for (const platform of ['linux', 'win32']) {
+    const p = path.join(HOME, 'Documents', 'vault');
+    const c = checkPath(p, HOME, platform);
+    assert.equal(c.protected, false, `${platform} must not be protected`);
+    assert.equal(c.prefix, null);
+  }
+});
+
+test('scheduler-tccguard: guard returns the first offender', () => {
+  const ok = path.join(HOME, 'wienerdog');
+  const bad = path.join(HOME, 'Desktop', 'vault');
+  const g = guard([ok, bad], HOME, 'darwin');
+  assert.equal(g.ok, false);
+  assert.equal(g.offending, bad);
+  assert.equal(g.prefix, 'Desktop');
+});
+
+test('scheduler-tccguard: guard is ok when all paths are safe', () => {
+  const g = guard([path.join(HOME, 'wienerdog'), path.join(HOME, '.wienerdog')], HOME, 'darwin');
+  assert.deepEqual(g, { ok: true, offending: null, prefix: null });
+});
+
+test('scheduler-tccguard: guard on linux always ok even for Documents', () => {
+  const g = guard([path.join(HOME, 'Documents', 'vault')], HOME, 'linux');
+  assert.equal(g.ok, true);
+});


### PR DESCRIPTION
Spec: docs/specs/WP-020-run-job-wrapper.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

Touched exactly the deliverables: `src/scheduler/tccguard.js` (create),
`src/cli/run-job.js` (create), `src/scheduler/generators.js` (add `ensureCatchup`),
`bin/wienerdog.js` (register `run-job` + usage line), `tests/unit/scheduler-tccguard.test.js`
(create), `tests/unit/scheduler-runjob.test.js` (create), plus the spec status flip.

## Verification output

```
$ npm test -- --test-name-pattern scheduler-tccguard
ℹ tests 40   ℹ pass 40   ℹ fail 0

$ npm test -- --test-name-pattern scheduler-runjob
ℹ tests 38   ℹ pass 38   ℹ fail 0

$ npm test           # full suite
ℹ tests 222  ℹ pass 222  ℹ fail 0

$ npm run lint
--- markdownlint ---   Summary: 0 error(s)
--- shellcheck ---
--- frontmatter check ---  frontmatter check passed: 12 spec(s), 4 agent(s)
lint passed

$ # End-to-end single job with a fake brain (no real model, no launchd)
$ WIENERDOG_RUNJOB_CMD="node -e 'process.exit(0)'" node bin/wienerdog.js run-job hello
wienerdog: job "hello" ok (skill:wienerdog-noop) in 0s; logged to .../logs/hello/.
$ cat "$WIENERDOG_HOME/state/schedule.json"
{ "hello": { "last_success": "2026-07-02T23:46:39.228Z", "last_status": "ok" } }

$ # Catch-up: runs the overdue job, then reports nothing overdue on re-run
$ node bin/wienerdog.js run-job --catch-up
wienerdog: catch-up ran 1 overdue job: hello (ok).
$ node bin/wienerdog.js run-job --catch-up
wienerdog: catch-up — nothing overdue.
```

## Decisions made

- **Skill brain is Claude only.** `skill:<name>` jobs run `claude -p /<skill>`;
  Codex-exec routine brains are a later WP (per spec Out-of-scope). Noted in the
  child-command resolver.
- **Test seams via env, per the spec's stated preference.** `WIENERDOG_RUNJOB_CMD`
  replaces the child command (mirrors WP-017's `WIENERDOG_DREAM_CMD`), spawned with
  `shell:true` so the verification one-liner `node -e '...'` works; real jobs never
  use a shell. Added `WIENERDOG_RUNJOB_TIMEOUT_MS` (test-only) so the watchdog-kill
  test can time out in ~2s without a real 1-minute floor — mirrors the existing
  `WIENERDOG_FAKE_TODAY` precedent.
- **Fail-loud alert is an injectable seam** (`opts.sendAlert`, default = the
  `gws _alert` subprocess the spec pins). Tests inject a stub so they never spawn
  real `gws`; the banner-fallback test drives the email-fails path directly. The
  child-command seam stays env-based as the spec prefers; only the alert is injected.
- **`opts.platform` seam** lets the TCC-refusal test force darwin on any host so the
  "refused before spawn, fails loud, exits 1" path is covered in CI on Linux too.
- **Log rotation sorts by filename** (ISO run stamps sort lexically = chronologically)
  rather than mtime — deterministic and tie-free.
- **`ensureCatchup` is best-effort on the success path** and darwin-gated; failures
  are swallowed since `schedule add` (WP-013) is the primary installer of the entry.

## Discovered issues (out of scope, not fixed)

- `src/cli/schedule.js` already has a private `ensureCatchup(paths, manifest, loader, uid)`
  helper that overlaps with the new `generators.ensureCatchup(paths, {loader})`. They
  are not identical (schedule.js threads an already-loaded manifest; the generators
  version self-loads/saves). I did not unify them — `schedule.js` is not in this WP's
  Deliverables. A future cleanup could have `schedule.js` call the generators version.

---
Generated-by: claude-opus-4-8
