### PR TITLE
feat(install): defer vault creation until path is chosen (WP-027)

### DIFF
--- a/docs/specs/ROADMAP.md
+++ b/docs/specs/ROADMAP.md
@@ -45,7 +45,7 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 | [WP-024](done/WP-024-layout-aware-dream.md) | Layout-aware dream write path (validate tiers, brain prompt, skill) | M3 | opus | Done | WP-022 |
 | [WP-025](done/WP-025-guided-import.md) | Guided import from an existing vault (setup skill step 3) | M2 | sonnet | Done | WP-022 |
 | [WP-026](done/WP-026-full-adoption-flow.md) | Full vault adoption — `wienerdog adopt` CLI, prerequisites, layout mapping | M2/M3 | opus | Done | WP-024, WP-025 |
-| [WP-027](WP-027-defer-vault-creation.md) | Defer vault creation until the vault path is chosen (init `--fresh-vault`) | M2/M3 | opus | Ready | WP-026 |
+| [WP-027](WP-027-defer-vault-creation.md) | Defer vault creation until the vault path is chosen (init `--fresh-vault`) | M2/M3 | opus | In-Review | WP-026 |
 
 ## Dependency graph
 

--- a/docs/specs/WP-027-defer-vault-creation.md
+++ b/docs/specs/WP-027-defer-vault-creation.md
@@ -102,6 +102,9 @@ Tests that touch this area:
   `tests/integration/dream.test.js` — none assert the default vault exists after
   `init`; they build their own vaults or only check `config.yaml`. They keep
   passing.
+- `tests/unit/codex-adapter.test.js` — its integration test does
+  `init` → drop identity → `sync`, which now exits 1 on `vault: null`. Its init
+  call gains `--fresh-vault` (in Deliverables above). No assertions change.
 - `tests/unit/setup-skill-structure.test.js` — string-presence checks on the
   setup skill; must keep passing (all asserted substrings are preserved) plus a
   new assertion for the `--fresh-vault` command.
@@ -122,6 +125,7 @@ Tests that touch this area:
 | modify | tests/unit/init.test.js | add deferred-vault + `--fresh-vault` coverage |
 | create | tests/unit/doctor.test.js | cover the three vault-check states |
 | modify | tests/unit/setup-skill-structure.test.js | assert the skill references `wienerdog init --fresh-vault` |
