### PR TITLE
fix(gws): reject CR/LF in MIME header fields (WP-085)

### DIFF
--- a/docs/specs/WP-085-gws-mime-crlf-sanitization.md
+++ b/docs/specs/WP-085-gws-mime-crlf-sanitization.md
@@ -1,7 +1,7 @@
 ---
 id: WP-085
 title: Reject CR/LF in Gmail MIME header fields (close the send-grant header-injection bypass)
-status: Draft
+status: In-Review
 model: sonnet
 size: S
 depends_on: []

--- a/src/gws/gmail.js
+++ b/src/gws/gmail.js
@@ -1,10 +1,26 @@
 'use strict';
 
+const { WienerdogError } = require('../core/errors');
+
 /**
  * Gmail verb functions. Each takes `(services, opts)` and returns plain data;
  * they perform no console I/O (that is index.js's job). `services` is the
  * object from getServices; tests pass a stub with just the methods used.
  */
+
+/** Reject a header field value that contains a CR or LF (RFC-2822 header
+ *  injection — a bare/paired CR/LF would smuggle an extra header such as Bcc:,
+ *  defeating the send-grant allowlist, ADR-0007). Header fields are single-line
+ *  by construction (addresses, a subject); a legitimate value never contains a
+ *  line break, so rejecting is safe and is the fail-closed choice.
+ *  @param {string} value @param {string} field  e.g. 'Subject'
+ *  @returns {string} the value unchanged when safe; throws otherwise. */
+function assertHeaderSafe(value, field) {
+  if (/[\r\n]/.test(String(value))) {
+    throw new WienerdogError(`refusing to build email: ${field} contains a line break (possible header injection)`);
+  }
+  return String(value);
+}
 
 /**
  * Pull a header value (case-insensitive) from a Gmail headers array.
@@ -174,12 +190,12 @@ async function send(services, opts) {
  */
 function buildMime(m) {
   const lines = [];
-  if (m.from) lines.push(`From: ${m.from}`);
-  lines.push(`To: ${m.to}`);
-  lines.push(`Subject: ${m.subject}`);
+  if (m.from) lines.push(`From: ${assertHeaderSafe(m.from, 'From')}`);
+  lines.push(`To: ${assertHeaderSafe(m.to, 'To')}`);
+  lines.push(`Subject: ${assertHeaderSafe(m.subject, 'Subject')}`);
   lines.push('Content-Type: text/plain; charset="UTF-8"');
   lines.push('');
-  lines.push(m.body);
+  lines.push(m.body);           // body unchanged — content, not a header
   const mime = lines.join('\r\n');
   return Buffer.from(mime).toString('base64url');
 }

