### PR TITLE
test(scenarios): run the scenario harness on subscription auth (WP-023)

### DIFF
--- a/.github/workflows/scenarios.yml
+++ b/.github/workflows/scenarios.yml
@@ -1,12 +1,16 @@
 name: scenarios
 
-# Nightly, real-brain scenario harness (WP-015). Runs the actual `wienerdog
-# dream` pipeline against the real Claude model and Haiku grader, so it
-# spends real model quota. It must NEVER run per-PR — schedule + manual
-# dispatch only.
+# DORMANT under ADR-0009 (subscription-everywhere). The project's primary
+# scenario run is a local subscription routine on the maintainer's machine
+# (see tests/scenarios/README.md); this workflow is retained only as an
+# optional path for a future contributor who accepts running scenarios under
+# an ANTHROPIC_API_KEY secret in CI (GitHub Actions cannot do subscription
+# OAuth). It does nothing until such a contributor supplies the secret.
+#
+# Real-brain scenario harness (WP-015). Runs the actual `wienerdog dream`
+# pipeline against the real Claude model and Haiku grader, so it spends real
+# model quota. It must NEVER run per-PR — manual dispatch only, no schedule.
 on:
-  schedule:
-    - cron: "0 6 * * *"
   workflow_dispatch: {}
 
 jobs:

--- a/docs/specs/WP-023-scenario-subscription-auth.md
+++ b/docs/specs/WP-023-scenario-subscription-auth.md
@@ -1,7 +1,7 @@
 ---
 id: WP-023
 title: Rework the scenario harness to run on subscription auth (decouple fixture isolation from auth)
-status: Ready
+status: In-Review
 model: sonnet
 size: M
 depends_on: [WP-015, WP-020]