+| modify | tests/unit/codex-adapter.test.js | its init→drop-identity→sync integration test needs a vault for the sync leg; change its init call to `--fresh-vault` (test-census gap, no assertions changed) |
 
 **Explicitly NOT touched (and why):** `src/core/vault.js` (`scaffoldVault`
 unchanged), `tests/unit/vault.test.js`, `tests/golden/vault-default/**` (golden

--- a/docs/specs/WP-027-defer-vault-creation.md
+++ b/docs/specs/WP-027-defer-vault-creation.md
@@ -1,7 +1,7 @@
 ---
 id: WP-027
 title: Defer vault creation until the vault path is chosen
-status: Ready
+status: In-Review
 model: opus
 size: M
 depends_on: [WP-026]

--- a/skills/wienerdog-setup/SKILL.md
+++ b/skills/wienerdog-setup/SKILL.md
@@ -26,6 +26,10 @@ in plain language. This is a conversation, not a form.
 
 First, find the vault path (see Step 1) and open `06-Identity/profile.md`.
 
+If there is no vault yet — the `vault:` line is empty or `null`, or the folder
+does not exist — this is always a first-time setup. Skip the `profile.md` peek
+and go straight to Step 1, then Step 3, where the vault gets created or chosen.
+
 - **If it still looks like an empty template** (headings like `## Role` with
   nothing written under them), this is a first-time setup. Go to Step 1 and do
   the full interview.
@@ -44,9 +48,14 @@ First, find the vault path (see Step 1) and open `06-Identity/profile.md`.
 Read `~/.wienerdog/config.yaml` and look at the `vault:` line — that is the
 folder where their notes live.
 
-Check that the folder actually exists. If it does not (or the `vault:` line is
-empty), stop and tell them to run `npx wienerdog init` first, then start this
-skill again.
+- **If `config.yaml` itself is missing** → stop; tell them to run
+  `npx wienerdog init` first, then start this skill again.
+- **If the `vault:` line is empty or `null`, or the folder does not exist yet**
+  → this is normal right after install; they have not chosen a vault yet. Treat
+  it as a first-time setup and continue to Step 3, where you create or choose
+  the vault **before** writing any notes.
+- **If it points at an existing folder with real identity content** → this is
+  the settings-panel case; use the Step 0 menu.
 
 ## Step 2 — The interview
 
@@ -69,8 +78,10 @@ where it lives.
 
 If they do, offer them three choices in plain language:
 
-1. **Start fresh** — keep the new, empty vault and do nothing with the old
-   one. This is the default if they are not sure.
+1. **Start fresh** — create a brand-new, empty vault and do nothing with the
+   old one. This is the default if they are not sure. To create it, run
+   `wienerdog init --fresh-vault` in the terminal — that scaffolds the default
+   vault at `~/wienerdog`, records it in `config.yaml`, and puts it under git.
 2. **Import from it** — you read their old vault once, pull the useful facts
    about them into the new vault, and leave the old vault completely
    untouched. Best for most people who already have notes somewhere.
@@ -84,6 +95,9 @@ If they do, offer them three choices in plain language:
 
 **If they choose Import**, do the following:
 
+- First, run `wienerdog init --fresh-vault` in the terminal to create the fresh
+  vault the import will write into (it scaffolds `~/wienerdog`, records it in
+  `config.yaml`, and puts it under git).
 - Ask for the path to their existing vault. Read it **read-only**. You must
   **never move, copy wholesale, edit, or delete any file in their existing
   vault** — you only read it, and every write goes into the new vault
@@ -112,6 +126,10 @@ If they do, offer them three choices in plain language:
 the interview normally. Adoption's own folder-layout mapping and
 prerequisite checks are handled entirely by `wienerdog adopt`, so this skill
 never edits the old vault.
+
+Shelling out to `wienerdog init --fresh-vault` (like `wienerdog sync` in
+Step 6) is consistent with the "only write inside the vault and `config.yaml`"
+rule: that command writes only to the vault and `config.yaml`.
 
 ## Step 4 — How much should the AI remember?
 

--- a/src/cli/adopt.js
+++ b/src/cli/adopt.js
@@ -248,7 +248,9 @@ async function run(argv) {
   console.log(`  Vault:        ${adoptedPath}`);
   console.log(`  Memory mode:  conservative (strict gates for your first week)`);
   console.log(`  Folders made: ${createdDirs.length}, starter notes seeded: ${seededFiles.length}`);
-  console.log(`\nThe default vault at ${paths.vault} is now unused — you can delete it if you like.`);
+  if (dirExists(paths.vault)) {
+    console.log(`\nThe default vault at ${paths.vault} is now unused — you can delete it if you like.`);
+  }
   console.log('Run `wienerdog sync` to render your session digest from this vault.');
 }
 

--- a/src/cli/doctor.js
+++ b/src/cli/doctor.js
@@ -23,6 +23,20 @@ function fileExists(p) {
   }
 }
 
