### PR TITLE
feat(setup): guided import from an existing vault (WP-025)

### DIFF
--- a/docs/specs/WP-025-guided-import.md
+++ b/docs/specs/WP-025-guided-import.md
@@ -1,7 +1,7 @@
 ---
 id: WP-025
 title: Guided import from an existing vault (setup skill step 3)
-status: Ready
+status: In-Review
 model: sonnet
 size: S
 depends_on: [WP-022]

--- a/skills/wienerdog-setup/SKILL.md
+++ b/skills/wienerdog-setup/SKILL.md
@@ -64,11 +64,54 @@ fine to skip a topic if they have nothing to say.
 
 ## Step 3 — Existing notes
 
-Ask whether they already keep an Obsidian vault or another notes system.
+Ask whether they already keep an Obsidian vault or another notes system, and
+where it lives.
 
-If they do, note where it lives so it is captured in the conversation, and let
-them know that automatically adopting an existing notes system is coming in a
-later version. **Do not move, copy, or change any of their existing files.**
+If they do, offer them three choices in plain language:
+
+1. **Start fresh** — keep the new, empty vault and do nothing with the old
+   one. This is the default if they are not sure.
+2. **Import from it** — you read their old vault once, pull the useful facts
+   about them into the new vault, and leave the old vault completely
+   untouched. Best for most people who already have notes somewhere.
+3. **Adopt it in place** (power users) — Wienerdog uses their existing vault
+   AS the vault, instead of the new one. This is not done here: tell them to
+   finish or exit this setup and run `wienerdog adopt <path-to-their-vault>`
+   from the terminal. That command checks the prerequisites (a normal local
+   folder, not iCloud or Documents; a git repository — it will offer to set
+   one up if it is not) and confirms the folder layout with them before it
+   changes anything. Do not attempt adoption yourself from inside this skill.
+
+**If they choose Import**, do the following:
+
+- Ask for the path to their existing vault. Read it **read-only**. You must
+  **never move, copy wholesale, edit, or delete any file in their existing
+  vault** — you only read it, and every write goes into the new vault
+  instead.
+- Mine four things from the old vault: who they are (role and background),
+  how they like to work (preferences, tone, tools), what they are working
+  toward (goals), and their current active projects. Look in the obvious
+  places — an about or profile note, recent daily notes, project folders and
+  MOCs.
+- Write what you found into the new vault's identity notes — the same four
+  files Step 5 uses (`06-Identity/profile.md`, `preferences.md`, `goals.md`,
+  `instructions.md`) — and seed each active project you find as its own
+  `01-Projects/<kebab-case-name>/index.md`. Only write facts you actually
+  found in the old vault; invent nothing.
+- On every note you write from imported content, set the frontmatter
+  `origin:` to **`import`** (not `interview`), so where it came from stays
+  auditable. Keep the rest of the standard note frontmatter as usual.
+- **Then show them exactly what was taken**: list, right there in the
+  conversation, each fact or project you imported and which file it went
+  into, so they can see it and correct anything that is wrong. This summary
+  of what was taken is mandatory — import is never silent.
+- After importing, carry on with the interview as normal (Steps 4–6) to fill
+  any gaps and let them fix anything the import got wrong.
+
+**If they choose Start fresh or Adopt**, skip the mining above and continue
+the interview normally. Adoption's own folder-layout mapping and
+prerequisite checks are handled entirely by `wienerdog adopt`, so this skill
+never edits the old vault.
 
 ## Step 4 — How much should the AI remember?
 

