### PR TITLE
fix(sync): register skills + hooks on bootstrap so init leaves /wienerdog-setup usable (WP-028)

### DIFF
--- a/docs/specs/WP-028-bootstrap-skill-registration.md
+++ b/docs/specs/WP-028-bootstrap-skill-registration.md
@@ -1,7 +1,7 @@
 ---
 id: WP-028
 title: Register skills + hooks on bootstrap so a fresh init leaves /wienerdog-setup usable
-status: Ready
+status: In-Review
 model: opus
 size: M
 depends_on: [WP-027]

--- a/src/adapters/claude.js
+++ b/src/adapters/claude.js
@@ -12,20 +12,23 @@ const shared = require('./shared');
  * (fresher digest between syncs). Correctness never depends on a hook firing.
  *
  * @param {ReturnType<import('../core/paths').getPaths>} paths
- * @param {{dryRun?: boolean, manifest?: object}} [opts]
+ * @param {{dryRun?: boolean, manifest?: object, skipManagedBlock?: boolean}} [opts]
  * @returns {{changed: string[], unchanged: string[], notices: string[]}}
  *  Steps (each idempotent; on dryRun make NO writes, still report intended changes):
- *    1. Managed block in <claudeDir>/CLAUDE.md ← contents of <state>/digest.md
+ *    1. Managed block in <claudeDir>/CLAUDE.md ← contents of <state>/digest.md.
+ *       Requires a vault/digest: skipped when opts.skipManagedBlock is set, or
+ *       (with a notice) when <state>/digest.md is absent.
  *    2. Copy hook scripts to <core>/bin/; register SessionStart + SessionEnd in
  *       <claudeDir>/settings.json (merge, never clobber the user's other hooks)
  *    3. Symlink each <core>/skills/wienerdog-* into <claudeDir>/skills/
- *  Records new entries in opts.manifest (never duplicates an existing kind+path).
- *  `changed` / `unchanged` list absolute paths acted on; `notices` are warnings.
- *  Never throws on a missing digest — if <state>/digest.md is absent, return
- *  early with a notice (sync writes it first).
+ *  Steps 2-3 carry no user knowledge and ALWAYS run; only Step 1 is gated on a
+ *  vault/digest. Records new entries in opts.manifest (never duplicates an
+ *  existing kind+path). `changed` / `unchanged` list absolute paths acted on;
+ *  `notices` are warnings. Never throws on a missing digest.
  */
 function applyClaudeAdapter(paths, opts = {}) {
   const dryRun = opts.dryRun === true;
+  const skipManagedBlock = opts.skipManagedBlock === true;
   const manifest = opts.manifest;
   /** @type {{changed: string[], unchanged: string[], notices: string[]}} */
   const out = { changed: [], unchanged: [], notices: [] };
@@ -37,16 +40,23 @@ function applyClaudeAdapter(paths, opts = {}) {
   const claudeSkillsDir = path.join(paths.claudeDir, 'skills');
   const digestPath = path.join(paths.state, 'digest.md');
 
-  let digest;
-  try {
-    digest = fs.readFileSync(digestPath, 'utf8');
-  } catch {
-    out.notices.push(`digest not found at ${digestPath}; skipping Claude adapter`);
-    return out;
+  // Step 1 — managed block. Requires a vault/digest; skipped on a no-vault
+  // machine. Skills + hooks (Steps 2-3) carry no user knowledge and ALWAYS run.
+  if (!skipManagedBlock) {
+    let digest = null;
+    try {
+      digest = fs.readFileSync(digestPath, 'utf8');
+    } catch {
+      digest = null;
+    }
+    if (digest !== null) {
+      shared.applyManagedBlock(claudeMd, digest, dryRun, manifest, out);
+    } else {
+      out.notices.push(
+        `digest not found at ${digestPath}; managed block skipped (hooks + skills still installed)`
+      );
+    }
   }
-
-  // Step 1 — managed block.
-  shared.applyManagedBlock(claudeMd, digest, dryRun, manifest, out);
 
   // Step 2 — hook scripts + settings.json.
   const startSrc = path.resolve(__dirname, '..', '..', 'templates', 'hooks', 'session-start.sh');

--- a/src/adapters/codex.js
+++ b/src/adapters/codex.js
@@ -14,11 +14,13 @@ const shared = require('./shared');
  * works with zero hooks trusted.
  *
  * @param {ReturnType<import('../core/paths').getPaths>} paths
- * @param {{dryRun?: boolean, manifest?: object}} [opts]
+ * @param {{dryRun?: boolean, manifest?: object, skipManagedBlock?: boolean}} [opts]
  * @returns {{changed: string[], unchanged: string[], notices: string[]}}
  *  Steps (each idempotent; on dryRun make NO writes, still report intended changes):
  *    1. Managed block in <codexDir>/AGENTS.md ← contents of <state>/digest.md.
- *       If <codexDir>/AGENTS.override.md exists, push a NOTICE: our AGENTS.md is
+ *       Requires a vault/digest: skipped when opts.skipManagedBlock is set, or
+ *       (with a notice) when <state>/digest.md is absent. If
+ *       <codexDir>/AGENTS.override.md exists, push a NOTICE: our AGENTS.md is
  *       silently shadowed by the override (research fact) — user must merge manually.
  *    2. Copy session-start.sh + codex-session-end.sh into <core>/bin/ (0755); register
  *       SessionStart + Stop command hooks in <codexDir>/hooks.json (settings-entry).
@@ -26,11 +28,13 @@ const shared = require('./shared');
  *       the AGENTS.md block already carries the digest so context works regardless.
  *    3. Symlink each <core>/skills/wienerdog-* into <home>/.agents/skills/ (Codex
  *       user-scope skill-discovery dir; NOT config.toml — see the research memo).
- *  Never throws on a missing digest — if <state>/digest.md is absent, return early
- *  with a notice (sync writes it first). Records new entries in opts.manifest.
+ *  Steps 2-3 carry no user knowledge and ALWAYS run; only Step 1 is gated on a
+ *  vault/digest. Never throws on a missing digest. Records new entries in
+ *  opts.manifest.
  */
 function applyCodexAdapter(paths, opts = {}) {
   const dryRun = opts.dryRun === true;
+  const skipManagedBlock = opts.skipManagedBlock === true;
   const manifest = opts.manifest;
   /** @type {{changed: string[], unchanged: string[], notices: string[]}} */
   const out = { changed: [], unchanged: [], notices: [] };
@@ -47,20 +51,27 @@ function applyCodexAdapter(paths, opts = {}) {
   const startAbs = path.join(binDir, 'session-start.sh');
   const stopAbs = path.join(binDir, 'codex-session-end.sh');
 
-  let digest;
-  try {
-    digest = fs.readFileSync(digestPath, 'utf8');
-  } catch {
-    out.notices.push(`digest not found at ${digestPath}; skipping Codex adapter`);
-    return out;
-  }
-
-  // Step 1 — managed block.
-  shared.applyManagedBlock(agentsMd, digest, dryRun, manifest, out);
-  if (fs.existsSync(overridePath)) {
-    out.notices.push(
-      "~/.codex/AGENTS.override.md exists — it shadows Wienerdog's AGENTS.md; merge the managed block manually or remove the override"
-    );
+  // Step 1 — managed block. Requires a vault/digest; skipped on a no-vault
+  // machine. Skills + hooks (Steps 2-3) carry no user knowledge and ALWAYS run.
+  if (!skipManagedBlock) {
+    let digest = null;
+    try {
+      digest = fs.readFileSync(digestPath, 'utf8');
+    } catch {
+      digest = null;
+    }
+    if (digest !== null) {
+      shared.applyManagedBlock(agentsMd, digest, dryRun, manifest, out);
+      if (fs.existsSync(overridePath)) {
+        out.notices.push(
+          "~/.codex/AGENTS.override.md exists — it shadows Wienerdog's AGENTS.md; merge the managed block manually or remove the override"
+        );
+      }
+    } else {
+      out.notices.push(
+        `digest not found at ${digestPath}; managed block skipped (hooks + skills still installed)`
+      );
+    }
   }
 
   // Step 2 — hook scripts + hooks.json.

--- a/src/cli/init.js
+++ b/src/cli/init.js
@@ -100,6 +100,7 @@ async function run(argv) {
 
   if (missingDirs.length === 0 && !needConfig && !vaultStep) {
     console.log('wienerdog: already installed, nothing to do.');
+    console.log("Tip: run 'wienerdog sync' to refresh skills, hooks, and memory.");
     return;
   }
 
@@ -165,6 +166,14 @@ async function run(argv) {
   }
 
   manifestLib.save(paths, manifest);
+
+  // Register skills + hooks into every detected harness (and, when a vault is
+  // configured, the digest + managed block) so the promised /wienerdog-setup skill
+  // is live the moment init finishes. sync is idempotent; with no vault it installs
+  // skills + hooks and defers memory features (exit 0). Passing our argv is safe —
+  // sync only reads --dry-run from it, and we never reach here on a dry-run.
+  await require('./sync').run(argv);
+
   if (vaultStep) {
     console.log('\nwienerdog: installed with a fresh vault. Run `wienerdog doctor` to check the setup.');
   } else if (vaultConfigured) {

--- a/src/cli/sync.js
+++ b/src/cli/sync.js
@@ -124,58 +124,63 @@ async function run(argv) {
   const dryRun = argv.includes('--dry-run');
   const paths = getPaths();
   const vaultPath = readVaultPath(paths.config);
-  if (!vaultPath) {
-    throw new WienerdogError(
-      'no vault set up yet — run /wienerdog-setup to create or choose your vault ' +
-        "(or 'wienerdog init --fresh-vault' for the default)."
-    );
-  }
-  let isDir = false;
-  try {
-    isDir = fs.statSync(vaultPath).isDirectory();
-  } catch {
-    isDir = false;
-  }
-  if (!isDir) {
-    throw new WienerdogError(
-      `vault not found at ${vaultPath} — run /wienerdog-setup, or 'wienerdog init --fresh-vault' for the default.`
-    );
+
+  // A configured vault MUST exist on disk. An UNSET vault is a valid first-time
+  // state (WP-027): we still install skills + hooks, we just defer memory.
+  if (vaultPath) {
+    let isDir = false;
+    try {
+      isDir = fs.statSync(vaultPath).isDirectory();
+    } catch {
+      isDir = false;
+    }
+    if (!isDir) {
+      throw new WienerdogError(
+        `vault not found at ${vaultPath} — run /wienerdog-setup, or 'wienerdog init --fresh-vault' for the default.`
+      );
+    }
   }
 
-  // 1. Render + write the digest atomically.
-  const layout = readVaultLayout(paths.config);
-  const digest = renderDigest(vaultPath, layout);
-  const dest = path.join(paths.state, 'digest.md');
-  if (!dryRun) {
-    fs.mkdirSync(paths.state, { recursive: true });
-    const tmp = path.join(paths.state, `.digest.md.${process.pid}.tmp`);
-    fs.writeFileSync(tmp, digest);
-    fs.renameSync(tmp, dest);
-  }
-  console.log(`wienerdog: ${dryRun ? 'would write' : 'wrote'} ${dest} (${Buffer.byteLength(digest)} bytes).`);
-
-  // 2. Load the manifest so adapter + skill staging can extend it.
   const manifest = manifestMod.load(paths);
-
   /** @type {{changed: string[], unchanged: string[], notices: string[]}} */
   const summary = { changed: [], unchanged: [], notices: [] };
 
-  // 3. Stage shipped skills into the core (vendor-neutral).
+  // 1. Digest + managed block need a vault. Skip both when unset (exit 0).
+  const skipManagedBlock = !vaultPath;
+  if (vaultPath) {
+    const layout = readVaultLayout(paths.config);
+    const digest = renderDigest(vaultPath, layout);
+    const dest = path.join(paths.state, 'digest.md');
+    if (!dryRun) {
+      fs.mkdirSync(paths.state, { recursive: true });
+      const tmp = path.join(paths.state, `.digest.md.${process.pid}.tmp`);
+      fs.writeFileSync(tmp, digest);
+      fs.renameSync(tmp, dest);
+    }
+    console.log(
+      `wienerdog: ${dryRun ? 'would write' : 'wrote'} ${dest} (${Buffer.byteLength(digest)} bytes).`
+    );
+  } else {
+    console.log(
+      'wienerdog: no vault yet — memory features (digest + managed block) activate after /wienerdog-setup; skills and hooks are installed.'
+    );
+  }
+
+  // 2. Stage shipped skills into the core (vendor-neutral) — ALWAYS.
   stageSkills(paths, dryRun, manifest, summary);
 
-  // 4. Apply the Claude Code adapter if Claude Code is present.
+  // 3. Apply each present harness adapter — ALWAYS. They install skills + hooks
+  //    and only skip the managed block when skipManagedBlock is true.
   if (detectHarnesses(process.env).claude.present) {
-    const res = applyClaudeAdapter(paths, { dryRun, manifest });
+    const res = applyClaudeAdapter(paths, { dryRun, manifest, skipManagedBlock });
     summary.changed.push(...res.changed);
     summary.unchanged.push(...res.unchanged);
     summary.notices.push(...res.notices);
   } else {
     console.log('Claude Code not detected; skipping adapter.');
   }
-
-  // 4b. Apply the Codex CLI adapter if Codex CLI is present.
   if (detectHarnesses(process.env).codex.present) {
-    const res = applyCodexAdapter(paths, { dryRun, manifest });
+    const res = applyCodexAdapter(paths, { dryRun, manifest, skipManagedBlock });
     summary.changed.push(...res.changed);
     summary.unchanged.push(...res.unchanged);
     summary.notices.push(...res.notices);
@@ -183,10 +188,8 @@ async function run(argv) {
     console.log('Codex CLI not detected; skipping adapter.');
   }
 
-  // 5. Persist the manifest (never on dry-run).
   if (!dryRun) manifestMod.save(paths, manifest);
 
-  // 6. Summary.
   console.log(
     `wienerdog: ${summary.changed.length} changed, ${summary.unchanged.length} unchanged.`
   );

--- a/tests/integration/bootstrap-seam.test.js
+++ b/tests/integration/bootstrap-seam.test.js
@@ -1,0 +1,144 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const bin = path.join(repoRoot, 'bin', 'wienerdog.js');
+
+/**
+ * Run wienerdog as a subprocess with a fully isolated env.
+ * @param {string[]} args
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {{status: number, stdout: string, stderr: string}}
+ */
+function run(args, env) {
+  try {
+    const stdout = execFileSync('node', [bin, ...args], { env, encoding: 'utf8' });
+    return { status: 0, stdout, stderr: '' };
+  } catch (err) {
+    return { status: err.status, stdout: err.stdout || '', stderr: err.stderr || '' };
+  }
+}
+
+/** A fresh temp root; never touches the real $HOME, ~/.claude, ~/.codex or ~/.agents. */
+function tempRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'wd-seam-'));
+}
+
+/** Every hook command string registered under an event in a settings/hooks file. */
+function hookCommands(filePath, event) {
+  const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  return (parsed.hooks[event] || []).flatMap((g) => g.hooks.map((h) => h.command));
+}
+
+test('Claude present, plain init: skills + hooks registered, NO memory', () => {
+  const root = tempRoot();
+  const wd = path.join(root, 'wd');
+  const claudeDir = path.join(root, 'claude');
+  const env = {
+    ...process.env,
+    HOME: root,
+    WIENERDOG_HOME: wd,
+    WIENERDOG_VAULT: path.join(root, 'vault'),
+    CLAUDE_CONFIG_DIR: claudeDir,
+    CODEX_HOME: path.join(root, 'absent-codex'),
+  };
+  fs.mkdirSync(claudeDir, { recursive: true }); // Claude detected
+
+  const r = run(['init', '--yes'], env);
+  assert.equal(r.status, 0, r.stderr);
+
+  const cfg = fs.readFileSync(path.join(wd, 'config.yaml'), 'utf8');
+  assert.match(cfg, /^vault: null/m, 'vault deferred');
+  assert.equal(fs.existsSync(env.WIENERDOG_VAULT), false, 'no vault dir');
+  assert.equal(fs.existsSync(path.join(wd, 'state', 'digest.md')), false, 'no digest');
+  assert.equal(fs.existsSync(path.join(claudeDir, 'CLAUDE.md')), false, 'no managed block');
+
+  const startAbs = path.join(wd, 'bin', 'session-start.sh');
+  assert.ok(
+    hookCommands(path.join(claudeDir, 'settings.json'), 'SessionStart').includes(startAbs),
+    'session-start.sh registered'
+  );
+
+  if (process.platform !== 'win32') {
+    const link = path.join(claudeDir, 'skills', 'wienerdog-setup');
+    assert.ok(fs.lstatSync(link).isSymbolicLink(), 'setup skill symlinked');
+  }
+});
+
+test('Claude present, init --fresh-vault: everything incl. digest + managed block', () => {
+  const root = tempRoot();
+  const wd = path.join(root, 'wd');
+  const vault = path.join(root, 'vault');
+  const claudeDir = path.join(root, 'claude');
+  const env = {
+    ...process.env,
+    HOME: root,
+    WIENERDOG_HOME: wd,
+    WIENERDOG_VAULT: vault,
+    CLAUDE_CONFIG_DIR: claudeDir,
+    CODEX_HOME: path.join(root, 'absent-codex'),
+  };
+  fs.mkdirSync(claudeDir, { recursive: true });
+
+  const r = run(['init', '--fresh-vault', '--yes'], env);
+  assert.equal(r.status, 0, r.stderr);
+
+  assert.ok(fs.statSync(vault).isDirectory(), 'vault dir exists');
+  const count = execFileSync('git', ['-C', vault, 'rev-list', '--count', 'HEAD'], {
+    encoding: 'utf8',
+  }).trim();
+  assert.equal(count, '1', 'vault is a git repo with one commit');
+
+  assert.ok(fs.existsSync(path.join(wd, 'state', 'digest.md')), 'digest rendered');
+  const claudeMd = fs.readFileSync(path.join(claudeDir, 'CLAUDE.md'), 'utf8');
+  assert.ok(claudeMd.includes('<!-- wienerdog:begin -->'), 'managed block written');
+
+  const startAbs = path.join(wd, 'bin', 'session-start.sh');
+  assert.ok(
+    hookCommands(path.join(claudeDir, 'settings.json'), 'SessionStart').includes(startAbs),
+    'session-start.sh registered'
+  );
+  if (process.platform !== 'win32') {
+    const link = path.join(claudeDir, 'skills', 'wienerdog-setup');
+    assert.ok(fs.lstatSync(link).isSymbolicLink(), 'setup skill symlinked');
+  }
+});
+
+test('Codex present, plain init: skills + hooks under .agents, NO memory', () => {
+  const root = tempRoot();
+  const wd = path.join(root, 'wd');
+  const codexDir = path.join(root, 'codex');
+  const env = {
+    ...process.env,
+    HOME: root,
+    WIENERDOG_HOME: wd,
+    WIENERDOG_VAULT: path.join(root, 'vault'),
+    CODEX_HOME: codexDir,
+    CLAUDE_CONFIG_DIR: path.join(root, 'absent-claude'),
+  };
+  fs.mkdirSync(codexDir, { recursive: true }); // Codex detected
+
+  const r = run(['init', '--yes'], env);
+  assert.equal(r.status, 0, r.stderr);
+
+  assert.equal(fs.existsSync(env.WIENERDOG_VAULT), false, 'no vault dir');
+  assert.equal(fs.existsSync(path.join(wd, 'state', 'digest.md')), false, 'no digest');
+  assert.equal(fs.existsSync(path.join(codexDir, 'AGENTS.md')), false, 'no managed block');
+
+  const startAbs = path.join(wd, 'bin', 'session-start.sh');
+  assert.ok(
+    hookCommands(path.join(codexDir, 'hooks.json'), 'SessionStart').includes(startAbs),
+    'session-start.sh registered in hooks.json'
+  );
+
+  if (process.platform !== 'win32') {
+    const link = path.join(root, '.agents', 'skills', 'wienerdog-setup');
+    assert.ok(fs.lstatSync(link).isSymbolicLink(), 'setup skill symlinked under .agents');
+  }
+});

--- a/tests/scenarios/run-scenarios.js
+++ b/tests/scenarios/run-scenarios.js
@@ -327,8 +327,8 @@ async function main() {
 
     // 3. Seed: init the core + vault, then plant the fixtures under the
     // collection override (not the config dir).
-    console.log('scenarios: seeding harness (wienerdog init --yes)...');
-    const initRes = runWienerdog(['init', '--yes'], env);
+    console.log('scenarios: seeding harness (wienerdog init --fresh-vault --yes)...');
+    const initRes = runWienerdog(['init', '--fresh-vault', '--yes'], env);
     if (initRes.stdout) console.log(initRes.stdout);
     if (initRes.status !== 0) {
       failures.push(`wienerdog init exited ${initRes.status}: ${(initRes.stderr || '').trim()}`);

--- a/tests/unit/claude-adapter.test.js
+++ b/tests/unit/claude-adapter.test.js
@@ -167,12 +167,23 @@ test('dry-run makes no writes but reports intended changes', () => {
   assert.equal(fs.existsSync(path.join(paths.core, 'bin', 'session-start.sh')), false);
 });
 
-test('missing digest: returns early with a notice, no throw', () => {
+test('missing digest: skips the managed block but still installs hooks + skills', () => {
   const paths = setup();
   fs.rmSync(path.join(paths.state, 'digest.md'));
+  const coreSkill = path.join(paths.core, 'skills', 'wienerdog-setup');
+  fs.mkdirSync(coreSkill, { recursive: true });
+  fs.writeFileSync(path.join(coreSkill, 'SKILL.md'), '# skill\n');
+
   const res = applyClaudeAdapter(paths, { manifest: freshManifest() });
-  assert.deepEqual(res.changed, []);
-  assert.ok(res.notices.some((n) => n.includes('digest not found')));
+
+  const claudeMd = path.join(paths.claudeDir, 'CLAUDE.md');
+  assert.equal(fs.existsSync(claudeMd), false, 'no managed block without a digest');
+  assert.ok(res.notices.some((n) => n.includes('managed block skipped')));
+  assert.ok(fs.existsSync(path.join(paths.core, 'bin', 'session-start.sh')), 'hook script installed');
+  if (process.platform !== 'win32') {
+    const link = path.join(paths.claudeDir, 'skills', 'wienerdog-setup');
+    assert.ok(fs.lstatSync(link).isSymbolicLink(), 'skill symlinked');
+  }
 });
 
 test('sync then uninstall round-trips a pre-existing CLAUDE.md byte-identically', () => {


### PR DESCRIPTION
Spec: docs/specs/WP-028-bootstrap-skill-registration.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

Files touched (all in the Deliverables table): `src/cli/sync.js`, `src/adapters/claude.js`, `src/adapters/codex.js`, `src/cli/init.js`, `tests/integration/bootstrap-seam.test.js` (new), `tests/unit/claude-adapter.test.js`, `tests/scenarios/run-scenarios.js`, plus the spec status flip.

## What changed

- `sync` no longer throws on a null vault. Skill staging + skill symlinks + hook registration always run for detected harnesses; digest render + managed block are the only vault-gated steps, skipped with a one-line notice (exit 0). Configured-but-missing vault still exits 1.
- Both adapters gained `opts.skipManagedBlock`; Steps 2-3 (hooks + skills) are unconditional, Step 1 (managed block) is gated on a vault/digest. Missing-digest no longer early-returns.
- `init` runs `sync` at the end of a successful install (not the already-installed fast path, per D3); the fast path prints a `wienerdog sync` tip.

## Verification output

`npm test` — 287 pass, 0 fail.
`npm run lint` — markdownlint 0 errors, shellcheck clean, frontmatter passed → `lint passed`.
`node --test tests/integration/bootstrap-seam.test.js` — 3 pass, 0 fail.

Manual fresh-env sequence (all OK):
```
OK: setup skill registered
OK: hook registered
OK: no digest (deferred vault)
OK: no managed block
OK: vault deferred
sync exit: 0            # "no vault yet …" notice, 0 changed 17 unchanged
OK: digest rendered     # after init --fresh-vault
OK: managed block present
OK: idempotent          # second init --yes → "already installed"
```

No-vault `sync` output (Claude present, Codex absent) matches the spec contract:
```
wienerdog: no vault yet — memory features (digest + managed block) activate after /wienerdog-setup; skills and hooks are installed.
Codex CLI not detected; skipping adapter.
wienerdog: 17 changed, 0 unchanged.
```

## Decisions made

- Followed D1-D4 verbatim (exit-1 only for configured-but-missing vault; skills/hooks always run; init runs sync on the successful-install path only; session-start.sh untouched).
- `tests/scenarios/run-scenarios.js` is not executed by `npm test` (spends model quota); verified by inspection that its `vault` variable equals `WIENERDOG_VAULT`, so the `--fresh-vault` seed scaffolds the path the later `commitCount(vault)` reads.

## Discovered issues (out of scope, not fixed)

none

---
Generated-by: claude-opus-4-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EA5BsHCfHRViJFXdovC86