+/** @param {string} configPath @returns {string|null} configured vault path, or null. */
+function readVaultPath(configPath) {
+  let content;
+  try {
+    content = fs.readFileSync(configPath, 'utf8');
+  } catch {
+    return null;
+  }
+  const m = content.match(/^vault:[ \t]*(.*)$/m);
+  if (!m) return null;
+  const value = m[1].split('#')[0].trim();
+  return value === '' || value === 'null' ? null : value;
+}
+
 /**
  * Report on an existing install. Prints one `ok`/`warn`/`fail` line per check;
  * exits 1 (via process.exitCode) if any check fails.
@@ -59,6 +73,16 @@ async function run(_argv) {
     check('ok', 'config.yaml exists and is non-empty');
   } else {
     check('fail', `config.yaml missing or empty (${paths.config})`);
+  }
+
+  // Memory vault — unset is a valid just-installed state (warn, not fail).
+  const vaultPath = readVaultPath(paths.config);
+  if (vaultPath === null) {
+    check('warn', 'no memory vault yet — run /wienerdog-setup to create or choose one (this is normal right after install)');
+  } else if (dirExists(vaultPath)) {
+    check('ok', `vault ready (${vaultPath})`);
+  } else {
+    check('fail', `vault is set to ${vaultPath} but that folder is missing — run /wienerdog-setup, or 'wienerdog init --fresh-vault' for the default`);
   }
 
   // secrets directory permissions (skip on Windows).

--- a/src/cli/init.js
+++ b/src/cli/init.js
@@ -52,7 +52,7 @@ function readConfigVaultPath(configContent) {
 function renderConfig(harnesses) {
   return `# Wienerdog configuration — https://github.com/wienerdog-ai/wienerdog
 version: 1
-vault: null            # set by vault setup (WP-004)
+vault: null            # set by /wienerdog-setup or \`wienerdog adopt\`
 harnesses:
   claude: ${harnesses.claude.present}        # set true by init when detected
   codex: ${harnesses.codex.present}
@@ -84,6 +84,7 @@ function confirm(prompt) {
 async function run(argv) {
   const dryRun = argv.includes('--dry-run');
   const yes = argv.includes('--yes');
+  const freshVault = argv.includes('--fresh-vault');
   const paths = getPaths();
   const harnesses = detectHarnesses();
 
@@ -92,10 +93,12 @@ async function run(argv) {
   const missingDirs = dirs.filter((d) => !dirExists(d));
 
   const existingConfigContent = needConfig ? null : fs.readFileSync(paths.config, 'utf8');
-  const vaultNeeded = needConfig || isVaultNull(existingConfigContent);
-  const configuredVaultPath = (existingConfigContent && readConfigVaultPath(existingConfigContent)) || paths.vault;
+  // Scaffold the default vault ONLY under --fresh-vault, and only if the config
+  // does not already point at a vault (fresh machine, or config still `vault: null`).
+  const vaultStep = freshVault && (needConfig || isVaultNull(existingConfigContent));
+  const vaultConfigured = !needConfig && !isVaultNull(existingConfigContent);
 
-  if (missingDirs.length === 0 && !needConfig && !vaultNeeded) {
+  if (missingDirs.length === 0 && !needConfig && !vaultStep) {
     console.log('wienerdog: already installed, nothing to do.');
     return;
   }
@@ -106,9 +109,14 @@ async function run(argv) {
   console.log('\nFiles:');
   console.log(`  ${fileExists(paths.config) ? '[exists]' : '[create]'} ${paths.config}`);
   console.log('\nVault:');
-  console.log(
-    `  ${vaultNeeded ? '[create]' : dirExists(configuredVaultPath) ? '[exists]' : '[MISSING]'} ${configuredVaultPath}`
-  );
+  if (vaultStep) {
+    console.log(`  [create] ${paths.vault}`);
+  } else if (vaultConfigured) {
+    console.log(`  [configured] ${readConfigVaultPath(existingConfigContent)}`);
+  } else {
+    console.log('  [deferred] choose or create your vault with /wienerdog-setup');
+    console.log("             (or run 'wienerdog init --fresh-vault' for the default ~/wienerdog)");
+  }
   console.log('\nDetected AI tools:');
   console.log(`  Claude Code: ${harnesses.claude.present ? 'found' : 'not found'} (${harnesses.claude.dir})`);
   console.log(`  Codex CLI:   ${harnesses.codex.present ? 'found' : 'not found'} (${harnesses.codex.dir})`);
@@ -143,7 +151,7 @@ async function run(argv) {
     manifestLib.record(manifest, { kind: 'file', path: paths.config, hash: sha256(content) });
   }
 
-  if (vaultNeeded) {
+  if (vaultStep) {
     console.log(`\nVault: scaffolding ${paths.vault}`);
     const { created, skipped } = await scaffoldVault(paths.vault, { manifest });
     console.log(`  created ${created.length} file(s), skipped ${skipped.length} existing file(s)`);
@@ -154,12 +162,19 @@ async function run(argv) {
     // uninstall doesn't mistake it for a user edit and refuse to remove it.
     const configEntry = manifest.entries.find((e) => e.kind === 'file' && e.path === paths.config);
     if (configEntry) configEntry.hash = sha256(updatedConfig);
-  } else if (!dirExists(configuredVaultPath)) {
-    console.log(`\nwienerdog: configured vault ${configuredVaultPath} not found — skipping vault step.`);
   }
 
   manifestLib.save(paths, manifest);
-  console.log('\nwienerdog: installed. Run `wienerdog doctor` to check the setup.');
+  if (vaultStep) {
+    console.log('\nwienerdog: installed with a fresh vault. Run `wienerdog doctor` to check the setup.');
+  } else if (vaultConfigured) {
+    console.log('\nwienerdog: installed. Run `wienerdog doctor` to check the setup.');
+  } else {
+    console.log('\nwienerdog: core installed — no vault yet.');
+    console.log('Next: run /wienerdog-setup in Claude Code to create or choose your vault,');
+    console.log("or run 'wienerdog init --fresh-vault' for the default ~/wienerdog vault.");
+    console.log('Then run `wienerdog doctor` to check the setup.');
+  }
 }
 
 module.exports = { run };

--- a/src/cli/sync.js
+++ b/src/cli/sync.js
@@ -125,7 +125,10 @@ async function run(argv) {
   const paths = getPaths();
   const vaultPath = readVaultPath(paths.config);
   if (!vaultPath) {
-    throw new WienerdogError('no vault configured in config.yaml — run `npx wienerdog init` first.');
+    throw new WienerdogError(
+      'no vault set up yet — run /wienerdog-setup to create or choose your vault ' +
+        "(or 'wienerdog init --fresh-vault' for the default)."
+    );
   }
   let isDir = false;
   try {
@@ -134,7 +137,9 @@ async function run(argv) {
     isDir = false;
   }
   if (!isDir) {
-    throw new WienerdogError(`vault not found at ${vaultPath} — run \`npx wienerdog init\` first.`);
+    throw new WienerdogError(
+      `vault not found at ${vaultPath} — run /wienerdog-setup, or 'wienerdog init --fresh-vault' for the default.`
+    );
   }
 
   // 1. Render + write the digest atomically.

--- a/tests/unit/codex-adapter.test.js
+++ b/tests/unit/codex-adapter.test.js
@@ -229,8 +229,10 @@ test('Codex-only machine: full setup + working dream from rollout files alone', 
   const subprocessEnv = { ...process.env, HOME: home, WIENERDOG_HOME: core, WIENERDOG_VAULT: vault, CODEX_HOME: codexHome };
   delete subprocessEnv.CLAUDE_CONFIG_DIR;
 
-  // 1. `wienerdog init --yes` — Claude absent (no CLAUDE_CONFIG_DIR, no <home>/.claude), Codex present.
-  execFileSync('node', [bin, 'init', '--yes'], { env: subprocessEnv, encoding: 'utf8' });
+  // 1. `wienerdog init --fresh-vault --yes` — Claude absent (no CLAUDE_CONFIG_DIR, no
+  //    <home>/.claude), Codex present. --fresh-vault so a vault exists for sync (WP-027:
+  //    plain `init` now defers vault creation).
+  execFileSync('node', [bin, 'init', '--fresh-vault', '--yes'], { env: subprocessEnv, encoding: 'utf8' });
 
   // 2. Drop the WP-005 identity fixture into <vault>/06-Identity/.
   const identitySrc = path.join(repoRoot, 'tests', 'fixtures', 'identity-filled', '06-Identity');

--- a/tests/unit/doctor.test.js
+++ b/tests/unit/doctor.test.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const bin = path.join(repoRoot, 'bin', 'wienerdog.js');
+
+/** Build an isolated temp HOME with env overrides that never touch real dirs. */
+function tempEnv() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-doctor-'));
+  const core = path.join(root, 'wd');
+  return {
+    root,
+    core,
+    env: {
+      ...process.env,
+      WIENERDOG_HOME: core,
+      WIENERDOG_VAULT: path.join(root, 'vault'),
+      CLAUDE_CONFIG_DIR: path.join(root, 'absent-claude'),
+      CODEX_HOME: path.join(root, 'absent-codex'),
+    },
+  };
+}
+
+/**
+ * @param {string[]} args
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {{status: number, stdout: string, stderr: string}}
+ */
+function run(args, env) {
+  try {
+    const stdout = execFileSync('node', [bin, ...args], { env, encoding: 'utf8' });
+    return { status: 0, stdout, stderr: '' };
+  } catch (err) {
+    return { status: err.status, stdout: err.stdout || '', stderr: err.stderr || '' };
+  }
+}
+
+test('doctor after a plain init warns about the deferred vault and exits 0', () => {
+  const { env } = tempEnv();
+  run(['init', '--yes'], env);
+  const r = run(['doctor'], env);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /\[warn\]/);
+  assert.match(r.stdout, /wienerdog-setup/);
+  assert.doesNotMatch(r.stdout, /\[fail\]/);
+});
+
+test('doctor after init --fresh-vault reports the vault ready and exits 0', () => {
+  const { env } = tempEnv();
+  run(['init', '--fresh-vault', '--yes'], env);
+  const r = run(['doctor'], env);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /\[ok\]/);
+  assert.match(r.stdout, /vault ready/);
+});
+
+test('doctor with a set-but-missing vault fails and exits 1', () => {
+  const { core, env } = tempEnv();
+  run(['init', '--yes'], env);
+  const configPath = path.join(core, 'config.yaml');
+  const cfg = fs.readFileSync(configPath, 'utf8');
+  fs.writeFileSync(configPath, cfg.replace(/^vault: null.*$/m, 'vault: /definitely/missing/dir'));
+  const r = run(['doctor'], env);
+  assert.equal(r.status, 1);
+  assert.match(r.stdout, /\[fail\].*vault/);
+});

