### PR TITLE
feat(cli): full vault adoption — wienerdog adopt (WP-026)

### DIFF
--- a/bin/wienerdog.js
+++ b/bin/wienerdog.js
@@ -9,6 +9,7 @@ Usage: wienerdog <command> [options]
 
 Commands:
   init        Create the Wienerdog core (~/.wienerdog) and detect your AI tools
+  adopt       Use an existing vault in place as your Wienerdog vault
   sync        Re-render the session digest from your vault's identity notes
   dream       Consolidate recent sessions into vault memory (one commit)
   schedule    Add, remove, or list scheduled jobs (dream, routines)
@@ -37,6 +38,7 @@ async function main() {
   /** @type {Record<string, () => {run: (argv: string[]) => Promise<void>}>} */
   const commands = {
     init: () => require('../src/cli/init'),
+    adopt: () => require('../src/cli/adopt'),
     sync: () => require('../src/cli/sync'),
     dream: () => require('../src/cli/dream'),
     schedule: () => require('../src/cli/schedule'),

--- a/docs/specs/WP-026-full-adoption-flow.md
+++ b/docs/specs/WP-026-full-adoption-flow.md
@@ -1,7 +1,7 @@
 ---
 id: WP-026
 title: Full vault adoption — `wienerdog adopt` CLI, prerequisites, layout mapping
-status: Ready
+status: In-Review
 model: opus
 size: M
 depends_on: [WP-024, WP-025]

--- a/docs/specs/WP-026-full-adoption-flow.md
+++ b/docs/specs/WP-026-full-adoption-flow.md
@@ -36,6 +36,22 @@ So `adopt` enforces hard prerequisites before writing anything:
 4. **Conservative memory_mode for the first week** — set `memory_mode: conservative`
    so the strictest gates apply while the user builds trust.
 
+**Symlink-domain rule (binding):** every path handed to `tccguard.guard` must be
+in the same symlink-resolution domain — call it as
+`guard([fs.realpathSync(adoptedPath)], fs.realpathSync(paths.home))`. Comparing
+a realpath'd vault path against a raw `paths.home` makes `path.relative` yield
+`../…` under any symlinked home component (relocated homes, MDM setups, /tmp in
+tests) and the guard silently fails OPEN — reproduced in PR #26 review. A test
+must cover the symlinked-home refusal (macOS /tmp → /private/tmp makes this
+directly testable).
+
+**inferLayout hygiene (binding):** every proposal must be `trim()`ed and must
+pass `isSafeRelativePath` before being emitted (explicit validation, not
+safety-by-construction) — otherwise a folder named with surrounding whitespace
+round-trips differently through `readVaultLayout`'s trim and the config points
+at a different dir than adopt created.
+
+
 Then `adopt` points config at the adopted path, writes the confirmed `vault_layout`
 block, fills only the **missing** mapped directories (never overwriting existing
 files — the standing `scaffoldVault` guarantee), records manifest entries that

--- a/docs/specs/WP-026-full-adoption-flow.md
+++ b/docs/specs/WP-026-full-adoption-flow.md
@@ -51,7 +51,6 @@ safety-by-construction) — otherwise a folder named with surrounding whitespace
 round-trips differently through `readVaultLayout`'s trim and the config points
 at a different dir than adopt created.
 
-
 Then `adopt` points config at the adopted path, writes the confirmed `vault_layout`
 block, fills only the **missing** mapped directories (never overwriting existing
 files — the standing `scaffoldVault` guarantee), records manifest entries that

--- a/src/cli/adopt.js
+++ b/src/cli/adopt.js
@@ -1,0 +1,251 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const readline = require('node:readline');
+const { spawnSync } = require('node:child_process');
+const { getPaths } = require('../core/paths');
+const { WienerdogError } = require('../core/errors');
+const manifestLib = require('../core/manifest');
+const tccguard = require('../scheduler/tccguard');
+const { inferLayout } = require('../core/layout-infer');
+const { resolveDailyPath } = require('../core/layout');
+const { scaffoldMappedDirs } = require('../core/vault');
+
+// Small helpers copied from init.js (init does not export them, and it is not
+// in this WP's deliverables). Kept identical so behavior matches.
+
+/** @param {string} p @returns {boolean} */
+function dirExists(p) {
+  try {
+    return fs.statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** @param {string} p @returns {boolean} */
+function fileExists(p) {
+  try {
+    return fs.statSync(p).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** @param {string} content @returns {string} sha256 hex. */
+function sha256(content) {
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+/**
+ * Ask a yes/no question on stdin.
+ * @param {string} prompt
+ * @returns {Promise<boolean>}
+ */
+function confirm(prompt) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(prompt, (answer) => {
+      rl.close();
+      resolve(/^y(es)?$/i.test(answer.trim()));
+    });
+  });
+}
+
+/** @param {string} dir @param {string[]} args @returns {import('child_process').SpawnSyncReturns<Buffer>} */
+function git(dir, args) {
+  return spawnSync('git', ['-C', dir, ...args]);
+}
+
+/** @param {string} dir @returns {boolean} true if dir is inside a git work tree. */
+function isGitRepo(dir) {
+  const r = git(dir, ['rev-parse', '--git-dir']);
+  return !r.error && r.status === 0;
+}
+
+/**
+ * Render the `vault_layout:` block appended to config.yaml. Two-space indented,
+ * exactly the shape readVaultLayout parses.
+ * @param {import('../core/layout').VaultLayout} layout
+ * @returns {string}
+ */
+function renderLayoutBlock(layout) {
+  return [
+    'vault_layout:',
+    `  identity_dir: ${layout.identity_dir}`,
+    `  daily_dir: ${layout.daily_dir}`,
+    `  daily_filename: ${layout.daily_filename}`,
+    `  projects_dir: ${layout.projects_dir}`,
+    `  skills_dir: ${layout.skills_dir}`,
+    `  reports_dir: ${layout.reports_dir}`,
+    `  inbox_dir: ${layout.inbox_dir}`,
+    '',
+  ].join('\n');
+}
+
+/**
+ * Print the inferred folder mapping in plain language — one line per slot, with a
+ * concrete example daily-note path so the user can sanity-check the nesting.
+ * @param {import('../core/layout').VaultLayout} layout
+ */
+function printLayout(layout) {
+  const exampleDaily = resolveDailyPath(layout, '2026-07-03');
+  console.log('\nProposed folder mapping (how Wienerdog will read your vault):');
+  console.log(`  Identity notes:  ${layout.identity_dir}`);
+  console.log(`  Daily notes:     ${layout.daily_dir}, filenames like ${exampleDaily}`);
+  console.log(`  Projects:        ${layout.projects_dir}`);
+  console.log(`  Skills:          ${layout.skills_dir}`);
+  console.log(`  Inbox:           ${layout.inbox_dir}`);
+  console.log(`  Dream reports:   ${layout.reports_dir}`);
+}
+
+/**
+ * Adopt an existing vault in place as THE Wienerdog vault. Gated on a local
+ * (non-TCC) path and a git repo (so every night's memory writes are one commit
+ * that `git revert` can undo), confirms an inferred folder mapping, then points
+ * config at the vault, writes the layout, and seeds only MISSING mapped dirs —
+ * never overwriting the user's files. Reversible: adopted-vault artifacts are
+ * recorded under manifest kinds uninstall skips, so uninstall leaves the vault
+ * exactly as found.
+ * @param {string[]} argv
+ */
+async function run(argv) {
+  const dryRun = argv.includes('--dry-run');
+  const yes = argv.includes('--yes');
+  const rawPath = argv.find((a) => !a.startsWith('--'));
+
+  // 1. Parse args.
+  if (!rawPath) {
+    throw new WienerdogError('usage: wienerdog adopt <path> [--dry-run] [--yes]');
+  }
+
+  // 2. Require an existing install.
+  const paths = getPaths();
+  if (!fileExists(paths.config)) {
+    throw new WienerdogError('no Wienerdog install found — run `npx wienerdog init` first.');
+  }
+  const manifest = manifestLib.load(paths);
+
+  // 3. Path must be an existing directory.
+  const absPath = path.resolve(rawPath);
+  if (!dirExists(absPath)) {
+    throw new WienerdogError(`not a directory: ${absPath} — point adopt at an existing vault folder.`);
+  }
+  const adoptedPath = fs.realpathSync(absPath);
+
+  // 4. Refuse re-adoption (raw-text check keeps the config rewrite atomic).
+  const configText = fs.readFileSync(paths.config, 'utf8');
+  if (/^vault_layout:/m.test(configText)) {
+    throw new WienerdogError(
+      'this install already has a vault_layout; edit `config.yaml` or reinstall to re-adopt.'
+    );
+  }
+
+  // 5. TCC / local-disk check (macOS only; off-darwin always ok).
+  const tcc = tccguard.guard([adoptedPath], paths.home);
+  if (!tcc.ok) {
+    throw new WienerdogError(
+      `that folder is inside ${tcc.prefix}, a macOS-protected location (${tcc.offending}).\n` +
+        'Unattended nightly jobs hang forever on the permission prompt those folders trigger.\n' +
+        'Move the vault to a plain folder in your home directory (e.g. ~/notes) and try again,\n' +
+        'or use guided import (`wienerdog init`) to copy it into a fresh vault instead.'
+    );
+  }
+
+  // 6. Git prerequisite — the whole revert-safety guarantee rests on it.
+  const alreadyRepo = isGitRepo(adoptedPath);
+  if (!alreadyRepo) {
+    console.log(
+      '\nThis folder is not yet tracked by git.\n' +
+        'Wienerdog needs git so a night of auto-written memory is one commit you can undo\n' +
+        'with a single `git revert`. Without it, adopted memory would not be recoverable.'
+    );
+    if (dryRun) {
+      console.log('(--dry-run: would initialize a git repository and take an initial snapshot here.)');
+    } else {
+      const okGit = yes || (await confirm('Initialize a git repository here and take an initial snapshot? [y/N] '));
+      if (!okGit) {
+        throw new WienerdogError('adoption needs a git repo; aborted.');
+      }
+      const init = git(adoptedPath, ['init']);
+      if (init.error || init.status !== 0) {
+        throw new WienerdogError('failed to run `git init` — is git installed?');
+      }
+      git(adoptedPath, ['add', '-A']);
+      const commit = git(adoptedPath, [
+        '-c',
+        'user.name=wienerdog',
+        '-c',
+        'user.email=wienerdog@localhost',
+        'commit',
+        // --allow-empty so an initial snapshot always exists (giving `git revert`
+        // a HEAD to undo the first dream against) even if the vault has no
+        // committable content yet.
+        '--allow-empty',
+        '-m',
+        'wienerdog: adopt — initial snapshot',
+      ]);
+      if (commit.error || commit.status !== 0) {
+        throw new WienerdogError('failed to take the initial git snapshot.');
+      }
+    }
+  }
+
+  // 7. Infer + confirm layout.
+  const layout = inferLayout(adoptedPath);
+  printLayout(layout);
+  if (!dryRun && !yes) {
+    const okLayout = await confirm('\nUse this folder mapping? [y/N] ');
+    if (!okLayout) {
+      throw new WienerdogError(
+        'layout not confirmed; aborted — re-run and confirm, or edit config.yaml after adopting.'
+      );
+    }
+  }
+
+  // 8. --dry-run stop point: report the scaffold plan, make no writes.
+  if (dryRun) {
+    const plan = scaffoldMappedDirs(adoptedPath, layout, { dryRun: true });
+    console.log('\nWould create these missing folders:');
+    if (plan.createdDirs.length === 0) console.log('  (none — all mapped folders already exist)');
+    for (const d of plan.createdDirs) console.log(`  ${d}`);
+    if (plan.seededFiles.length > 0) {
+      console.log('Would seed identity starter notes:');
+      for (const f of plan.seededFiles) console.log(`  ${f}`);
+    }
+    console.log('\n--dry-run: no changes made.');
+    return;
+  }
+
+  // 9. Write config: point vault at the adopted path, set conservative mode,
+  //    append the confirmed vault_layout block. Keep the manifest hash in sync.
+  let updated = configText;
+  updated = updated.replace(/^vault:.*$/m, `vault: ${adoptedPath}`);
+  updated = updated.replace(
+    /^memory_mode:.*$/m,
+    'memory_mode: conservative  # set by adopt — strict gates for the first week'
+  );
+  if (!updated.endsWith('\n')) updated += '\n';
+  updated += renderLayoutBlock(layout);
+  fs.writeFileSync(paths.config, updated);
+  const configEntry = manifest.entries.find((e) => e.kind === 'file' && e.path === paths.config);
+  if (configEntry) configEntry.hash = sha256(updated);
+
+  // 10. Scaffold only the missing mapped dirs (never overwrites existing files).
+  const { createdDirs, seededFiles } = scaffoldMappedDirs(adoptedPath, layout, { manifest });
+
+  // 11. Persist the manifest.
+  manifestLib.save(paths, manifest);
+
+  // 12. Next steps.
+  console.log('\nwienerdog: adoption complete.');
+  console.log(`  Vault:        ${adoptedPath}`);
+  console.log(`  Memory mode:  conservative (strict gates for your first week)`);
+  console.log(`  Folders made: ${createdDirs.length}, starter notes seeded: ${seededFiles.length}`);
+  console.log(`\nThe default vault at ${paths.vault} is now unused — you can delete it if you like.`);
+  console.log('Run `wienerdog sync` to render your session digest from this vault.');
+}
+
+module.exports = { run };

--- a/src/cli/adopt.js
+++ b/src/cli/adopt.js
@@ -144,7 +144,11 @@ async function run(argv) {
   }
 
   // 5. TCC / local-disk check (macOS only; off-darwin always ok).
-  const tcc = tccguard.guard([adoptedPath], paths.home);
+  // Symlink-domain rule (spec, binding): guard compares via path.relative, so
+  // both sides must be in the same symlink-resolution domain. adoptedPath is
+  // already realpath'd above; a RAW home against it makes path.relative yield
+  // `../…` under any symlinked home component and the guard fails OPEN.
+  const tcc = tccguard.guard([adoptedPath], fs.realpathSync(paths.home));
   if (!tcc.ok) {
     throw new WienerdogError(
       `that folder is inside ${tcc.prefix}, a macOS-protected location (${tcc.offending}).\n` +

--- a/src/core/layout-infer.js
+++ b/src/core/layout-infer.js
@@ -31,7 +31,25 @@ function topLevelDirs(dir) {
 }
 
 /**
- * First top-level dir name whose lowercased form contains keyword, else fallback.
+ * True when a value is a safe vault-relative path. Copied from layout.js's
+ * private isSafeRelativePath (not exported; layout.js may not be modified) —
+ * same rules: rejects empty, absolute, any `..` segment, or a backslash.
+ * @param {string} value
+ * @returns {boolean}
+ */
+function isSafeRelativePath(value) {
+  if (value === '') return false;
+  if (path.isAbsolute(value) || value[0] === '/') return false;
+  if (value.includes('\\')) return false;
+  if (value.split('/').includes('..')) return false;
+  return true;
+}
+
+/**
+ * First top-level dir name whose lowercased form contains keyword (trimmed),
+ * else fallback. Trimming keeps the proposal in the same domain readVaultLayout
+ * round-trips through (its parser trims values), so config and scaffold agree
+ * on ONE directory even for a folder named with surrounding whitespace.
  * @param {string[]} dirs   top-level dir names
  * @param {string} keyword  lowercase substring to match
  * @param {string} fallback default when nothing matches
@@ -39,7 +57,7 @@ function topLevelDirs(dir) {
  */
 function pick(dirs, keyword, fallback) {
   const hit = dirs.find((d) => d.toLowerCase().includes(keyword));
-  return hit || fallback;
+  return hit ? hit.trim() : fallback;
 }
 
 /**
@@ -100,7 +118,17 @@ function inferLayout(vaultDir) {
     layout.reports_dir = 'reports/dreams';
   } else {
     const reportsTop = dirs.find((d) => d.toLowerCase().includes('reports'));
-    layout.reports_dir = reportsTop ? path.posix.join(reportsTop, 'dreams') : 'reports/dreams';
+    layout.reports_dir = reportsTop ? path.posix.join(reportsTop.trim(), 'dreams') : 'reports/dreams';
+  }
+
+  // inferLayout hygiene (spec, binding): every emitted proposal is trim()ed and
+  // explicitly validated with isSafeRelativePath — validation, not
+  // safety-by-construction. An unsafe proposal falls back to the built-in
+  // default for that key (same per-key rule readVaultLayout applies on read).
+  const defaults = defaultLayout();
+  for (const key of Object.keys(defaults)) {
+    const value = String(layout[key]).trim();
+    layout[key] = isSafeRelativePath(value) ? value : defaults[key];
   }
 
   return layout;

--- a/src/core/layout-infer.js
+++ b/src/core/layout-infer.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { defaultLayout } = require('./layout');
+
+/** @param {string} p @returns {boolean} */
+function dirExists(p) {
+  try {
+    return fs.statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * List the immediate subdirectory names of dir (sorted). Missing/unreadable → [].
+ * @param {string} dir
+ * @returns {string[]}
+ */
+function topLevelDirs(dir) {
+  try {
+    return fs
+      .readdirSync(dir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort((a, b) => a.localeCompare(b));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * First top-level dir name whose lowercased form contains keyword, else fallback.
+ * @param {string[]} dirs   top-level dir names
+ * @param {string} keyword  lowercase substring to match
+ * @param {string} fallback default when nothing matches
+ * @returns {string}
+ */
+function pick(dirs, keyword, fallback) {
+  const hit = dirs.find((d) => d.toLowerCase().includes(keyword));
+  return hit || fallback;
+}
+
+/**
+ * Probe a daily dir for its filename pattern. Direct `YYYY-MM-DD.md` files →
+ * flat; a `\d{4}/\d{2}/YYYY-MM-DD.md` nesting → nested; else flat default.
+ * @param {string} dailyAbs  absolute path to the chosen daily dir
+ * @returns {string} 'YYYY-MM-DD.md' | 'YYYY/MM/YYYY-MM-DD.md'
+ */
+function probeDailyFilename(dailyAbs) {
+  const flat = 'YYYY-MM-DD.md';
+  const nested = 'YYYY/MM/YYYY-MM-DD.md';
+  if (!dirExists(dailyAbs)) return flat;
+
+  const dateFile = /^\d{4}-\d{2}-\d{2}\.md$/;
+  const entries = fs.readdirSync(dailyAbs, { withFileTypes: true });
+
+  // Flat: a YYYY-MM-DD.md sitting directly in the daily dir.
+  if (entries.some((e) => e.isFile() && dateFile.test(e.name))) return flat;
+
+  // Nested: <YYYY>/<MM>/YYYY-MM-DD.md.
+  const yearDirs = entries.filter((e) => e.isDirectory() && /^\d{4}$/.test(e.name));
+  for (const y of yearDirs) {
+    const yAbs = path.join(dailyAbs, y.name);
+    for (const m of fs.readdirSync(yAbs, { withFileTypes: true })) {
+      if (!m.isDirectory() || !/^\d{2}$/.test(m.name)) continue;
+      const mAbs = path.join(yAbs, m.name);
+      const hasDate = fs
+        .readdirSync(mAbs, { withFileTypes: true })
+        .some((f) => f.isFile() && dateFile.test(f.name));
+      if (hasDate) return nested;
+    }
+  }
+  return flat;
+}
+
+/**
+ * Infer a vault_layout from an existing vault's real structure. Pure, read-only,
+ * deterministic. For each slot, pick the first EXISTING top-level directory whose
+ * name contains the keyword (case-insensitive); otherwise the default. Detect daily
+ * nesting by probing the chosen daily dir. All returned paths use POSIX `/`.
+ * @param {string} vaultDir
+ * @returns {import('./layout').VaultLayout}
+ */
+function inferLayout(vaultDir) {
+  const layout = defaultLayout();
+  const dirs = topLevelDirs(vaultDir);
+
+  layout.identity_dir = pick(dirs, 'identity', layout.identity_dir);
+  layout.projects_dir = pick(dirs, 'projects', layout.projects_dir);
+  layout.skills_dir = pick(dirs, 'skills', layout.skills_dir);
+  layout.inbox_dir = pick(dirs, 'inbox', layout.inbox_dir);
+  layout.daily_dir = pick(dirs, 'daily', layout.daily_dir);
+
+  layout.daily_filename = probeDailyFilename(path.join(vaultDir, layout.daily_dir));
+
+  // reports_dir: prefer an existing reports/dreams; else <top-level *reports*>/dreams.
+  if (dirExists(path.join(vaultDir, 'reports', 'dreams'))) {
+    layout.reports_dir = 'reports/dreams';
+  } else {
+    const reportsTop = dirs.find((d) => d.toLowerCase().includes('reports'));
+    layout.reports_dir = reportsTop ? path.posix.join(reportsTop, 'dreams') : 'reports/dreams';
+  }
+
+  return layout;
+}
+
+module.exports = { inferLayout };

--- a/src/core/vault.js
+++ b/src/core/vault.js
@@ -129,4 +129,78 @@ async function scaffoldVault(targetDir, opts = {}) {
   return { created, skipped };
 }
 
-module.exports = { scaffoldVault };
+/** The four identity stub templates seeded into an empty identity dir. */
+const IDENTITY_STUBS = ['profile.md', 'preferences.md', 'goals.md', 'instructions.md'];
+
+/**
+ * Fill ONLY the missing mapped directories of an adopted vault, without laying down
+ * the full default template and WITHOUT git-init (adoption handles git separately).
+ * Existing files are never touched. Manifest entries use kinds `uninstall` skips
+ * (vault-dir / vault-file), so the adopted vault is never removed on uninstall.
+ * @param {string} targetDir  the adopted vault
+ * @param {import('./layout').VaultLayout} layout
+ * @param {{dryRun?: boolean, manifest?: object}} [opts]
+ * @returns {{createdDirs: string[], seededFiles: string[], skipped: string[]}}
+ */
+function scaffoldMappedDirs(targetDir, layout, opts = {}) {
+  const { dryRun = false, manifest } = opts;
+  const date = today();
+
+  /** @type {string[]} */ const createdDirs = [];
+  /** @type {string[]} */ const seededFiles = [];
+  /** @type {string[]} */ const skipped = [];
+
+  const mappedDirs = [
+    layout.identity_dir,
+    layout.daily_dir,
+    layout.projects_dir,
+    layout.inbox_dir,
+    layout.skills_dir,
+    layout.reports_dir,
+  ];
+
+  for (const rel of mappedDirs) {
+    const abs = path.join(targetDir, rel);
+    if (fs.existsSync(abs)) {
+      skipped.push(abs);
+      continue;
+    }
+    if (!dryRun) {
+      fs.mkdirSync(abs, { recursive: true });
+      if (manifest) manifestLib.record(manifest, { kind: 'vault-dir', path: abs });
+    }
+    createdDirs.push(abs);
+  }
+
+  // Seed identity stubs ONLY IF the mapped identity dir contains no *.md file —
+  // a real adopted vault keeps its own identity notes untouched.
+  const identityAbs = path.join(targetDir, layout.identity_dir);
+  const hasIdentityNotes = () => {
+    try {
+      return fs.readdirSync(identityAbs).some((name) => name.toLowerCase().endsWith('.md'));
+    } catch {
+      return false;
+    }
+  };
+  if (!hasIdentityNotes()) {
+    for (const name of IDENTITY_STUBS) {
+      const destPath = path.join(identityAbs, name);
+      if (fs.existsSync(destPath)) {
+        skipped.push(destPath);
+        continue;
+      }
+      if (!dryRun) {
+        const srcPath = path.join(TEMPLATE_ROOT, '06-Identity', name);
+        const content = fs.readFileSync(srcPath, 'utf8').replaceAll('{{DATE}}', date);
+        fs.mkdirSync(path.dirname(destPath), { recursive: true });
+        fs.writeFileSync(destPath, content);
+        if (manifest) manifestLib.record(manifest, { kind: 'vault-file', path: destPath });
+      }
+      seededFiles.push(destPath);
+    }
+  }
+
+  return { createdDirs, seededFiles, skipped };
+}
+
+module.exports = { scaffoldVault, scaffoldMappedDirs };

--- a/tests/fixtures/adopt/fake-brain-mapped.js
+++ b/tests/fixtures/adopt/fake-brain-mapped.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+'use strict';
+
+// Controlled stand-in for the real dream brain, for the WP-026 adoption e2e.
+// The dream pipeline runs it via WIENERDOG_DREAM_CMD. Unlike the default fake
+// brain (which writes hardcoded default-layout paths), this one reads the vault
+// LAYOUT from WIENERDOG_DREAM_LAYOUT (JSON that WP-024's spawnBrain sets, with a
+// `daily_today` = the resolved nested daily path) and writes through the MAPPED
+// tiers of an adopted, non-default-layout vault. Must be directly executable.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const vault = process.env.WIENERDOG_DREAM_VAULT;
+const date = process.env.WIENERDOG_FAKE_TODAY || '2026-07-02';
+const layout = JSON.parse(process.env.WIENERDOG_DREAM_LAYOUT || '{}');
+
+/** @param {string} rel @param {string} content */
+function write(rel, content) {
+  const full = path.join(vault, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+// 1. Valid Tier-3 identity note through the MAPPED identity dir — satisfies the
+//    confidence/recurrence floor and is not untrusted; must survive the gate.
+write(
+  path.join(layout.identity_dir, 'adopted-fact.md'),
+  ['---', 'confidence: 0.9', 'recurrence: 3', 'derived_from_untrusted: false', '---', '', 'Priya bills clients by the report.', ''].join('\n')
+);
+
+// 2. Tier-1 daily entry at the resolved (nested) daily path; create parents.
+write(
+  layout.daily_today,
+  ['---', 'type: daily', 'derived_from_untrusted: false', '---', '', `# ${date}`, '', 'Dreamed over recent sessions.', ''].join('\n')
+);
+
+// 3. Dream report through the MAPPED reports dir.
+write(path.join(layout.reports_dir, `${date}.md`), `# Dream report — ${date}\n\nConsolidated recent sessions.\n`);
+
+process.exit(0);

--- a/tests/integration/adopt-e2e.test.js
+++ b/tests/integration/adopt-e2e.test.js
@@ -1,0 +1,141 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const init = require('../../src/cli/init');
+const adopt = require('../../src/cli/adopt');
+const sync = require('../../src/cli/sync');
+const dream = require('../../src/cli/dream');
+const { readVaultLayout } = require('../../src/core/layout');
+
+const POWERUSER_FIXTURE = path.resolve(__dirname, '../fixtures/poweruser-vault');
+const FAKE_BRAIN = path.resolve(__dirname, '../fixtures/adopt/fake-brain-mapped.js');
+const INJ_FIXTURE = path.resolve(__dirname, '../fixtures/dream/transcripts/claude-injection.jsonl');
+const DATE = '2026-07-03';
+
+const ENV_KEYS = [
+  'HOME',
+  'WIENERDOG_HOME',
+  'WIENERDOG_VAULT',
+  'CLAUDE_CONFIG_DIR',
+  'CODEX_HOME',
+  'WIENERDOG_FAKE_TODAY',
+  'WIENERDOG_DREAM_CMD',
+];
+
+/** @param {string} cwd @param {string[]} args */
+function git(cwd, args) {
+  return execFileSync('git', ['-C', cwd, ...args], { encoding: 'utf8' });
+}
+
+/** @param {string} vault @returns {number} number of commits on HEAD. */
+function commitCount(vault) {
+  return Number(git(vault, ['rev-list', '--count', 'HEAD']).trim());
+}
+
+test('adopt-e2e: init → adopt → sync → dream through mapped tiers, one revertable commit', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-adopt-e2e-'));
+  const adopted = path.join(root, 'adopted');
+  const home = path.join(root, 'home');
+  const core = path.join(root, 'core');
+  const defaultVault = path.join(root, 'default-vault');
+  const claude = path.join(root, 'claude');
+  const codex = path.join(root, 'codex-absent');
+
+  const saved = {};
+  for (const k of ENV_KEYS) saved[k] = process.env[k];
+
+  const origLog = console.log;
+  console.log = () => {};
+
+  try {
+    // 1. Copy the (non-git) power-user vault to a temp dir we will adopt.
+    fs.cpSync(POWERUSER_FIXTURE, adopted, { recursive: true });
+    // adopt realpath-resolves the path (macOS /var → /private/var); config stores that form.
+    const adoptedReal = fs.realpathSync(adopted);
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(core, { recursive: true });
+    // A transcript so the dream pipeline has input (the fake brain ignores it).
+    const projDir = path.join(claude, 'projects', 'proj');
+    fs.mkdirSync(projDir, { recursive: true });
+    fs.copyFileSync(INJ_FIXTURE, path.join(projDir, 'inj.jsonl'));
+
+    // 2. Apply env.
+    Object.assign(process.env, {
+      HOME: home,
+      WIENERDOG_HOME: core,
+      WIENERDOG_VAULT: defaultVault,
+      CLAUDE_CONFIG_DIR: claude,
+      CODEX_HOME: codex,
+      WIENERDOG_FAKE_TODAY: DATE,
+      WIENERDOG_DREAM_CMD: FAKE_BRAIN,
+    });
+
+    const configPath = path.join(core, 'config.yaml');
+
+    // 3. init → default vault + config.
+    await init.run(['--yes']);
+    assert.ok(fs.existsSync(configPath), 'config.yaml written by init');
+
+    // 4. adopt the power-user vault.
+    await adopt.run([adopted, '--yes']);
+
+    // 4a. The adopted dir is now a git repo with ≥1 commit.
+    assert.ok(fs.existsSync(path.join(adopted, '.git')), 'adopted dir is a git repo');
+    assert.ok(commitCount(adopted) >= 1, 'adopted dir has an initial commit');
+
+    // 4b. Config points at the adopted vault, with the nested layout + conservative mode.
+    const cfg = fs.readFileSync(configPath, 'utf8');
+    assert.match(cfg, new RegExp(`^vault: ${adoptedReal}$`, 'm'));
+    assert.match(cfg, /^memory_mode: conservative\b/m);
+    const layout = readVaultLayout(configPath);
+    assert.equal(layout.daily_dir, '05-Daily');
+    assert.equal(layout.daily_filename, 'YYYY/MM/YYYY-MM-DD.md');
+    assert.equal(layout.identity_dir, '06-Identity');
+
+    // 4c. Manifest config hash resynced (no spurious "modified since install").
+    const manifest = JSON.parse(fs.readFileSync(path.join(core, 'install-manifest.json'), 'utf8'));
+    const cfgEntry = manifest.entries.find((e) => e.kind === 'file' && e.path === configPath);
+    const crypto = require('node:crypto');
+    assert.equal(cfgEntry.hash, crypto.createHash('sha256').update(cfg).digest('hex'));
+
+    // 4d. The user's own identity notes were NOT overwritten and no stubs seeded
+    //     (identity dir already had notes).
+    assert.match(fs.readFileSync(path.join(adopted, '06-Identity/profile.md'), 'utf8'), /Priya Nair/);
+
+    // 5. sync → digest rendered from the REAL identity notes + nested daily.
+    await sync.run([]);
+    const digest = fs.readFileSync(path.join(core, 'state', 'digest.md'), 'utf8');
+    assert.match(digest, /Priya Nair/, 'digest reflects the real identity profile');
+    assert.match(digest, /Interviewed two coastal-town planners/, 'digest reflects the nested daily Summary');
+
+    // 6. dream → writes through the mapped tiers, exactly one new commit.
+    const before = commitCount(adopted);
+    await dream.run(['--yes']);
+    assert.equal(commitCount(adopted), before + 1, 'exactly one dream commit');
+
+    const tracked = git(adopted, ['ls-files']);
+    assert.ok(tracked.includes('06-Identity/adopted-fact.md'), 'mapped Tier-3 identity note committed');
+    assert.ok(tracked.includes('05-Daily/2026/07/2026-07-03.md'), 'mapped Tier-1 nested daily committed');
+    assert.ok(fs.existsSync(path.join(adopted, 'reports/dreams', `${DATE}.md`)), 'mapped report exists');
+
+    // 7. git revert cleanly undoes the whole dream run.
+    const sha = git(adopted, ['rev-parse', 'HEAD']).trim();
+    git(adopted, ['revert', '--no-edit', sha]);
+    assert.equal(fs.existsSync(path.join(adopted, '06-Identity/adopted-fact.md')), false);
+    assert.equal(fs.existsSync(path.join(adopted, '05-Daily/2026/07/2026-07-03.md')), false);
+    assert.equal(git(adopted, ['status', '--porcelain']).trim(), '', 'working tree clean after revert');
+  } finally {
+    console.log = origLog;
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/integration/adopt-e2e.test.js
+++ b/tests/integration/adopt-e2e.test.js
@@ -139,3 +139,53 @@ test('adopt-e2e: init → adopt → sync → dream through mapped tiers, one rev
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+test(
+  'adopt-e2e: symlinked home — TCC guard refuses a Documents vault with zero writes',
+  { skip: process.platform !== 'darwin' && 'TCC is macOS-only' },
+  async () => {
+    // macOS /tmp is a symlink to /private/tmp: a HOME under /tmp is in a
+    // different symlink domain than the realpath'd adopted path, which is
+    // exactly the asymmetry that made the guard fail OPEN (PR #26 review).
+    const base = path.join('/tmp', `wd-adopt-tcc-${process.pid}-${Date.now()}`);
+    const home = path.join(base, 'home'); // raw, symlinked-domain HOME
+    const core = path.join(base, 'core');
+    const vault = path.join(home, 'Documents', 'myvault');
+
+    const saved = {};
+    for (const k of ENV_KEYS) saved[k] = process.env[k];
+
+    try {
+      fs.mkdirSync(vault, { recursive: true });
+      fs.mkdirSync(core, { recursive: true });
+      fs.writeFileSync(path.join(vault, 'note.md'), '# my note\n');
+      const configPath = path.join(core, 'config.yaml');
+      const configBefore = 'version: 1\nvault: null\nmemory_mode: standard  # conservative | standard | eager\n';
+      fs.writeFileSync(configPath, configBefore);
+      fs.writeFileSync(
+        path.join(core, 'install-manifest.json'),
+        JSON.stringify({ version: 1, createdAt: 'x', entries: [{ kind: 'file', path: configPath, hash: 'x' }] })
+      );
+
+      Object.assign(process.env, { HOME: home, WIENERDOG_HOME: core });
+      for (const k of ['WIENERDOG_VAULT', 'CLAUDE_CONFIG_DIR', 'CODEX_HOME']) delete process.env[k];
+
+      await assert.rejects(
+        () => adopt.run([vault, '--yes']),
+        /macOS-protected location/,
+        'adopt must refuse a Documents vault even under a symlinked home'
+      );
+
+      // Zero writes: config untouched, vault untouched (no git init, no scaffold).
+      assert.equal(fs.readFileSync(configPath, 'utf8'), configBefore, 'config unchanged');
+      assert.deepEqual(fs.readdirSync(vault).sort(), ['note.md'], 'vault dir unchanged');
+      assert.equal(fs.existsSync(path.join(vault, '.git')), false, 'no git init');
+    } finally {
+      for (const k of ENV_KEYS) {
+        if (saved[k] === undefined) delete process.env[k];
+        else process.env[k] = saved[k];
+      }
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  }
+);

--- a/tests/unit/layout-infer.test.js
+++ b/tests/unit/layout-infer.test.js
@@ -7,6 +7,8 @@ const os = require('node:os');
 const path = require('node:path');
 
 const { inferLayout } = require('../../src/core/layout-infer');
+const { readVaultLayout } = require('../../src/core/layout');
+const { scaffoldMappedDirs } = require('../../src/core/vault');
 
 const POWERUSER_FIXTURE = path.resolve(__dirname, '../fixtures/poweruser-vault');
 
@@ -30,6 +32,34 @@ test('layout-infer: a flat daily dir yields a flat filename and the matched dir 
     const layout = inferLayout(root);
     assert.equal(layout.daily_dir, 'Daily');
     assert.equal(layout.daily_filename, 'YYYY-MM-DD.md');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('layout-infer: a whitespace-named folder is trimmed and round-trips config → scaffold to ONE dir', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-infer-ws-'));
+  try {
+    // A folder named with surrounding whitespace that matches the inbox keyword.
+    fs.mkdirSync(path.join(root, '  Inbox  '), { recursive: true });
+
+    // The proposal is trimmed and explicitly validated.
+    const layout = inferLayout(root);
+    assert.equal(layout.inbox_dir, 'Inbox');
+
+    // Round-trip: write the proposal into a vault_layout block, read it back.
+    const configPath = path.join(root, 'config.yaml');
+    fs.writeFileSync(
+      configPath,
+      ['vault_layout:', `  inbox_dir: ${layout.inbox_dir}`, ''].join('\n')
+    );
+    const roundTripped = readVaultLayout(configPath);
+    assert.equal(roundTripped.inbox_dir, layout.inbox_dir);
+
+    // scaffoldMappedDirs, driven by the same proposal, creates that same dir —
+    // config and scaffold agree on ONE directory.
+    scaffoldMappedDirs(root, layout, {});
+    assert.ok(fs.statSync(path.join(root, roundTripped.inbox_dir)).isDirectory());
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/tests/unit/layout-infer.test.js
+++ b/tests/unit/layout-infer.test.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { inferLayout } = require('../../src/core/layout-infer');
+
+const POWERUSER_FIXTURE = path.resolve(__dirname, '../fixtures/poweruser-vault');
+
+test('layout-infer: power-user fixture yields the nested-daily mapping', () => {
+  const layout = inferLayout(POWERUSER_FIXTURE);
+  assert.equal(layout.identity_dir, '06-Identity');
+  assert.equal(layout.daily_dir, '05-Daily');
+  assert.equal(layout.daily_filename, 'YYYY/MM/YYYY-MM-DD.md');
+  assert.equal(layout.projects_dir, '01-Projects');
+  // The fixture has no skills dir → default.
+  assert.equal(layout.skills_dir, '05-Skills');
+  assert.equal(layout.inbox_dir, '00-Inbox');
+  assert.equal(layout.reports_dir, 'reports/dreams');
+});
+
+test('layout-infer: a flat daily dir yields a flat filename and the matched dir name', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-infer-'));
+  try {
+    fs.mkdirSync(path.join(root, 'Daily'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'Daily', '2026-07-03.md'), '# today\n');
+    const layout = inferLayout(root);
+    assert.equal(layout.daily_dir, 'Daily');
+    assert.equal(layout.daily_filename, 'YYYY-MM-DD.md');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Spec: docs/specs/WP-026-full-adoption-flow.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

Files: `src/cli/adopt.js` (create), `src/core/layout-infer.js` (create),
`src/core/vault.js` (modify — `scaffoldMappedDirs`), `bin/wienerdog.js` (modify),
`tests/unit/layout-infer.test.js` (create),
`tests/fixtures/adopt/fake-brain-mapped.js` (create),
`tests/integration/adopt-e2e.test.js` (create). Plus the DoD-mandated
`status:` flip in the spec.

## Verification output

```
$ npm test -- --test-name-pattern layout-infer
# (both layout-infer unit tests pass)

$ npm test -- --test-name-pattern adopt-e2e
# adopt-e2e integration test passes

$ npm test
ℹ tests 275
ℹ pass 275
ℹ fail 0
ℹ duration_ms ~4744

$ npm run lint
--- markdownlint ---  Summary: 0 error(s)
--- shellcheck ---
--- frontmatter check ---  frontmatter check passed: 4 spec(s), 4 agent(s)
lint passed
```

Additionally smoke-tested (not in the automated suite): TCC-guard refusal
(Documents flagged), `--dry-run` leaves config untouched, re-adoption refused
cleanly, and an empty non-git dir gets an initial commit.

## Decisions made

- **`--allow-empty` on the initial adopt snapshot.** An adopted dir with no
  committable content (empty, or all-ignored) would make `git commit` fail with
  "nothing to commit", aborting adoption. Adoption always needs a HEAD for the
  revert-safety guarantee, so the initial snapshot commit uses `--allow-empty`.
  Real mature vaults have content; this only hardens the empty edge case.
- **`--dry-run` and `--yes` are non-interactive.** With `--dry-run` (even
  without `--yes`) `adopt` never prompts — it reports whether git-init would be
  offered and prints the scaffold plan, then stops before any write. Simpler and
  matches "prints the plan and stops before any write."
- **TCC = macOS-only, no bespoke mount check** (per spec): `tccguard.guard`
  returns `ok:true` off darwin; "not TCC-protected" is v1's definition of an
  acceptable local path.
- **Realpath then existence check ordering:** resolve to absolute, verify the
  dir exists, then `realpathSync` (so a missing path yields a clean
  "not a directory" error rather than a realpath throw). The e2e compares the
  config `vault:` against the realpath'd form (macOS `/var`→`/private/var`).

## Discovered issues (out of scope, not fixed)

none

---
Generated-by: claude-opus-4-8
