### PR TITLE
fix(adopt): harden initial-snapshot git errors, stale-lock, .gitignore (WP-029)

### DIFF
--- a/docs/specs/ROADMAP.md
+++ b/docs/specs/ROADMAP.md
@@ -47,7 +47,7 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 | [WP-026](done/WP-026-full-adoption-flow.md) | Full vault adoption — `wienerdog adopt` CLI, prerequisites, layout mapping | M2/M3 | opus | Done | WP-024, WP-025 |
 | [WP-027](done/WP-027-defer-vault-creation.md) | Defer vault creation until the vault path is chosen (init `--fresh-vault`) | M2/M3 | opus | Done | WP-026 |
 | [WP-028](done/WP-028-bootstrap-skill-registration.md) | Register skills + hooks on bootstrap (sync vault-independent; init runs sync) | M2 | opus | Done | WP-027 |
-| [WP-029](WP-029-adopt-snapshot-robustness.md) | Harden `adopt` initial-snapshot (surfaced git errors, stale-lock recovery, starter .gitignore) | M2/M3 | opus | Ready | WP-026 |
+| [WP-029](WP-029-adopt-snapshot-robustness.md) | Harden `adopt` initial-snapshot (surfaced git errors, stale-lock recovery, starter .gitignore) | M2/M3 | opus | In-Review | WP-026 |
 | [WP-030](WP-030-digest-h1-and-adopt-invocation.md) | Digest: drop note's leading H1; setup skill shows both adopt invocation forms | M2/M3 | sonnet | Ready | WP-022 |
 
 ## Dependency graph

--- a/docs/specs/WP-029-adopt-snapshot-robustness.md
+++ b/docs/specs/WP-029-adopt-snapshot-robustness.md
@@ -1,7 +1,7 @@
 ---
 id: WP-029
 title: Harden `wienerdog adopt` initial-snapshot (surfaced git errors, stale-lock recovery, starter .gitignore)
-status: Ready
+status: In-Review
 model: opus
 size: M
 depends_on: [WP-026]

--- a/src/cli/adopt.js
+++ b/src/cli/adopt.js
@@ -12,6 +12,7 @@ const tccguard = require('../scheduler/tccguard');
 const { inferLayout } = require('../core/layout-infer');
 const { resolveDailyPath } = require('../core/layout');
 const { scaffoldMappedDirs } = require('../core/vault');
+const adoptGit = require('../core/adopt-git');
 
 // Small helpers copied from init.js (init does not export them, and it is not
 // in this WP's deliverables). Kept identical so behavior matches.
@@ -158,42 +159,80 @@ async function run(argv) {
     );
   }
 
-  // 6. Git prerequisite — the whole revert-safety guarantee rests on it.
+  // 6. Git prerequisite + initial snapshot — the revert-safety guarantee rests on it.
+  //    Idempotent: take the snapshot whenever the repo has no HEAD commit yet, so a
+  //    re-run after a crash mid-snapshot heals itself instead of skipping the block.
   const alreadyRepo = isGitRepo(adoptedPath);