--- a/tests/unit/gws-gmail.test.js
+++ b/tests/unit/gws-gmail.test.js
@@ -2,8 +2,12 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const gmail = require('../../src/gws/gmail');
+const alert = require('../../src/gws/alert');
 
 /** base64url-encode a plain string the way Gmail returns body data. */
 function b64url(s) {
@@ -166,4 +170,102 @@ test('buildMime produces base64url with To/Subject/Content-Type headers and body
     'From: f@x.com\r\nTo: t@x.com\r\nSubject: S\r\n' +
       'Content-Type: text/plain; charset="UTF-8"\r\n\r\nB'
   );
+});
+
+test('buildMime throws WienerdogError when subject contains a CRLF (header injection)', () => {
+  assert.throws(
+    () => gmail.buildMime({ to: 'a@b.com', subject: 'x\r\nBcc: evil@evil.com', body: 'hi' }),
+    (err) => err.name === 'WienerdogError' && /Subject/.test(err.message)
+  );
+});
+
+test('buildMime throws WienerdogError when to contains a bare LF', () => {
+  assert.throws(
+    () => gmail.buildMime({ to: 'a@b.com\nBcc: evil@evil.com', subject: 'x', body: 'hi' }),
+    (err) => err.name === 'WienerdogError' && /To/.test(err.message)
+  );
+});
+
+test('buildMime throws WienerdogError when from contains a CR', () => {
+  assert.throws(
+    () => gmail.buildMime({ from: 'a@b.com\rBcc: evil@evil.com', to: 'c@d.com', subject: 'x', body: 'hi' }),
+    (err) => err.name === 'WienerdogError' && /From/.test(err.message)
+  );
+});
+
+/** Write a minimal config.yaml granting `routine` to send to `to`, and return
+ *  a paths-shaped object exposing only the `config` field `gmail.send` reads. */
+function grantedPaths(routine, to) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-gmail-grant-'));
+  const config = path.join(dir, 'config.yaml');
+  fs.writeFileSync(
+    config,
+    '# --- wienerdog:grants (managed by `wienerdog grant`; do not edit by hand) ---\n' +
+      'grants:\n' +
+      `  - routine: ${routine}\n` +
+      '    to:\n' +
+      `      - ${to}\n` +
+      '# --- end wienerdog:grants ---\n'
+  );
+  return { config };
+}
+
+test('send with a granted recipient but a CRLF-bearing subject throws and never calls messages.send', async () => {
+  const paths = grantedPaths('daily-digest', 'a@b.com');
+  const calls = { send: [], drafts: [] };
+  const services = {
+    gmail: {
+      users: {
+        messages: {
+          send: async (args) => {
+            calls.send.push(args);
+            return { data: { id: 'sent-1' } };
+          },
+        },
+        drafts: {
+          create: async (args) => {
+            calls.drafts.push(args);
+            return { data: { id: 'r-1', message: { id: 'm-1' } } };
+          },
+        },
+      },
+    },
+  };
+
+  await assert.rejects(
+    () =>
+      gmail.send(services, {
+        to: 'a@b.com',
+        subject: 'x\r\nBcc: evil@evil.com',
+        body: 'hi',
+        routine: 'daily-digest',
+        paths,
+      }),
+    (err) => err.name === 'WienerdogError' && /Subject/.test(err.message)
+  );
+  assert.equal(calls.send.length, 0);
+  assert.equal(calls.drafts.length, 0);
+});
+
+test('_alert (via alert.run) throws when opts.subject contains a CRLF', async () => {
+  const calls = { send: 0 };
+  const services = {
+    gmail: {
+      users: {
+        getProfile: async () => ({ data: { emailAddress: 'owner@example.com' } }),
+        messages: {
+          send: async () => {
+            calls.send++;
+            return { data: { id: 'x' } };
+          },
+        },
+      },
+    },
+  };
+
+  await assert.rejects(
+    () => alert.run(services, { subject: 'watchdog failed\r\nBcc: evil@evil.com', body: 'job X crashed' }),
+    (err) => err.name === 'WienerdogError' && /Subject/.test(err.message)
+  );
+  assert.equal(calls.send, 0);
 });


### PR DESCRIPTION
Spec: docs/specs/WP-085-gws-mime-crlf-sanitization.md

Closes a send-grant allowlist bypass surfaced by the Codex adversarial audit of the gws module. `buildMime` interpolated `To`/`Subject`/`From` into RFC-2822 headers with no CR/LF sanitization, so an attacker-controlled subject (e.g. from an injection-steered routine) could inject a `Bcc:` header that the recipient gate never sees — reaching a non-allowlisted recipient and defeating **ADR-0007 / Threat T4a**.

Fix: a single `assertHeaderSafe` at the shared `buildMime` choke point rejects any CR/LF in a header field (fail-closed via `WienerdogError`, no strip); the body is intentionally not validated (post-blank-line content cannot inject a header). Closes the same hole for `send`, `draft`, and the `_alert` self-send.

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table (`src/gws/gmail.js`, `tests/unit/gws-gmail.test.js`)
- [x] Spec status flipped to In-Review

## Verification output

```
npm test -- --test-name-pattern gmail : 53/53 pass
npm test                              : 641/641 pass
npm run lint                          : clean (markdownlint, shellcheck, PSScriptAnalyzer, frontmatter)
```

Independently re-run and confirmed by wd-reviewer → **APPROVE** (verified the tests prove the hole is closed, not just that a function was called).

## Decisions made

- For the "granted recipient + CRLF subject" test, used a self-contained grant-shaped `config.yaml` fixture in the new test file rather than touching the out-of-scope `gws-send.test.js`.

## Discovered issues (out of scope, not fixed)

- A pre-existing markdownlint MD038 typo in the WP-089 spec surfaced during the run; fixed separately on `main` (this branch is rebased onto that fix, so lint is clean here).

---
Generated-by: claude-sonnet (implement) + claude-fable-5 (orchestrate); wd-reviewer: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uxThuapovGTPsbyn86BAf