--- a/tests/unit/setup-skill-structure.test.js
+++ b/tests/unit/setup-skill-structure.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const skillPath = path.join(repoRoot, 'skills', 'wienerdog-setup', 'SKILL.md');
+const text = fs.readFileSync(skillPath, 'utf8');
+const lower = text.toLowerCase();
+
+test('setup-skill: frontmatter has name and a non-empty description', () => {
+  assert.match(text, /^---\n[\s\S]*?\bname:\s*wienerdog-setup\b[\s\S]*?\n---/m);
+  const desc = text.match(/^description:\s*(.+)$/m);
+  assert.ok(desc, 'description: key is present');
+  assert.ok(desc[1].trim().length > 0, 'description is non-empty');
+});
+
+test('setup-skill: the two top-of-file hard rules are unchanged', () => {
+  assert.ok(
+    text.includes('Only ever write inside the vault and `config.yaml`'),
+    'hard rule about only writing inside the vault/config.yaml is missing'
+  );
+  assert.ok(
+    text.includes('Never touch `CLAUDE.md` or `AGENTS.md` yourself'),
+    'hard rule about never touching CLAUDE.md/AGENTS.md is missing'
+  );
+});
+
+test('setup-skill: Step 3 presents all three vault paths', () => {
+  assert.ok(lower.includes('start fresh'), '"start fresh" option missing');
+  assert.ok(lower.includes('import from it'), '"import from it" option missing');
+  assert.ok(lower.includes('adopt it in place'), '"adopt it in place" option missing');
+  assert.ok(text.includes('wienerdog adopt'), 'wienerdog adopt command missing');
+});
+
+test('setup-skill: Step 3 states the read-only guarantee', () => {
+  assert.ok(lower.includes('read-only'), '"read-only" missing');
+  assert.ok(
+    lower.includes('never') && lower.includes('move, copy wholesale, edit, or delete'),
+    'guarantee against moving/copying/editing/deleting the old vault missing'
+  );
+});
+
+test('setup-skill: Step 3 requires origin: import provenance', () => {
+  assert.ok(text.includes('origin:` to **`import`**'), 'origin: import provenance marker missing');
+});
+
+test('setup-skill: Step 3 requires a mandatory "what was taken" summary', () => {
+  assert.ok(lower.includes('exactly what was taken'), '"what was taken" summary instruction missing');
+  assert.ok(lower.includes('import is never silent'), 'mandatory-summary framing missing');
+});
+
+test('setup-skill: Step 3 seeds identity notes and project seeds on import', () => {
+  for (const note of ['profile.md', 'preferences.md', 'goals.md', 'instructions.md']) {
+    assert.ok(text.includes(note), `missing identity note reference: ${note}`);
+  }
+  assert.ok(text.includes('01-Projects/'), 'project seed path missing');
+});
+
+test('setup-skill: Step 6 still references wienerdog sync', () => {
+  assert.ok(text.includes('wienerdog sync'), 'wienerdog sync reference missing');
+});


### PR DESCRIPTION
Spec: docs/specs/WP-025-guided-import.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

## Verification output

```
$ npm test -- --test-name-pattern setup-skill
...
✔ setup-skill: frontmatter has name and a non-empty description (0.900083ms)
✔ setup-skill: the two top-of-file hard rules are unchanged (0.064042ms)
✔ setup-skill: Step 3 presents all three vault paths (0.061958ms)
✔ setup-skill: Step 3 states the read-only guarantee (0.053916ms)
✔ setup-skill: Step 3 requires origin: import provenance (0.049875ms)
✔ setup-skill: Step 3 requires a mandatory "what was taken" summary (0.050209ms)
✔ setup-skill: Step 3 seeds identity notes and project seeds on import (0.062458ms)
✔ setup-skill: Step 6 still references wienerdog sync (0.0525ms)
ℹ tests 46
ℹ pass 46
ℹ fail 0

$ npm test
ℹ tests 253
ℹ pass 253
ℹ fail 0

$ npm run lint
--- markdownlint ---
Summary: 0 error(s)
--- shellcheck ---
--- frontmatter check ---
frontmatter check passed: 4 spec(s), 4 agent(s)
lint passed
```

## Decisions made

- `depends_on: [WP-022]` in the spec frontmatter is a coherence dependency
  only per the architect's note (import is prompt-only, writes into the
  default-layout new vault, and consumes no `vault_layout` code from
  WP-022); implemented in parallel as authorized.
- Test file name: used `tests/unit/setup-skill-structure.test.js` exactly
  as named in the spec's Deliverables table.
- Kept the guided-import prose closely aligned to the spec's "Exact
  contracts" wording so the structural test's literal-substring assertions
  stay stable and traceable back to the spec.
- No new headings/steps added beyond rewriting Step 3, per the spec's
  "Out of scope" list.

## Discovered issues (out of scope, not fixed)

- None.

---
Generated-by: claude-sonnet-5