-  if (!alreadyRepo) {
-    console.log(
-      '\nThis folder is not yet tracked by git.\n' +
-        'Wienerdog needs git so a night of auto-written memory is one commit you can undo\n' +
-        'with a single `git revert`. Without it, adopted memory would not be recoverable.'
-    );
+  const hasHead = alreadyRepo && git(adoptedPath, ['rev-parse', '--verify', 'HEAD']).status === 0;
+
+  if (!hasHead) {
+    if (!alreadyRepo) {
+      console.log(
+        '\nThis folder is not yet tracked by git.\n' +
+          'Wienerdog needs git so a night of auto-written memory is one commit you can undo\n' +
+          'with a single `git revert`. Without it, adopted memory would not be recoverable.'
+      );
+    }
+
     if (dryRun) {
-      console.log('(--dry-run: would initialize a git repository and take an initial snapshot here.)');
+      console.log(
+        alreadyRepo
+          ? '(--dry-run: this repo has no initial commit; would offer a starter .gitignore, clear any stale index.lock, and take an initial snapshot.)'
+          : '(--dry-run: would init git, offer a starter .gitignore, clear any stale index.lock, and take an initial snapshot here.)'
+      );
     } else {
-      const okGit = yes || (await confirm('Initialize a git repository here and take an initial snapshot? [y/N] '));
-      if (!okGit) {
-        throw new WienerdogError('adoption needs a git repo; aborted.');
+      // 6a. Consent to git init only when the folder is not a repo yet.
+      if (!alreadyRepo) {
+        const okGit = yes || (await confirm('Initialize a git repository here and take an initial snapshot? [y/N] '));
+        if (!okGit) throw new WienerdogError('adoption needs a git repo; aborted.');
+        adoptGit.runGitStep(adoptedPath, ['init'], 'git init');
       }
-      const init = git(adoptedPath, ['init']);
-      if (init.error || init.status !== 0) {
-        throw new WienerdogError('failed to run `git init` — is git installed?');
+
+      // 6b. Offer a starter .gitignore BEFORE staging, so churny/hazardous files
+      //     (running plugin binaries, huge caches) never enter the snapshot.
+      const plan = adoptGit.planGitignore(adoptedPath);
+      if (plan.missing.length > 0) {
+        console.log('\nWienerdog can add a starter .gitignore so git skips churny or hazardous files:');
+        for (const l of plan.missing) console.log(`  ${l}`);
+        console.log('(Appended to any existing .gitignore; nothing you wrote is overwritten.)');
+        const okIgnore = yes || (await confirm('Add these lines to .gitignore? [y/N] '));
+        if (okIgnore) adoptGit.applyGitignore(plan);
+        else console.log('Proceeding without them — a very large or locked file may make git fail.');
       }
-      git(adoptedPath, ['add', '-A']);
-      const commit = git(adoptedPath, [
-        '-c',
-        'user.name=wienerdog',
-        '-c',
-        'user.email=wienerdog@localhost',
-        'commit',
-        // --allow-empty so an initial snapshot always exists (giving `git revert`
-        // a HEAD to undo the first dream against) even if the vault has no
-        // committable content yet.
-        '--allow-empty',
-        '-m',
-        'wienerdog: adopt — initial snapshot',
-      ]);
-      if (commit.error || commit.status !== 0) {
-        throw new WienerdogError('failed to take the initial git snapshot.');
+
+      // 6c. Recover from a stale index.lock left by an interrupted earlier run.
+      const lock = adoptGit.inspectIndexLock(adoptedPath);
+      if (lock.present && lock.stale) {
+        console.log(
+          `\nFound a leftover git lock (${lock.lockPath}), about ${Math.round(lock.ageMs / 1000)}s old,\n` +
+            'likely from an interrupted earlier run. No git process appears to be using it.'
+        );
+        const okRm = yes || (await confirm('Remove the stale lock and continue? [y/N] '));
+        if (!okRm) throw new WienerdogError('git index is locked; remove `.git/index.lock` and retry.');
+        adoptGit.removeIndexLock(lock.lockPath);
+      } else if (lock.present && !lock.stale) {
+        throw new WienerdogError(
+          'another git process seems to be using this repo right now (a fresh `.git/index.lock`); ' +
+            'finish or stop it, then retry.'
+        );
       }
+
+      // 6d. Snapshot. Every step surfaces stderr + code/signal on failure.
+      adoptGit.runGitStep(adoptedPath, ['add', '-A'], 'git add -A (staging the vault)');
+      adoptGit.runGitStep(
+        adoptedPath,
+        [
+          '-c',
+          'user.name=wienerdog',
+          '-c',
+          'user.email=wienerdog@localhost',
+          'commit',
+          '--allow-empty',
+          '-m',
+          'wienerdog: adopt — initial snapshot',
+        ],
+        'git commit (initial snapshot)'
+      );
     }
   }
 

--- a/src/core/adopt-git.js
+++ b/src/core/adopt-git.js
@@ -1,0 +1,147 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { WienerdogError } = require('./errors');
+
+/**
+ * @typedef {(cmd: string, args: string[], opts?: object)
+ *   => { status: number|null, signal: string|null, error?: Error,
+ *        stdout?: Buffer, stderr?: Buffer }} SpawnFn
+ */
+
+/** Default lines `adopt` offers to append to the vault's .gitignore. Order-stable. */
+const DEFAULT_GITIGNORE_LINES = [
+  '.obsidian/plugins/*/bin/',
+  '.smart-env/',
+  '.obsidian/workspace*',
+  '.DS_Store',
+  '.trash/',
+];
+
+/** A .git/index.lock older than this (ms) is treated as a crash orphan, not a live op. */
+const STALE_LOCK_AGE_MS = 10_000;
+
+/** Header line prepended to the appended .gitignore block. */
+const GITIGNORE_HEADER = '# Added by wienerdog adopt — churny / hazardous paths not worth tracking.';
+
+/**
+ * Run ONE git step under `-C dir`. On ANY failure (spawn error, non-zero exit,
+ * or termination by signal) throw a WienerdogError carrying the full cause:
+ * how it failed (signal name, or exit code, or spawn error code), git's stderr,
+ * and — when the child was SIGKILLed / exit 137 or stderr smells of size/memory —
+ * a hint that a very large or locked file is the likely cause. NEVER swallows stderr.
+ * @param {string} dir @param {string[]} args @param {string} label human step name, e.g. "git add -A"
+ * @param {{spawn?: SpawnFn}} [opts]
+ * @returns {import('child_process').SpawnSyncReturns<Buffer>} the (successful) spawn result
+ */
+function runGitStep(dir, args, label, opts = {}) {
+  const spawn = opts.spawn || spawnSync;
+  const r = spawn('git', ['-C', dir, ...args]);
+
+  if (!r.error && !r.signal && r.status === 0) return r;
+
+  const stderr = r.stderr ? r.stderr.toString() : '';
+  let how;
+  if (r.error) {
+    how = `could not start git (${r.error.code || r.error.message})`;
+  } else if (r.signal) {
+    how = `git was killed by signal ${r.signal}`;
+  } else {
+    how = `git exited with code ${r.status}`;
+  }
+
+  const lines = [`${label} failed: ${how}.`, `  git said: ${stderr.trim() || '(no output)'}`];
+
+  if (r.error) {
+    lines.push('  Is git installed and on your PATH?');
+  } else if (
+    r.signal === 'SIGKILL' ||
+    r.status === 137 ||
+    /large|too big|out of memory|cannot allocate|pack/i.test(stderr)
+  ) {
+    lines.push('  This usually means git choked on a very large or locked file (e.g. a running');
+    lines.push('  binary or a multi-hundred-MB file). Exclude such paths via .gitignore and retry.');
+  }
+
+  throw new WienerdogError(lines.join('\n'));
+}
+
+/**
+ * Inspect `<dir>/.git/index.lock`. Absent => not present. Present => stale iff its
+ * mtime age >= STALE_LOCK_AGE_MS (a crashed `git add` leaves an aged lock; a live
+ * op holds a fresh one). `now` is injectable for tests.
+ * @param {string} dir @param {{now?: number}} [opts]
+ * @returns {{present: boolean, stale: boolean, lockPath: string, ageMs: number|null}}
+ */
+function inspectIndexLock(dir, opts = {}) {
+  const now = opts.now !== undefined ? opts.now : Date.now();
+  const lockPath = path.join(dir, '.git', 'index.lock');
+  let st;
+  try {
+    st = fs.statSync(lockPath);
+  } catch {
+    return { present: false, stale: false, lockPath, ageMs: null };
+  }
+  const ageMs = now - st.mtimeMs;
+  return { present: true, stale: ageMs >= STALE_LOCK_AGE_MS, lockPath, ageMs };
+}
+
+/**
+ * Delete the lock file (force; missing is fine).
+ * @param {string} lockPath
+ */
+function removeIndexLock(lockPath) {
+  fs.rmSync(lockPath, { force: true });
+}
+
+/**
+ * Which DEFAULT_GITIGNORE_LINES are MISSING from `<dir>/.gitignore` (exact,
+ * trimmed line match). `existing` reports whether a .gitignore already exists.
+ * @param {string} dir
+ * @returns {{path: string, existing: boolean, missing: string[]}}
+ */
+function planGitignore(dir) {
+  const p = path.join(dir, '.gitignore');
+  let content = '';
+  let existing = false;
+  try {
+    content = fs.readFileSync(p, 'utf8');
+    existing = true;
+  } catch {
+    existing = false;
+  }
+  const present = new Set(content.split('\n').map((l) => l.trim()));
+  const missing = DEFAULT_GITIGNORE_LINES.filter((l) => !present.has(l));
+  return { path: p, existing, missing };
+}
+
+/**
+ * Append the plan's missing lines under a one-line header comment. APPEND-ONLY:
+ * never rewrites, reorders, or removes existing content. No-op when nothing is
+ * missing (so re-running adopt never duplicates lines — idempotent).
+ * @param {{path: string, existing: boolean, missing: string[]}} plan
+ */
+function applyGitignore(plan) {
+  if (plan.missing.length === 0) return;
+  const block = [GITIGNORE_HEADER, ...plan.missing].join('\n') + '\n';
+  if (!plan.existing) {
+    fs.writeFileSync(plan.path, block);
+    return;
+  }
+  let content = fs.readFileSync(plan.path, 'utf8');
+  if (content.length > 0 && !content.endsWith('\n')) content += '\n';
+  content += '\n' + block;
+  fs.writeFileSync(plan.path, content);
+}
+
+module.exports = {
+  DEFAULT_GITIGNORE_LINES,
+  STALE_LOCK_AGE_MS,
+  runGitStep,
+  inspectIndexLock,
+  removeIndexLock,
+  planGitignore,
+  applyGitignore,
+};

--- a/tests/integration/adopt-e2e.test.js
+++ b/tests/integration/adopt-e2e.test.js
@@ -82,8 +82,28 @@ test('adopt-e2e: init → adopt → sync → dream through mapped tiers, one rev
     await init.run(['--yes']);
     assert.ok(fs.existsSync(configPath), 'config.yaml written by init');
 
+    // 3a. Seed a pre-existing .gitignore with one custom line + one default line,
+    //     to prove adopt appends (never overwrites) and skips the already-present default.
+    const gitignorePath = path.join(adopted, '.gitignore');
+    fs.writeFileSync(gitignorePath, 'my-secret-notes/\n.DS_Store\n');
+
     // 4. adopt the power-user vault.
     await adopt.run([adopted, '--yes']);
+
+    // 4-gitignore. The starter .gitignore offer ran under --yes: all five defaults
+    //     present, the custom line preserved, and .DS_Store not duplicated.
+    const gitignore = fs.readFileSync(gitignorePath, 'utf8');
+    for (const l of [
+      '.obsidian/plugins/*/bin/',
+      '.smart-env/',
+      '.obsidian/workspace*',
+      '.DS_Store',
+      '.trash/',
+    ]) {
+      assert.ok(gitignore.includes(l), `.gitignore contains default line ${l}`);
+    }
+    assert.ok(gitignore.includes('my-secret-notes/'), 'custom .gitignore line survives (append-not-overwrite)');
+    assert.equal(gitignore.match(/\.DS_Store/g).length, 1, 'already-present default not duplicated');
 
     // 4a. The adopted dir is now a git repo with ≥1 commit.
     assert.ok(fs.existsSync(path.join(adopted, '.git')), 'adopted dir is a git repo');

--- a/tests/unit/adopt-git.test.js
+++ b/tests/unit/adopt-git.test.js
@@ -1,0 +1,214 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const adoptGit = require('../../src/core/adopt-git');
+const { WienerdogError } = require('../../src/core/errors');
+
+/** @param {object} result @returns {import('../../src/core/adopt-git').SpawnFn} */
+function fakeSpawn(result) {
+  return () => result;
+}
+
+test('runGitStep: success returns the spawn result and does not throw', () => {
+  const r = { status: 0, signal: null, stdout: Buffer.from(''), stderr: Buffer.from('') };
+  const out = adoptGit.runGitStep('/x', ['add', '-A'], 'git add -A', { spawn: fakeSpawn(r) });
+  assert.equal(out, r);
+});
+
+test('runGitStep: non-zero exit surfaces stderr + exit code', () => {
+  const r = { status: 1, signal: null, stdout: Buffer.from(''), stderr: Buffer.from('fatal: bad thing\n') };
+  assert.throws(
+    () => adoptGit.runGitStep('/x', ['commit'], 'git commit (initial snapshot)', { spawn: fakeSpawn(r) }),
+    (err) => {
+      assert.ok(err instanceof WienerdogError);
+      assert.match(err.message, /git commit \(initial snapshot\) failed: git exited with code 1\./);
+      assert.match(err.message, /git said: fatal: bad thing/);
+      // No size/lock hint for a plain non-zero exit with unremarkable stderr.
+      assert.doesNotMatch(err.message, /very large or locked file/);
+      return true;
+    }
+  );
+});
+
+test('runGitStep: SIGKILL surfaces the signal name and the size/lock hint', () => {
+  const r = { status: null, signal: 'SIGKILL', stdout: Buffer.from(''), stderr: Buffer.from('') };
+  assert.throws(
+    () => adoptGit.runGitStep('/x', ['add', '-A'], 'git add -A (staging the vault)', { spawn: fakeSpawn(r) }),
+    (err) => {
+      assert.match(err.message, /git add -A \(staging the vault\) failed: git was killed by signal SIGKILL\./);
+      assert.match(err.message, /git said: \(no output\)/);
+      assert.match(err.message, /very large or locked file/);
+      assert.match(err.message, /Exclude such paths via \.gitignore and retry\./);
+      return true;
+    }
+  );
+});
+
+test('runGitStep: exit 137 also triggers the size/lock hint', () => {
+  const r = { status: 137, signal: null, stdout: Buffer.from(''), stderr: Buffer.from('') };
+  assert.throws(
+    () => adoptGit.runGitStep('/x', ['add', '-A'], 'git add -A', { spawn: fakeSpawn(r) }),
+    /very large or locked file/
+  );
+});
+
+test('runGitStep: size-smelling stderr triggers the hint even on a plain non-zero exit', () => {
+  const r = { status: 1, signal: null, stdout: Buffer.from(''), stderr: Buffer.from('fatal: out of memory, malloc failed\n') };
+  assert.throws(
+    () => adoptGit.runGitStep('/x', ['add', '-A'], 'git add -A', { spawn: fakeSpawn(r) }),
+    /very large or locked file/
+  );
+});
+
+test('runGitStep: spawn error surfaces "could not start git" + git-installed hint', () => {
+  const r = { status: null, signal: null, error: { code: 'ENOENT' } };
+  assert.throws(
+    () => adoptGit.runGitStep('/x', ['init'], 'git init', { spawn: fakeSpawn(r) }),
+    (err) => {
+      assert.match(err.message, /git init failed: could not start git \(ENOENT\)\./);
+      assert.match(err.message, /Is git installed and on your PATH\?/);
+      // Spawn error uses the git-installed hint, NOT the size hint.
+      assert.doesNotMatch(err.message, /very large or locked file/);
+      return true;
+    }
+  );
+});
+
+test('inspectIndexLock: absent lock => present:false', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-lock-'));
+  try {
+    fs.mkdirSync(path.join(dir, '.git'));
+    const r = adoptGit.inspectIndexLock(dir);
+    assert.equal(r.present, false);
+    assert.equal(r.stale, false);
+    assert.equal(r.ageMs, null);
+    assert.equal(r.lockPath, path.join(dir, '.git', 'index.lock'));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('inspectIndexLock: freshly-created lock => stale:false', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-lock-'));
+  try {
+    fs.mkdirSync(path.join(dir, '.git'));
+    const lockPath = path.join(dir, '.git', 'index.lock');
+    fs.writeFileSync(lockPath, '');
+    const r = adoptGit.inspectIndexLock(dir);
+    assert.equal(r.present, true);
+    assert.equal(r.stale, false);
+    assert.ok(r.ageMs < adoptGit.STALE_LOCK_AGE_MS);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('inspectIndexLock: aged lock (mtime in the past) => stale:true', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-lock-'));
+  try {
+    fs.mkdirSync(path.join(dir, '.git'));
+    const lockPath = path.join(dir, '.git', 'index.lock');
+    fs.writeFileSync(lockPath, '');
+    const past = (Date.now() - 60_000) / 1000; // 60s ago, in seconds
+    fs.utimesSync(lockPath, past, past);
+    const r = adoptGit.inspectIndexLock(dir);
+    assert.equal(r.present, true);
+    assert.equal(r.stale, true);
+    assert.ok(r.ageMs >= adoptGit.STALE_LOCK_AGE_MS);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('inspectIndexLock: injectable now flips staleness deterministically', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-lock-'));
+  try {
+    fs.mkdirSync(path.join(dir, '.git'));
+    const lockPath = path.join(dir, '.git', 'index.lock');
+    fs.writeFileSync(lockPath, '');
+    const mtimeMs = fs.statSync(lockPath).mtimeMs;
+    const fresh = adoptGit.inspectIndexLock(dir, { now: mtimeMs + 1000 });
+    assert.equal(fresh.stale, false);
+    const stale = adoptGit.inspectIndexLock(dir, { now: mtimeMs + adoptGit.STALE_LOCK_AGE_MS });
+    assert.equal(stale.stale, true);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('removeIndexLock: deletes the lock; missing is fine', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-lock-'));
+  try {
+    const lockPath = path.join(dir, 'index.lock');
+    fs.writeFileSync(lockPath, '');
+    adoptGit.removeIndexLock(lockPath);
+    assert.equal(fs.existsSync(lockPath), false);
+    // Second removal on a now-missing file must not throw.
+    adoptGit.removeIndexLock(lockPath);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('planGitignore/applyGitignore: fresh file gets all five lines + header', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-ignore-'));
+  try {
+    const plan = adoptGit.planGitignore(dir);
+    assert.equal(plan.existing, false);
+    assert.deepEqual(plan.missing, adoptGit.DEFAULT_GITIGNORE_LINES);
+    adoptGit.applyGitignore(plan);
+    const written = fs.readFileSync(plan.path, 'utf8');
+    assert.match(written, /^# Added by wienerdog adopt/);
+    for (const l of adoptGit.DEFAULT_GITIGNORE_LINES) assert.ok(written.includes(l), `has ${l}`);
+    assert.ok(written.endsWith('\n'));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('planGitignore/applyGitignore: existing file with two defaults + custom → append only the missing three, preserve custom', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-ignore-'));
+  try {
+    const p = path.join(dir, '.gitignore');
+    fs.writeFileSync(p, 'node_modules/\n.DS_Store\n.trash/\n'); // custom + two defaults
+    const plan = adoptGit.planGitignore(dir);
+    assert.equal(plan.existing, true);
+    assert.deepEqual(plan.missing, [
+      '.obsidian/plugins/*/bin/',
+      '.smart-env/',
+      '.obsidian/workspace*',
+    ]);
+    adoptGit.applyGitignore(plan);
+    const after = fs.readFileSync(p, 'utf8');
+    // Custom line preserved, not reordered/removed.
+    assert.ok(after.includes('node_modules/'), 'custom line survives');
+    // The two already-present defaults are not duplicated.
+    assert.equal(after.match(/\.DS_Store/g).length, 1, '.DS_Store not duplicated');
+    assert.equal(after.match(/\.trash\//g).length, 1, '.trash/ not duplicated');
+    // The three missing defaults appended.
+    for (const l of plan.missing) assert.ok(after.includes(l), `appended ${l}`);
+    assert.match(after, /# Added by wienerdog adopt/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('applyGitignore: second run is a no-op (idempotent — no duplicate lines)', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-ignore-'));
+  try {
+    adoptGit.applyGitignore(adoptGit.planGitignore(dir));
+    const first = fs.readFileSync(path.join(dir, '.gitignore'), 'utf8');
+    const plan2 = adoptGit.planGitignore(dir);
+    assert.deepEqual(plan2.missing, [], 'nothing missing on re-plan');
+    adoptGit.applyGitignore(plan2);
+    const second = fs.readFileSync(path.join(dir, '.gitignore'), 'utf8');
+    assert.equal(second, first, 'file unchanged on second apply');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Spec: docs/specs/WP-029-adopt-snapshot-robustness.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

Changed files: `src/core/adopt-git.js` (create), `src/cli/adopt.js` (modify), `tests/unit/adopt-git.test.js` (create), `tests/integration/adopt-e2e.test.js` (modify). Plus always-allowed: the spec (status flip) and `docs/specs/ROADMAP.md` (status cell synced to In-Review).

## Verification output

```
$ node --test tests/unit/adopt-git.test.js
ℹ tests 14
ℹ pass 14
ℹ fail 0

$ node --test tests/integration/adopt-e2e.test.js
ℹ tests 2
ℹ pass 2
ℹ fail 0

$ npm test
ℹ tests 301
ℹ pass 301
ℹ fail 0

$ git status --porcelain tests/golden
(empty — no golden changed)
```

`npm run lint`: markdownlint reports 4 pre-existing MD038 errors, all in spec
markdown (`WP-029` message-shape code spans and `WP-030`), identical on a clean
`origin/main` checkout and unrelated to this change. None of this WP's deliverables
are markdown, so this change introduces zero lint findings. See Discovered issues.

## Decisions made

- **Stale-lock staleness = mtime age >= 10s** (the spec's proposed heuristic),
  not a `ps` process scan — matches the architect's rationale; recorded as accepted.
- **`inspectIndexLock` uses `fs.statSync` + injectable `now`**; `ageMs = now - mtimeMs`.
  A lock with age exactly `>= STALE_LOCK_AGE_MS` is stale (inclusive), per the contract.
- **ROADMAP status cell** synced from `Ready` to `In-Review` alongside the spec
  frontmatter flip (roadmap is in the always-allowed list) so the two don't drift.
- **`applyGitignore` re-reads the file** before appending rather than trusting the
  plan's captured content, avoiding any staleness between plan and apply.

## Discovered issues (out of scope, not fixed)

- `npm run lint` already fails on clean `origin/main`: 4 MD038 "spaces inside code
  span" errors in `docs/specs/WP-029-...md` (the literal hint-line code spans, lines
  217/218/220) and `docs/specs/WP-030-...md:172`. Both are spec prose authored before
  this WP; `WP-030` is another work package's file. Not fixed — fixing WP-029's spans
  would misrepresent the exact literal output the code emits, and WP-030 is out of scope.

---
Generated-by: claude-opus-4-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EA5BsHCfHRViJFXdovC86
