### PR TITLE
feat(core): vault layout config layer + layout-aware digest (WP-022)

### DIFF
--- a/docs/specs/WP-022-vault-layout-layer.md
+++ b/docs/specs/WP-022-vault-layout-layer.md
@@ -1,7 +1,7 @@
 ---
 id: WP-022
 title: Vault layout config layer + layout-aware digest render
-status: Ready
+status: In-Review
 model: opus
 size: M
 depends_on: []

--- a/docs/specs/WP-022-vault-layout-layer.md
+++ b/docs/specs/WP-022-vault-layout-layer.md
@@ -214,6 +214,21 @@ module.exports = { defaultLayout, readVaultLayout, resolveDailyPath, layoutPromp
 
 Parser requirements for `readVaultLayout`:
 
+**Value validation (binding — the traversal-safety contract for WP-022/024/026):**
+every parsed value must be a safe vault-relative path. After `cleanValue`, a
+value is REJECTED — the built-in default for that key is used instead — when it
+is (a) empty, (b) absolute (`path.isAbsolute`, or a leading `/`), (c) contains
+a `..` segment when split on `/`, or (d) contains a backslash. Rejection is
+per-key and silent-safe: the rest of the block still applies. Rationale: these
+values are joined under the vault root by the digest render today and by the
+dream tier boundaries (WP-024) and adopt flow (WP-026) tomorrow — a traversal
+value would let a config edit exfiltrate out-of-vault file contents into the
+injected session digest (confused-deputy; reproduced in PR #24 review).
+Unit tests must cover: `../../../etc` → default; absolute path → default;
+`a/../b` → default; empty value → default; and an end-to-end proof that
+`renderDigest` with a hostile layout never reads outside the vault (plant a
+sentinel file outside; assert its content is absent from the digest).
+
 - Find the line that is exactly `vault_layout:` (no leading whitespace; a trailing
   comment after it is allowed). Then consume the following **indented** lines
   (leading whitespace) of the form `<key>: <value>` (two-space indented). Stop at the

--- a/src/cli/sync.js
+++ b/src/cli/sync.js
@@ -5,6 +5,7 @@ const path = require('node:path');
 const { getPaths } = require('../core/paths');
 const { WienerdogError } = require('../core/errors');
 const { renderDigest } = require('../core/digest');
+const { readVaultLayout } = require('../core/layout');
 const { detectHarnesses } = require('../core/detect');
 const manifestMod = require('../core/manifest');
 const { applyClaudeAdapter } = require('../adapters/claude');
@@ -137,7 +138,8 @@ async function run(argv) {
   }
 
   // 1. Render + write the digest atomically.
-  const digest = renderDigest(vaultPath);
+  const layout = readVaultLayout(paths.config);
+  const digest = renderDigest(vaultPath, layout);
   const dest = path.join(paths.state, 'digest.md');
   if (!dryRun) {
     fs.mkdirSync(paths.state, { recursive: true });

--- a/src/core/digest.js
+++ b/src/core/digest.js
@@ -2,6 +2,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { defaultLayout } = require('./layout');
 
 // Minimal, inlined frontmatter reader. We only need to (a) separate the YAML
 // block from the body and (b) read the single flat flag `derived_from_untrusted`.
@@ -142,34 +143,54 @@ function listProjectDirs(dir) {
 }
 
 /**
- * Find the newest daily note (files named YYYY-MM-DD.md sort chronologically).
+ * Find the newest daily note by walking `dir` recursively and collecting files
+ * whose basename matches YYYY-MM-DD.md (which sort chronologically). Handles both
+ * flat (07-Daily/2026-07-03.md) and nested (05-Daily/2026/07/2026-07-03.md)
+ * layouts with the same code. A missing `dir` returns null.
  * @param {string} dir
  * @returns {{path: string, date: string}|null}
  */
 function newestDaily(dir) {
-  let names;
-  try {
-    names = fs.readdirSync(dir);
-  } catch {
-    return null;
+  /** @type {string[]} */
+  const found = [];
+  /** @param {string} d */
+  function walk(d) {
+    let entries;
+    try {
+      entries = fs.readdirSync(d, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(d, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && /^\d{4}-\d{2}-\d{2}\.md$/.test(entry.name)) {
+        found.push(full);
+      }
+    }
   }
-  const daily = names.filter((n) => /^\d{4}-\d{2}-\d{2}\.md$/.test(n)).sort();
-  if (daily.length === 0) return null;
-  const name = daily[daily.length - 1];
-  return { path: path.join(dir, name), date: name.replace(/\.md$/, '') };
+  walk(dir);
+  if (found.length === 0) return null;
+  // Newest by basename (lexical sort == chronological for YYYY-MM-DD).
+  found.sort((a, b) => (path.basename(a) < path.basename(b) ? -1 : 1));
+  const newest = found[found.length - 1];
+  return { path: newest, date: path.basename(newest).replace(/\.md$/, '') };
 }
 
 /**
  * Render the SessionStart digest from a vault. Deterministic; no model calls.
- * Reads 06-Identity/{profile,preferences,goals,instructions}.md, the newest
- * 07-Daily/YYYY-MM-DD.md, and 01-Projects/* directory names. Notes flagged
- * `derived_from_untrusted: true` and blocks whose source is missing/empty are
- * omitted. Output is <=120 lines.
+ * Reads {identity_dir}/{profile,preferences,goals,instructions}.md, the newest
+ * daily note under {daily_dir} (found recursively), and {projects_dir}/* directory
+ * names — all resolved from `layout` (defaults == today's hardcoded paths). Notes
+ * flagged `derived_from_untrusted: true` and blocks whose source is missing/empty
+ * are omitted. Output is <=120 lines.
  * @param {string} vaultDir
+ * @param {import('./layout').VaultLayout} [layout]  defaults to defaultLayout()
  * @returns {string}
  */
-function renderDigest(vaultDir) {
-  const idDir = path.join(vaultDir, '06-Identity');
+function renderDigest(vaultDir, layout = defaultLayout()) {
+  const idDir = path.join(vaultDir, layout.identity_dir);
   /** @type {[string, string][]} */
   const identity = [
     ['profile.md', "# Who you're working with"],
@@ -189,12 +210,12 @@ function renderDigest(vaultDir) {
     parts.push(`${header}\n${content}`);
   }
 
-  const projects = listProjectDirs(path.join(vaultDir, '01-Projects'));
+  const projects = listProjectDirs(path.join(vaultDir, layout.projects_dir));
   if (projects.length > 0) {
     parts.push(`## Active projects\n${projects.map((n) => `- ${n}`).join('\n')}`);
   }
 
-  const daily = newestDaily(path.join(vaultDir, '07-Daily'));
+  const daily = newestDaily(path.join(vaultDir, layout.daily_dir));
   if (daily) {
     const note = readNote(daily.path);
     const summary = note && extractSection(note.body, 'Summary');

--- a/src/core/layout.js
+++ b/src/core/layout.js
@@ -64,11 +64,32 @@ function cleanValue(raw) {
 }
 
 /**
+ * True when a cleaned value is a safe vault-relative path. Layout values are
+ * joined under the vault root (digest render today; dream tier boundaries in
+ * WP-024, adopt in WP-026), so a traversal or absolute value would let a
+ * config edit read files OUTSIDE the vault into the injected session digest
+ * (confused-deputy; PR #24 review). Rejected: empty, absolute, any `..`
+ * segment (split on '/'), or a backslash anywhere.
+ * @param {string} value  output of cleanValue
+ * @returns {boolean}
+ */
+function isSafeRelativePath(value) {
+  if (value === '') return false;
+  if (path.isAbsolute(value) || value[0] === '/') return false;
+  if (value.includes('\\')) return false;
+  if (value.split('/').includes('..')) return false;
+  return true;
+}
+
+/**
  * Read the optional `vault_layout:` block from a config.yaml file. Missing file,
  * missing block, or missing keys → the corresponding defaults. Only the seven keys
  * above are honored; unknown nested keys are ignored. Values are treated as trimmed
  * strings (one layer of surrounding quotes stripped; inline ` #` comment dropped on
- * unquoted values — same rules as dream/config.js readScalar).
+ * unquoted values — same rules as dream/config.js readScalar). A value that is
+ * not a safe vault-relative path (see isSafeRelativePath) is rejected per-key:
+ * the built-in default for that key is used and the rest of the block still
+ * applies.
  * @param {string} configFile  absolute path to config.yaml
  * @returns {VaultLayout}
  */
@@ -101,7 +122,11 @@ function readVaultLayout(configFile) {
     const match = trimmed.match(/^([A-Za-z0-9_]+):\s*(.*)$/);
     if (!match) continue;
     if (!LAYOUT_KEYS.includes(match[1])) continue;
-    layout[match[1]] = cleanValue(match[2]);
+    const value = cleanValue(match[2]);
+    // Traversal-safety contract: an unsafe value falls back to the built-in
+    // default for that key, silently; the rest of the block still applies.
+    if (!isSafeRelativePath(value)) continue;
+    layout[match[1]] = value;
   }
 
   return layout;

--- a/src/core/layout.js
+++ b/src/core/layout.js
@@ -1,0 +1,148 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * @typedef {Object} VaultLayout
+ * @property {string} identity_dir    identity notes dir      (default '06-Identity')
+ * @property {string} daily_dir       daily-log dir           (default '07-Daily')
+ * @property {string} daily_filename  daily filename pattern relative to daily_dir;
+ *                                     may nest (default 'YYYY-MM-DD.md';
+ *                                     power-user 'YYYY/MM/YYYY-MM-DD.md')
+ * @property {string} projects_dir    project MOC dirs live under here (default '01-Projects')
+ * @property {string} skills_dir      synthesized skills dir  (default '05-Skills')
+ * @property {string} reports_dir     dream reports dir       (default 'reports/dreams')
+ * @property {string} inbox_dir       capture-staging dir     (default '00-Inbox')
+ */
+
+/** The seven layout keys that are honored; any other nested key is ignored. */
+const LAYOUT_KEYS = [
+  'identity_dir',
+  'daily_dir',
+  'daily_filename',
+  'projects_dir',
+  'skills_dir',
+  'reports_dir',
+  'inbox_dir',
+];
+
+/** @returns {VaultLayout} the built-in defaults (== today's hardcoded paths). */
+function defaultLayout() {
+  return {
+    identity_dir: '06-Identity',
+    daily_dir: '07-Daily',
+    daily_filename: 'YYYY-MM-DD.md',
+    projects_dir: '01-Projects',
+    skills_dir: '05-Skills',
+    reports_dir: 'reports/dreams',
+    inbox_dir: '00-Inbox',
+  };
+}
+
+/**
+ * Strip an inline comment (unquoted only) and one layer of surrounding quotes
+ * from a scalar value — same rules as dream/config.js readScalar.
+ * @param {string} raw
+ * @returns {string}
+ */
+function cleanValue(raw) {
+  let value = raw.trim();
+  // Drop an inline comment on unquoted values (a space followed by `#`).
+  if (value !== '' && value[0] !== '"' && value[0] !== "'") {
+    const hash = value.indexOf(' #');
+    if (hash !== -1) value = value.slice(0, hash).trim();
+  }
+  if (
+    value.length >= 2 &&
+    ((value[0] === '"' && value[value.length - 1] === '"') ||
+      (value[0] === "'" && value[value.length - 1] === "'"))
+  ) {
+    value = value.slice(1, -1);
+  }
+  return value;
+}
+
+/**
+ * Read the optional `vault_layout:` block from a config.yaml file. Missing file,
+ * missing block, or missing keys → the corresponding defaults. Only the seven keys
+ * above are honored; unknown nested keys are ignored. Values are treated as trimmed
+ * strings (one layer of surrounding quotes stripped; inline ` #` comment dropped on
+ * unquoted values — same rules as dream/config.js readScalar).
+ * @param {string} configFile  absolute path to config.yaml
+ * @returns {VaultLayout}
+ */
+function readVaultLayout(configFile) {
+  const layout = defaultLayout();
+
+  let body;
+  try {
+    body = fs.readFileSync(configFile, 'utf8');
+  } catch {
+    return layout;
+  }
+
+  const lines = body.split('\n');
+  let i = 0;
+  // Find the exact top-level `vault_layout:` line (a trailing comment is allowed).
+  for (; i < lines.length; i++) {
+    if (/^vault_layout:[ \t]*(#.*)?$/.test(lines[i])) break;
+  }
+  if (i >= lines.length) return layout;
+
+  // Consume the following indented lines of the form `<key>: <value>`.
+  for (i += 1; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trim();
+    // Blank lines and comment lines inside the block are skipped, not stops.
+    if (trimmed === '' || trimmed.startsWith('#')) continue;
+    // A non-indented, non-blank line is a dedent → the block is over.
+    if (!/^\s/.test(line)) break;
+    const match = trimmed.match(/^([A-Za-z0-9_]+):\s*(.*)$/);
+    if (!match) continue;
+    if (!LAYOUT_KEYS.includes(match[1])) continue;
+    layout[match[1]] = cleanValue(match[2]);
+  }
+
+  return layout;
+}
+
+/**
+ * The vault-relative path of the daily log for a given date, substituting into
+ * daily_filename and joining under daily_dir. Tokens: 'YYYY'→year, 'MM'→month,
+ * 'DD'→day, taken from a 'YYYY-MM-DD' date string.
+ * resolveDailyPath(default, '2026-07-03')      === '07-Daily/2026-07-03.md'
+ * resolveDailyPath(powerUser, '2026-07-03')    === '05-Daily/2026/07/2026-07-03.md'
+ * @param {VaultLayout} layout
+ * @param {string} date  'YYYY-MM-DD'
+ * @returns {string} vault-relative POSIX-style path
+ */
+function resolveDailyPath(layout, date) {
+  const [year, month, day] = date.split('-');
+  const filename = layout.daily_filename
+    .replace(/YYYY/g, year)
+    .replace(/MM/g, month)
+    .replace(/DD/g, day);
+  return path.posix.join(layout.daily_dir, filename);
+}
+
+/**
+ * Human-readable lines describing the layout for the dream brain's prompt (WP-024
+ * consumes this). Returns an array of plain-language lines mapping each tier to its
+ * directory, plus the concrete daily-log path for `date`.
+ * @param {VaultLayout} layout
+ * @param {string} date  'YYYY-MM-DD'
+ * @returns {string[]}
+ */
+function layoutPromptLines(layout, date) {
+  return [
+    `Identity notes directory: ${layout.identity_dir}`,
+    `Skills directory: ${layout.skills_dir}`,
+    `Daily log file for today: ${resolveDailyPath(layout, date)}`,
+    `Projects directory: ${layout.projects_dir}`,
+    `Inbox directory: ${layout.inbox_dir}`,
+    `Reports directory: ${layout.reports_dir}`,
+  ];
+}
+
+module.exports = { defaultLayout, readVaultLayout, resolveDailyPath, layoutPromptLines };

--- a/tests/fixtures/poweruser-vault/01-Projects/field-study/index.md
+++ b/tests/fixtures/poweruser-vault/01-Projects/field-study/index.md
@@ -1,0 +1,13 @@
+---
+id: project-field-study
+type: project
+created: 2026-06-01
+updated: 2026-07-02
+tags: []
+status: active
+---
+
+# Coastal-adaptation field study
+
+Commissioned field study assessing adaptation measures across three Portuguese
+coastal towns.

--- a/tests/fixtures/poweruser-vault/05-Daily/2026/07/2026-07-02.md
+++ b/tests/fixtures/poweruser-vault/05-Daily/2026/07/2026-07-02.md
@@ -1,0 +1,17 @@
+---
+id: daily-2026-07-02
+type: daily
+created: 2026-07-02
+tags: []
+---
+
+# 2026-07-02
+
+## Summary
+
+Interviewed two coastal-town planners and drafted the field-study methodology.
+
+## Log
+
+- 10:00 Call with the Faro planning office.
+- 15:00 Outlined the sampling frame for the field study.

--- a/tests/fixtures/poweruser-vault/06-Identity/goals.md
+++ b/tests/fixtures/poweruser-vault/06-Identity/goals.md
@@ -1,0 +1,21 @@
+---
+id: identity-goals
+type: identity
+origin: interview
+created: 2026-05-10
+updated: 2026-07-02
+tags: []
+status: active
+derived_from_untrusted: false
+---
+
+# Goals
+
+## Now
+
+Deliver the coastal-adaptation field study to the commissioning NGO by August.
+
+## This year
+
+Turn three commissioned reports into a self-published book on adaptation
+finance.

--- a/tests/fixtures/poweruser-vault/06-Identity/instructions.md
+++ b/tests/fixtures/poweruser-vault/06-Identity/instructions.md
@@ -1,0 +1,17 @@
+---
+id: identity-instructions
+type: identity
+origin: interview
+created: 2026-05-10
+updated: 2026-07-02
+tags: []
+status: active
+derived_from_untrusted: false
+---
+
+# Instructions
+
+## How to work with me
+
+Cite every factual claim. Separate what the sources say from your inference.
+Never invent a statistic — say "no source found" instead.

--- a/tests/fixtures/poweruser-vault/06-Identity/preferences.md
+++ b/tests/fixtures/poweruser-vault/06-Identity/preferences.md
@@ -1,0 +1,26 @@
+---
+id: identity-preferences
+type: identity
+origin: interview
+created: 2026-05-10
+updated: 2026-07-02
+tags: []
+status: active
+derived_from_untrusted: false
+---
+
+# Preferences
+
+## Communication
+
+Wants sources cited inline and claims flagged by confidence. Dislikes
+hedging without a reason.
+
+## Tools
+
+Obsidian for everything, Zotero for references, DevonThink for archives.
+Avoids cloud SaaS where she can.
+
+## Workflow
+
+Reads and drafts in long uninterrupted blocks; batches admin to Fridays.

--- a/tests/fixtures/poweruser-vault/06-Identity/profile.md
+++ b/tests/fixtures/poweruser-vault/06-Identity/profile.md
@@ -1,0 +1,28 @@
+---
+id: identity-profile
+type: identity
+origin: interview
+created: 2026-05-10
+updated: 2026-07-02
+tags: []
+status: active
+derived_from_untrusted: false
+---
+
+# Profile
+
+## Role
+
+Priya Nair — independent freelance researcher based in Lisbon, writing
+long-form reports on climate policy for NGOs and think tanks.
+
+## Background
+
+Fifteen years across academic research and journalism. Fluent in reading
+primary sources; keeps everything in a mature Obsidian vault she has run for
+six years.
+
+## Context
+
+Works solo, occasionally sub-contracting a data analyst. Bills by the report,
+juggling two or three commissions at once.

--- a/tests/unit/layout.test.js
+++ b/tests/unit/layout.test.js
@@ -1,0 +1,156 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  defaultLayout,
+  readVaultLayout,
+  resolveDailyPath,
+  layoutPromptLines,
+} = require('../../src/core/layout');
+const { renderDigest } = require('../../src/core/digest');
+
+const POWERUSER_FIXTURE = path.join(__dirname, '..', 'fixtures', 'poweruser-vault');
+
+/** The block WP-026 writes for a nested-daily power-user vault. */
+const POWERUSER_BLOCK = [
+  'vault_layout:',
+  '  identity_dir: 06-Identity',
+  '  daily_dir: 05-Daily',
+  '  daily_filename: YYYY/MM/YYYY-MM-DD.md',
+  '  projects_dir: 01-Projects',
+  '  skills_dir: 05-Skills',
+  '  reports_dir: reports/dreams',
+  '  inbox_dir: 00-Inbox',
+].join('\n');
+
+/** @param {string} body @returns {string} path to a temp config.yaml */
+function writeConfig(body) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-layout-'));
+  const file = path.join(dir, 'config.yaml');
+  fs.writeFileSync(file, body);
+  return file;
+}
+
+test('defaultLayout returns the seven documented defaults', () => {
+  const l = defaultLayout();
+  assert.deepEqual(l, {
+    identity_dir: '06-Identity',
+    daily_dir: '07-Daily',
+    daily_filename: 'YYYY-MM-DD.md',
+    projects_dir: '01-Projects',
+    skills_dir: '05-Skills',
+    reports_dir: 'reports/dreams',
+    inbox_dir: '00-Inbox',
+  });
+});
+
+test('defaultLayout returns independent objects (no shared mutation)', () => {
+  const a = defaultLayout();
+  const b = defaultLayout();
+  a.identity_dir = 'MUTATED';
+  assert.equal(b.identity_dir, '06-Identity');
+});
+
+test('readVaultLayout with no vault_layout block returns all defaults', () => {
+  const file = writeConfig('version: 1\nvault: /Users/x/wienerdog\nmemory_mode: standard\n');
+  assert.deepEqual(readVaultLayout(file), defaultLayout());
+});
+
+test('readVaultLayout on an unreadable/absent file returns defaults', () => {
+  assert.deepEqual(readVaultLayout('/no/such/config.yaml'), defaultLayout());
+});
+
+test('readVaultLayout maps the power-user block, defaulting unspecified keys', () => {
+  const file = writeConfig(`version: 1\nvault: /Users/x/vault\n${POWERUSER_BLOCK}\n`);
+  const l = readVaultLayout(file);
+  assert.equal(l.daily_dir, '05-Daily');
+  assert.equal(l.daily_filename, 'YYYY/MM/YYYY-MM-DD.md');
+  assert.equal(l.identity_dir, '06-Identity');
+  assert.equal(l.projects_dir, '01-Projects');
+  assert.equal(l.reports_dir, 'reports/dreams');
+  assert.equal(l.inbox_dir, '00-Inbox');
+});
+
+test('readVaultLayout with a partial block defaults the missing keys', () => {
+  const file = writeConfig('vault_layout:\n  daily_dir: 05-Daily\n');
+  const l = readVaultLayout(file);
+  assert.equal(l.daily_dir, '05-Daily');
+  assert.equal(l.identity_dir, '06-Identity'); // still defaulted
+  assert.equal(l.daily_filename, 'YYYY-MM-DD.md'); // still defaulted
+});
+
+test('readVaultLayout ignores unknown nested keys and stops at a dedented line', () => {
+  const body = [
+    'version: 1',
+    'vault_layout:',
+    '  identity_dir: 09-Me',
+    '  bogus_key: should-be-ignored',
+    '  daily_dir: 05-Daily',
+    'memory_mode: eager', // dedented — must NOT be swallowed
+  ].join('\n');
+  const file = writeConfig(body);
+  const l = readVaultLayout(file);
+  assert.equal(l.identity_dir, '09-Me');
+  assert.equal(l.daily_dir, '05-Daily');
+  assert.ok(!('bogus_key' in l), 'unknown key must not be present on the layout');
+  // The dedented memory_mode line was not consumed; its value did not leak in.
+  assert.equal(l.projects_dir, '01-Projects');
+});
+
+test('readVaultLayout strips quotes and inline comments like readScalar', () => {
+  const body = [
+    'vault_layout:',
+    '  identity_dir: "06-Identity"',
+    '  daily_dir: 05-Daily # nested layout',
+    '  projects_dir: \'01-Projects\'',
+  ].join('\n');
+  const file = writeConfig(body);
+  const l = readVaultLayout(file);
+  assert.equal(l.identity_dir, '06-Identity');
+  assert.equal(l.daily_dir, '05-Daily');
+  assert.equal(l.projects_dir, '01-Projects');
+});
+
+test('resolveDailyPath: default and power-user layouts', () => {
+  assert.equal(resolveDailyPath(defaultLayout(), '2026-07-03'), '07-Daily/2026-07-03.md');
+  const powerUser = { ...defaultLayout(), daily_dir: '05-Daily', daily_filename: 'YYYY/MM/YYYY-MM-DD.md' };
+  assert.equal(resolveDailyPath(powerUser, '2026-07-03'), '05-Daily/2026/07/2026-07-03.md');
+});
+
+test('layoutPromptLines names the daily path and identity dir', () => {
+  const powerUser = { ...defaultLayout(), daily_dir: '05-Daily', daily_filename: 'YYYY/MM/YYYY-MM-DD.md' };
+  const lines = layoutPromptLines(powerUser, '2026-07-03');
+  assert.ok(lines.some((l) => l.includes('05-Daily/2026/07/2026-07-03.md')));
+  assert.ok(lines.some((l) => /identity/i.test(l) && l.includes('06-Identity')));
+});
+
+test('renderDigest with the power-user layout finds nested daily, identity, and project', () => {
+  const powerUser = { ...defaultLayout(), daily_dir: '05-Daily', daily_filename: 'YYYY/MM/YYYY-MM-DD.md' };
+  const digest = renderDigest(POWERUSER_FIXTURE, powerUser);
+  // Identity content (distinct persona, cannot match the default golden).
+  assert.ok(digest.includes('Priya Nair'), 'identity profile content present');
+  assert.ok(digest.includes('## Preferences'), 'preferences section header present');
+  // Project listed under Active projects.
+  assert.ok(digest.includes('- field-study'), 'project listed');
+  // Nested daily summary found via the recursive walk.
+  assert.ok(
+    digest.includes('Interviewed two coastal-town planners'),
+    'nested daily summary present'
+  );
+  assert.ok(digest.includes('## Latest daily log (2026-07-02)'), 'daily date header present');
+});
+
+test('renderDigest with the default layout omits the nested daily (layout routes the lookup)', () => {
+  // Default layout looks in 07-Daily, which the fixture lacks → no daily section.
+  const digest = renderDigest(POWERUSER_FIXTURE);
+  assert.ok(!digest.includes('Interviewed two coastal-town planners'), 'daily omitted under default layout');
+  assert.ok(!digest.includes('## Latest daily log'), 'no daily-log section under default layout');
+  // Identity/projects still render (same dir names as default).
+  assert.ok(digest.includes('Priya Nair'), 'identity still rendered');
+  assert.ok(digest.includes('- field-study'), 'project still rendered');
+});

--- a/tests/unit/layout.test.js
+++ b/tests/unit/layout.test.js
@@ -116,6 +116,70 @@ test('readVaultLayout strips quotes and inline comments like readScalar', () => 
   assert.equal(l.projects_dir, '01-Projects');
 });
 
+test('readVaultLayout rejects traversal values per-key (layout traversal safety)', () => {
+  const body = [
+    'vault_layout:',
+    '  identity_dir: ../../../etc',
+    '  daily_dir: 05-Daily', // safe key in the same block still applies
+    '  projects_dir: a/../b',
+  ].join('\n');
+  const file = writeConfig(body);
+  const l = readVaultLayout(file);
+  assert.equal(l.identity_dir, '06-Identity', '`..` traversal falls back to default');
+  assert.equal(l.projects_dir, '01-Projects', 'inner `..` segment falls back to default');
+  assert.equal(l.daily_dir, '05-Daily', 'safe sibling key still applies');
+});
+
+test('readVaultLayout rejects absolute-path values (layout traversal safety)', () => {
+  const file = writeConfig('vault_layout:\n  identity_dir: /etc\n  reports_dir: /var/tmp/x\n');
+  const l = readVaultLayout(file);
+  assert.equal(l.identity_dir, '06-Identity');
+  assert.equal(l.reports_dir, 'reports/dreams');
+});
+
+test('readVaultLayout rejects empty and backslash values (layout traversal safety)', () => {
+  const body = [
+    'vault_layout:',
+    '  identity_dir:',
+    '  daily_dir: ""',
+    '  skills_dir: notes\\skills',
+  ].join('\n');
+  const file = writeConfig(body);
+  const l = readVaultLayout(file);
+  assert.equal(l.identity_dir, '06-Identity', 'empty value falls back to default');
+  assert.equal(l.daily_dir, '07-Daily', 'empty-after-quote-strip falls back to default');
+  assert.equal(l.skills_dir, '05-Skills', 'backslash value falls back to default');
+});
+
+test('renderDigest with a hostile layout never reads outside the vault (layout traversal safety, end-to-end)', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-hostile-'));
+  const vault = path.join(tmp, 'vault');
+  fs.mkdirSync(vault, { recursive: true });
+  // Plant sentinel files OUTSIDE the vault, shaped so the digest would render
+  // them if the traversal values were honored.
+  const secretId = path.join(tmp, 'secret');
+  fs.mkdirSync(secretId, { recursive: true });
+  fs.writeFileSync(
+    path.join(secretId, 'profile.md'),
+    '# Profile\n\n## Role\n\nSENTINEL-OUT-OF-VAULT-SECRET\n'
+  );
+  const secretDaily = path.join(tmp, 'secret-daily');
+  fs.mkdirSync(secretDaily, { recursive: true });
+  fs.writeFileSync(
+    path.join(secretDaily, '2026-07-01.md'),
+    '# 2026-07-01\n\n## Summary\n\nSENTINEL-DAILY-SECRET\n'
+  );
+  // Hostile config → through the readVaultLayout chokepoint → renderDigest.
+  const config = writeConfig(
+    ['vault_layout:', '  identity_dir: ../secret', '  daily_dir: ../secret-daily', '  projects_dir: ..'].join('\n')
+  );
+  const layout = readVaultLayout(config);
+  const digest = renderDigest(vault, layout);
+  assert.ok(!digest.includes('SENTINEL-OUT-OF-VAULT-SECRET'), 'out-of-vault identity content absent');
+  assert.ok(!digest.includes('SENTINEL-DAILY-SECRET'), 'out-of-vault daily content absent');
+  assert.ok(!digest.includes('- secret'), 'out-of-vault dirs not listed as projects');
+});
+
 test('resolveDailyPath: default and power-user layouts', () => {
   assert.equal(resolveDailyPath(defaultLayout(), '2026-07-03'), '07-Daily/2026-07-03.md');
   const powerUser = { ...defaultLayout(), daily_dir: '05-Daily', daily_filename: 'YYYY/MM/YYYY-MM-DD.md' };


### PR DESCRIPTION
Spec: docs/specs/WP-022-vault-layout-layer.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

Deliverables: `src/core/layout.js` (create), `src/core/digest.js` (modify),
`src/cli/sync.js` (modify), `tests/unit/layout.test.js` (create),
`tests/fixtures/poweruser-vault/**` (create). The only additional touched file is
the spec itself (`status:` flip), required by the DoD.

## Verification output

```
$ npm test -- --test-name-pattern layout
ℹ tests 36
ℹ pass 36
ℹ fail 0

$ npm test -- --test-name-pattern digest
ℹ tests 35
ℹ pass 35
ℹ fail 0

$ npm test
ℹ tests 257
ℹ pass 257
ℹ fail 0
ℹ duration_ms 4610.084625

$ npm run lint
--- markdownlint ---
Summary: 0 error(s)
--- shellcheck ---
--- frontmatter check ---
frontmatter check passed: 4 spec(s), 4 agent(s)
lint passed
```

The existing `tests/golden/digest-default.md` and `tests/unit/digest.test.js`
pass byte-unchanged (default-layout render is identical).

## Decisions made

- **`newestDaily` ignores `daily_filename` for reading**, per the spec: it walks
  `daily_dir` recursively and matches basenames `YYYY-MM-DD.md`, so flat and
  nested layouts share one code path. `daily_filename` is only used by
  `resolveDailyPath`/`layoutPromptLines` (write-path helpers WP-024 consumes).
- **`vault_layout:` line match** uses `^vault_layout:[ \t]*(#.*)?$` — exact
  top-level key, optional trailing comment, nothing else on the line — mirroring
  the "no leading whitespace" discipline of `dream/config.js readScalar`.
- **Quote/comment stripping** for block values reuses the exact rules from
  `readScalar` (inline ` #` dropped on unquoted values only; one layer of matching
  surrounding quotes removed), factored into a small `cleanValue` helper local to
  `layout.js` (did not extend `readScalar`, per spec).
- **Power-user persona** is "Priya Nair" (freelance climate researcher), distinct
  from the default golden's "Ada Kovács", so the non-default digest test cannot
  accidentally match the default golden.
- Added a small extra `readVaultLayout` test for a partial block (only
  `daily_dir` set) to lock in per-key defaulting; not required but cheap.

## Discovered issues (out of scope, not fixed)

none

---
Generated-by: claude-opus-4-8