--- a/tests/unit/init.test.js
+++ b/tests/unit/init.test.js
@@ -79,6 +79,40 @@ test('init --yes creates the core, config, and manifest', () => {
   assert.match(cfg, /memory_mode: standard/);
 });
 
+test('init --yes defers the vault (vault: null, no vault dir, next-step output)', () => {
+  const { core, env } = tempEnv();
+  const r = run(['init', '--yes'], env);
+  assert.equal(r.status, 0);
+  const cfg = fs.readFileSync(path.join(core, 'config.yaml'), 'utf8');
+  assert.match(cfg, /^vault: null/m);
+  assert.equal(fs.existsSync(env.WIENERDOG_VAULT), false, 'default vault dir must not be created');
+  assert.match(r.stdout, /no vault yet/i);
+  assert.match(r.stdout, /wienerdog-setup/);
+});
+
+test('init --fresh-vault --yes scaffolds the default vault as a git repo', () => {
+  const { core, env } = tempEnv();
+  const r = run(['init', '--fresh-vault', '--yes'], env);
+  assert.equal(r.status, 0);
+  const cfg = fs.readFileSync(path.join(core, 'config.yaml'), 'utf8');
+  assert.match(cfg, new RegExp(`^vault: ${env.WIENERDOG_VAULT}$`, 'm'));
+  assert.ok(fs.statSync(env.WIENERDOG_VAULT).isDirectory(), 'vault dir should exist');
+  const count = execFileSync('git', ['-C', env.WIENERDOG_VAULT, 'rev-list', '--count', 'HEAD'], {
+    encoding: 'utf8',
+  }).trim();
+  assert.equal(count, '1', 'vault should be a git repo with exactly one commit');
+});
+
+test('a second init --fresh-vault makes zero changes and says so', () => {
+  const { core, env } = tempEnv();
+  run(['init', '--fresh-vault', '--yes'], env);
+  const before = snapshot(core);
+  const r = run(['init', '--fresh-vault', '--yes'], env);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /already installed/i);
+  assert.deepEqual(snapshot(core), before);
+});
+
 test('secrets directory is created with mode 0700', { skip: process.platform === 'win32' }, () => {
   const { core, env } = tempEnv();
   run(['init', '--yes'], env);

--- a/tests/unit/setup-skill-structure.test.js
+++ b/tests/unit/setup-skill-structure.test.js
@@ -59,6 +59,13 @@ test('setup-skill: Step 3 seeds identity notes and project seeds on import', () 
   assert.ok(text.includes('01-Projects/'), 'project seed path missing');
 });
 
+test('setup-skill: Step 3 references wienerdog init --fresh-vault', () => {
+  assert.ok(
+    text.includes('wienerdog init --fresh-vault'),
+    'wienerdog init --fresh-vault command missing'
+  );
+});
+
 test('setup-skill: Step 6 still references wienerdog sync', () => {
   assert.ok(text.includes('wienerdog sync'), 'wienerdog sync reference missing');
 });


### PR DESCRIPTION
Spec: docs/specs/WP-027-defer-vault-creation.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

Plus one file outside the table (`tests/unit/codex-adapter.test.js`) — see Discovered issues.

## Verification output

```
$ npm test
ℹ tests 284
ℹ pass 284
ℹ fail 0

$ npm run lint
--- markdownlint ---   Summary: 0 error(s)
--- shellcheck ---
--- frontmatter check ---  frontmatter check passed: 1 spec(s), 4 agent(s)
lint passed

# 1. Plain init defers the vault — no phantom ~/wienerdog.
OK: vault deferred
OK: no phantom vault
[ok] core directory exists (...)
[ok] install manifest parses
[ok] config.yaml exists and is non-empty
[warn] no memory vault yet — run /wienerdog-setup to create or choose one (this is normal right after install)
[ok] secrets directory permissions are 0700
[ok] AI tools — Claude Code: not found, Codex CLI: not found
doctor exit: 0
# sync on unset vault:
wienerdog: no vault set up yet — run /wienerdog-setup to create or choose your vault (or 'wienerdog init --fresh-vault' for the default).
sync exit: 1

# 2. --fresh-vault creates it; idempotent.
OK: vault set
commits: 1
wienerdog: already installed, nothing to do.
OK: doctor ok

# 3. adopt after a plain init leaves no phantom-vault notice.
now-unused lines: 0
```

## Decisions made

- **Reused `scaffoldVault` verbatim** — `--fresh-vault` records `vault-file`
  manifest entries and resyncs the config hash exactly like the old eager path.
  `src/core/vault.js`, `tests/unit/vault.test.js`, and
  `tests/golden/vault-default/` are byte-unchanged.
- **Fresh vault stays preserved on uninstall** — `vault-file`/`vault-dir` are
  intentionally skipped by uninstall (M7: "leaves only the vault"). No change
  to that; a user's memory is never deleted.
- **Escaped the backticks** in the `renderConfig` `vault:` comment
  (`` \`wienerdog adopt\` ``). The spec's literal string uses backticks, but
  that comment lives inside a JS template literal — unescaped backticks would
  terminate the string. Rendered config output is identical to the spec text.
- **`[fail]` vault-line regex** in doctor.test.js matches `/\[fail\].*vault/`
  (single-line) rather than anchoring the exact message, to stay robust to
  wording.

## Discovered issues (out of scope, not fixed)

- **`tests/unit/codex-adapter.test.js` was NOT in the Deliverables table but
  its line-220 integration test broke** under the intended behavior change.
  The spec's Current-state note claimed the integration tests "keep passing,"
  but that test runs plain `init --yes`, drops identity files into the vault,
  then runs `sync` — which now throws on `vault: null`. I made the minimal
  one-line fix (switch its setup to `init --fresh-vault --yes`, matching the
  new reality) and flag it here as a spec gap. No behavior in the test's
  assertions changed. The gws-* tests that use plain `init` do not touch the
  vault and pass unchanged.

## WP-027 lessons

- WP-027: The `vault:` comment in init.js `renderConfig` sits inside a JS
  template literal — a spec-supplied string containing backticks must be
  escaped (`\``) or Node throws a SyntaxError at require time; the whole CLI
  crashed until escaped.
- WP-027: The spec's Current-state test census missed
  `tests/unit/codex-adapter.test.js`, which does `init` → `sync` end-to-end and
  depended on eager vault creation. When deferring an install step, grep for
  every test that runs the command and then a downstream command, not just the
  tests named in the spec.

---
Generated-by: claude-opus-4-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EA5BsHCfHRViJFXdovC86