--- a/src/core/paths.js
+++ b/src/core/paths.js
@@ -26,7 +26,11 @@ const path = require('node:path');
 function getPaths(env = process.env) {
   const home = env.HOME || os.homedir();
   const core = env.WIENERDOG_HOME || path.join(home, '.wienerdog');
-  const claudeDir = env.CLAUDE_CONFIG_DIR || path.join(home, '.claude');
+  // WIENERDOG_CLAUDE_DIR (wienerdog-internal; the scenario harness sets it to a
+  // fixtures dir) takes precedence so transcript discovery can be redirected WITHOUT
+  // touching CLAUDE_CONFIG_DIR — which the spawned `claude -p` brain needs for its
+  // real subscription credentials (ADR-0009). Unset in production → identical behavior.
+  const claudeDir = env.WIENERDOG_CLAUDE_DIR || env.CLAUDE_CONFIG_DIR || path.join(home, '.claude');
   const codexDir = env.CODEX_HOME || path.join(home, '.codex');
   const vault = env.WIENERDOG_VAULT || path.join(home, 'wienerdog');
   return {

--- a/tests/scenarios/README.md
+++ b/tests/scenarios/README.md
@@ -49,23 +49,72 @@ brain, `run-scenarios.js` asserts on the committed vault:
   the scenario if a note references anything not present in the transcripts
   (hallucinated memory).
 
-## Running locally
+## Running locally (subscription)
 
-This spends real model quota and needs the `claude` CLI (Claude Code) on
-`PATH`, authenticated via `ANTHROPIC_API_KEY`. Note: a Claude Code
-subscription/OAuth login will NOT work here — the harness isolates
-`CLAUDE_CONFIG_DIR`, and OAuth credentials do not follow it (they are bound
-to the default config dir). Set `ANTHROPIC_API_KEY` for local runs:
+This harness runs on the maintainer's Claude **subscription**, not an API
+key (ADR-0009: subscription auth everywhere). Preconditions: the `claude` CLI
+is on `PATH` and already logged in interactively, so OAuth already works in
+the shell you run from — a bare `claude -p "hi"` should succeed before you
+run this. It spends real model quota.
 
 ```bash
-export WIENERDOG_RUN_SCENARIOS=1
-export ANTHROPIC_API_KEY=...   # or however your `claude` CLI is authenticated
+export WIENERDOG_RUN_SCENARIOS=1   # the hard guard; without it, npm run scenarios skips
 npm run scenarios
 ```
+
+Do **not** set `ANTHROPIC_API_KEY`. The harness strips it from every child
+env anyway, so a stray key in your shell can never silently take over — but
+the intent is subscription-only.
 
 Without `WIENERDOG_RUN_SCENARIOS=1`, `npm run scenarios` prints a skip
 message and exits 0 — it never spends quota by accident, and `npm test`
 never runs this harness at all.
+
+### How auth and fixture isolation are decoupled
+
+The harness points transcript collection at a temp fixtures dir via
+`WIENERDOG_CLAUDE_DIR` (a wienerdog-internal override that only the
+collection phase honors), and leaves `HOME` and `CLAUDE_CONFIG_DIR`
+untouched so the real `claude -p` brain resolves the maintainer's default
+config dir and Keychain OAuth — i.e., the subscription. It also temporarily
+installs the `wienerdog-dream` skill into the real config dir's `skills/`
+(backing up and restoring any pre-existing copy — or leaving an identical
+copy untouched if one is already there) so the brain can load it via
+`--setting-sources user`. It never reads the maintainer's real transcripts:
+collection only ever looks under `WIENERDOG_CLAUDE_DIR`, which always points
+at a temp dir during a run.
+
+### CI is dormant (needs a key)
+
+`.github/workflows/scenarios.yml` is **disabled by default** — manual
+dispatch only, no nightly schedule. It is the *one* place an API key could
+ever appear in this project: GitHub Actions cannot do subscription OAuth, so
+a future contributor who wants CI scenario runs must add an
+`ANTHROPIC_API_KEY` secret. ADR-0009 excludes that credential type from the
+maintainer's own setup; the workflow exists only as a documented, opt-in path
+for someone who accepts the tradeoff.
+
+### Scheduling it as a weekly local routine (dogfooding the scheduler)
+
+The primary runner is a local schedule on the maintainer's machine — e.g. a
+weekly launchd/cron entry that runs, on subscription:
+
+```bash
+WIENERDOG_RUN_SCENARIOS=1 npm run --prefix /path/to/wienerdog scenarios
+```
+
+Running it through Wienerdog's *own* scheduler (`wienerdog schedule add
+scenarios --at ...` + `run-job`) is the goal — it would dogfood the
+product's own scheduler — but is **not wired yet**: `run-job`'s
+`resolveCommand` only dispatches `builtin:dream` and `skill:<name>`, and its
+clean-env allowlist does not pass `WIENERDOG_RUN_SCENARIOS` or
+`WIENERDOG_CLAUDE_DIR`, so the harness cannot run as a routine today. Wiring
+it (a new run-kind + env passthrough) is a **future work package**.
+`run-job` already sets `HOME` to the real home and resolves the default
+config dir, so it is subscription-compatible in principle — whether the
+login Keychain is reachable in a launchd/systemd session is a
+verify-at-first-live-run item, and `run-job`'s fail-loud alert (WP-020)
+covers a failure.
 
 ## Future extraction (out of scope here)
 

--- a/tests/scenarios/rubric.js
+++ b/tests/scenarios/rubric.js
@@ -24,11 +24,15 @@ const RUBRIC_PROMPT = [
 async function gradeNote(noteText, transcriptsText) {
   const prompt = [RUBRIC_PROMPT, '', '## Transcripts', transcriptsText, '', '## Note', noteText].join('\n');
 
+  const graderEnv = { ...process.env };
+  delete graderEnv.ANTHROPIC_API_KEY; // ADR-0009: subscription only, never a key
+
   let res;
   try {
     res = spawnSync('claude', ['-p', prompt, '--model', 'haiku', '--output-format', 'json'], {
       encoding: 'utf8',
       timeout: 120000,
+      env: graderEnv,
     });
   } catch (err) {
     return { pass: false, explanation: `grader error: failed to spawn claude CLI: ${err.message}` };

--- a/tests/scenarios/run-scenarios.js
+++ b/tests/scenarios/run-scenarios.js
@@ -153,6 +153,51 @@ function validateNoteFrontmatter(fm) {
 // ── small helpers ────────────────────────────────────────────────────────
 
 /**
+ * Recursively list every regular file under `dir`, as paths relative to `dir`.
+ * @param {string} dir
+ * @returns {string[]}
+ */
+function listFilesRecursive(dir) {
+  /** @type {string[]} */
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const abs = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...listFilesRecursive(abs).map((rel) => path.join(entry.name, rel)));
+    } else if (entry.isFile()) {
+      out.push(entry.name);
+    }
+  }
+  return out.sort();
+}
+
+/**
+ * Byte-for-byte comparison of two skill directories (same relative file set,
+ * identical contents) — used to detect an already-installed, up-to-date
+ * `wienerdog-dream` skill so the harness can leave it untouched instead of
+ * backing it up and restoring it.
+ * @param {string} srcDir @param {string} destDir
+ * @returns {boolean}
+ */
+function skillDirsIdentical(srcDir, destDir) {
+  let srcFiles, destFiles;
+  try {
+    srcFiles = listFilesRecursive(srcDir);
+    destFiles = listFilesRecursive(destDir);
+  } catch {
+    return false;
+  }
+  if (srcFiles.length !== destFiles.length || srcFiles.some((f, i) => f !== destFiles[i])) return false;
+  return srcFiles.every((rel) => {
+    try {
+      return fs.readFileSync(path.join(srcDir, rel)).equals(fs.readFileSync(path.join(destDir, rel)));
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
  * @param {string} vaultDir @param {string[]} args
  * @returns {{stdout:string, status:number|null}}
  */
@@ -235,29 +280,46 @@ async function main() {
   /** @type {string[]} */
   const failures = [];
   let root = null;
+  // Real config dir's skill install (set up below, restored in `finally`).
+  let skillBackup = null; // path we moved a pre-existing skill to, or null
+  let installedSkill = false; // did we create realSkillDest?
+  let realSkillDest = null;
 
   try {
-    // 2. Isolate: temp dirs for HOME / core / vault / Claude config.
+    // 2. Isolate: temp dirs for core / vault / fixture transcripts / codex.
+    // Deliberately do NOT create/point at a temp HOME or Claude config dir —
+    // the brain needs the maintainer's real HOME + default config dir to
+    // resolve subscription/Keychain OAuth (ADR-0009).
     root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-scenarios-'));
-    const home = path.join(root, 'home');
     const core = path.join(root, 'core');
     const vault = path.join(root, 'vault');
-    const claudeConfigDir = path.join(root, 'claude');
+    const transcriptsDir = path.join(root, 'claude-transcripts'); // fixtures live here
     const codexDir = path.join(root, 'codex-absent');
-    fs.mkdirSync(home, { recursive: true });
 
     const env = { ...process.env };
-    env.HOME = home;
     env.WIENERDOG_HOME = core;
     env.WIENERDOG_VAULT = vault;
-    env.CLAUDE_CONFIG_DIR = claudeConfigDir;
-    env.CODEX_HOME = codexDir;
+    env.WIENERDOG_CLAUDE_DIR = transcriptsDir; // collection reads fixtures from here
+    env.CODEX_HOME = codexDir; // isolate codex discovery (stays empty)
     env.WIENERDOG_FAKE_TODAY = FAKE_TODAY;
     // The scenario harness deliberately leaves this unset to exercise the
     // REAL brain — never inherit a fake-brain override from the caller's shell.
     delete env.WIENERDOG_DREAM_CMD;
+    delete env.ANTHROPIC_API_KEY; // ADR-0009: subscription only, never a key
+    // Deliberately NOT set: env.HOME (inherit the real one → default config +
+    // Keychain OAuth).
+    // Deliberately NOT set: env.CLAUDE_CONFIG_DIR (inherit the maintainer's
+    // real value, or none → ~/.claude; the brain authenticates against
+    // whatever their `claude` uses).
+    //
+    // Setting all four Wienerdog-scoped overrides (WIENERDOG_HOME,
+    // WIENERDOG_VAULT, WIENERDOG_CLAUDE_DIR, CODEX_HOME) fully redirects every
+    // Wienerdog write and read into temp dirs, so leaving HOME real is safe
+    // *and* required — the brain needs the real HOME to resolve the default
+    // config dir where the subscription/OAuth credential lives.
 
-    // 3. Seed: init the core + vault, then plant the fixtures + dream skill.
+    // 3. Seed: init the core + vault, then plant the fixtures under the
+    // collection override (not the config dir).
     console.log('scenarios: seeding harness (wienerdog init --yes)...');
     const initRes = runWienerdog(['init', '--yes'], env);
     if (initRes.stdout) console.log(initRes.stdout);
@@ -265,18 +327,36 @@ async function main() {
       failures.push(`wienerdog init exited ${initRes.status}: ${(initRes.stderr || '').trim()}`);
     }
 
-    const projDir = path.join(claudeConfigDir, 'projects', 'scenario');
+    const projDir = path.join(transcriptsDir, 'projects', 'scenario');
     fs.mkdirSync(projDir, { recursive: true });
     for (const f of FIXTURE_FILES) {
       fs.copyFileSync(path.join(FIXTURES_DIR, f), path.join(projDir, f));
     }
 
-    // Sync the dream skill into the harness so `claude -p` can load it
-    // (WP-009's dry-run precedent: copy skills/wienerdog-dream/ into the
-    // Claude Code skills dir for this run).
-    const skillsDest = path.join(claudeConfigDir, 'skills', 'wienerdog-dream');
-    fs.mkdirSync(path.dirname(skillsDest), { recursive: true });
-    fs.cpSync(DREAM_SKILL_SRC, skillsDest, { recursive: true });
+    // Install the dream skill into the REAL config dir so the brain (which
+    // resolves the real default config dir) can find it via
+    // `--setting-sources user`. Resolved from the harness's OWN process.env
+    // (not the child `env` above), since that's what the brain will inherit.
+    // Back up + restore any pre-existing copy so a maintainer who already
+    // dogfoods Wienerdog never loses their own installed skill. IMPROVEMENT:
+    // if an identical copy is already installed (e.g. via `wienerdog sync`),
+    // leave it untouched entirely — no backup/restore dance needed.
+    const realConfigDir = process.env.CLAUDE_CONFIG_DIR || path.join(process.env.HOME || os.homedir(), '.claude');
+    realSkillDest = path.join(realConfigDir, 'skills', 'wienerdog-dream');
+    fs.mkdirSync(path.dirname(realSkillDest), { recursive: true });
+    if (fs.existsSync(realSkillDest)) {
+      if (skillDirsIdentical(DREAM_SKILL_SRC, realSkillDest)) {
+        console.log('scenarios: an identical wienerdog-dream skill is already installed; leaving it untouched.');
+      } else {
+        skillBackup = path.join(root, 'wienerdog-dream.preexisting');
+        fs.renameSync(realSkillDest, skillBackup); // set aside the maintainer's own copy
+        fs.cpSync(DREAM_SKILL_SRC, realSkillDest, { recursive: true });
+        installedSkill = true;
+      }
+    } else {
+      fs.cpSync(DREAM_SKILL_SRC, realSkillDest, { recursive: true });
+      installedSkill = true;
+    }
 
     const baselineCommits = commitCount(vault);
     const baselineSha = git(vault, ['rev-parse', 'HEAD']);
@@ -371,6 +451,15 @@ async function main() {
       }
     }
   } finally {
+    // Restore the real config dir's skills/ to exactly its pre-run state
+    // before removing the temp root, wrapped so a cleanup error can never
+    // mask a scenario failure.
+    try {
+      if (installedSkill && realSkillDest) fs.rmSync(realSkillDest, { recursive: true, force: true });
+      if (skillBackup && realSkillDest && fs.existsSync(skillBackup)) fs.renameSync(skillBackup, realSkillDest);
+    } catch (err) {
+      console.error(`scenarios: WARNING — could not restore ${realSkillDest}: ${err.message}`);
+    }
     if (root) fs.rmSync(root, { recursive: true, force: true });
   }
 

--- a/tests/unit/paths.test.js
+++ b/tests/unit/paths.test.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { getPaths } = require('../../src/core/paths');
+
+test('paths: claudeDir precedence — WIENERDOG_CLAUDE_DIR > CLAUDE_CONFIG_DIR > <home>/.claude', () => {
+  assert.equal(
+    getPaths({ HOME: '/h', WIENERDOG_CLAUDE_DIR: '/wd', CLAUDE_CONFIG_DIR: '/cc' }).claudeDir,
+    '/wd'
+  );
+  assert.equal(getPaths({ HOME: '/h', CLAUDE_CONFIG_DIR: '/cc' }).claudeDir, '/cc');
+  assert.equal(getPaths({ HOME: '/h' }).claudeDir, '/h/.claude');
+});


### PR DESCRIPTION
Spec: docs/specs/WP-023-scenario-subscription-auth.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

## Verification output

```
$ npm test -- --test-name-pattern paths
...
✔ paths: claudeDir precedence — WIENERDOG_CLAUDE_DIR > CLAUDE_CONFIG_DIR > <home>/.claude (0.796792ms)
...
ℹ tests 32
ℹ pass 32
ℹ fail 0

$ npm run scenarios
scenarios: set WIENERDOG_RUN_SCENARIOS=1 to run (uses real model quota); skipping.
(exit 0, no quota spent)

$ npm test
ℹ tests 245
ℹ pass 245
ℹ fail 0
(harness not invoked)

$ npm run lint
--- markdownlint ---
Summary: 0 error(s)
--- shellcheck ---
--- frontmatter check ---
frontmatter check passed: 1 spec(s), 4 agent(s)
lint passed
```

**EXPENSIVE full run (real subscription quota): NOT executed in this session.**
This session runs in an isolated worktree whose harness rules forbid writing
into this machine's real `~/.claude` during automated verification — and the
expensive run's one deliberate real-config-dir touch (installing
`wienerdog-dream` into `<real config dir>/skills/`) is exactly the code path
that rule protects. The non-expensive steps above confirm the guard, the unit
suite, and lint are green; a maintainer should run the EXPENSIVE step from
their own shell (`export WIENERDOG_RUN_SCENARIOS=1; unset ANTHROPIC_API_KEY;
npm run scenarios`) before relying on the injection-gating claim, per
ADR-0009's acknowledged tradeoff (no CI fallback).

**VERIFY-AT-FIRST-LIVE-RUN claims: not verified live in this session** (same
reason). All three are runtime/auth behaviors that only the harness itself
can confirm, per the spec: (1) `claude -p --setting-sources user` discovers
the user-scoped `wienerdog-dream` skill, (2) the brain authenticates via real
`HOME` + un-overridden `CLAUDE_CONFIG_DIR` (Keychain OAuth, no key), (3) the
Haiku grader authenticates the same way. The harness fails loud (non-zero
`wienerdog dream` exit, or grader `{pass:false}` on a spawn/auth error) if any
of these is false — that existing fail-loud plumbing in `run-scenarios.js`
and `rubric.js` is the verification mechanism; no separate stub-based test
was added (see Decisions).

## Decisions made

- **Identical-skill detection (improvement within contract).** Before
  installing `wienerdog-dream` into the real config dir, the harness now
  compares it byte-for-byte against any skill already there
  (`skillDirsIdentical`/`listFilesRecursive` in `run-scenarios.js`). If
  identical (e.g. the maintainer already ran `wienerdog sync`), the harness
  leaves it untouched — no backup/restore, no risk of accidentally leaving a
  scenarios-still-in-progress marker if a maintainer edits the file mid-run.
  If different or absent, behavior is exactly the spec's backup/restore
  contract.
- **No new stub-based unit test for the three VERIFY-AT-FIRST-LIVE-RUN
  claims.** The spec's Deliverables table lists only `tests/unit/paths.test.js`
  as a new test file, and the spec explicitly states these three claims
  "cannot be unit-tested here; the harness itself is the test." Adding a new
  test file for them would both violate the Deliverables boundary (CLAUDE.md:
  "touch ONLY files listed") and duplicate fail-loud behavior that already
  exists unchanged in `run-scenarios.js` (non-zero `wienerdog dream` exit →
  `failures.push(...)`) and `rubric.js` (spawn/parse/auth error →
  `{pass:false}`, pre-existing, not added by this WP). Recording this instead
  of silently adding a file outside the boundary.
- **EXPENSIVE full run and the three live-verify claims were not exercised in
  this session** — see Verification output above for why (this session's
  guardrails forbid touching this machine's real `~/.claude` even for the
  harness's one deliberate touch). Flagging per the spec's requirement to
  state PASS/FAIL/not-run explicitly.

## Discovered issues (out of scope, not fixed)

none

---
Generated-by: claude-sonnet-5
