### PR TITLE
fix(gws): harden the send-grant confirmation boundary (WP-086)

### DIFF
--- a/docs/specs/WP-086-send-grant-boundary-hardening.md
+++ b/docs/specs/WP-086-send-grant-boundary-hardening.md
@@ -1,7 +1,7 @@
 ---
 id: WP-086
 title: Harden the send-grant boundary — require a terminal to mint a grant; fail closed on an empty recipient list
-status: Draft
+status: In-Review
 model: sonnet
 size: S
 depends_on: []

--- a/src/cli/grant.js
+++ b/src/cli/grant.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const fs = require('node:fs');
 const readline = require('node:readline');
 const { getPaths } = require('../core/paths');
 const { WienerdogError } = require('../core/errors');
@@ -7,24 +8,50 @@ const grantLib = require('../gws/grant');
 
 /**
  * `wienerdog grant send` — the ONLY way a send grant is created (ADR-0007).
- * The typed-word confirmation is the security boundary: it is driven by real
- * stdin and `--yes` does NOT bypass it, so no skill, hook, dream, or headless
- * job (nothing scriptable via `--yes`) can mint or widen a grant.
+ * The typed-word confirmation is the security boundary: it is read from a real
+ * controlling terminal (never a piped/redirected stdin) and `--yes` does NOT
+ * bypass it, so no skill, hook, dream, or headless job (nothing scriptable via
+ * `--yes` or a plain pipe) can mint or widen a grant.
  */
 
-/**
- * Default prompt: read one line from stdin. Injectable so the CLI is unit
- * testable without a real TTY.
- * @param {string} question
- * @returns {Promise<string>}
- */
-function defaultPrompt(question) {
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+const NO_TTY_GRANT_MESSAGE =
+  'wienerdog: a send grant can only be created at a real terminal (no terminal here). ' +
+  'Run `wienerdog grant send …` in an interactive shell.';
+
+/** Read the typed-word confirmation from a real controlling terminal. When stdin
+ *  is a TTY, read it directly; otherwise open the controlling terminal (/dev/tty).
+ *  There is NO environment override — a headless process must not be able to point
+ *  this at a regular file and script the confirmation (ADR-0007). `openTty` is a
+ *  code-level test seam only: tests pass a fake stream factory; production uses the
+ *  literal /dev/tty. On no reachable terminal (piped/redirected/EOF/error) it prints
+ *  a refusal and resolves to '' — which can never equal the confirmation word.
+ *  @param {string} question
+ *  @param {{openTty?:() => NodeJS.ReadableStream}} [opts]
+ *  @returns {Promise<string>} */
+function defaultPrompt(question, opts = {}) {
+  if (process.stdin.isTTY) {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    return new Promise((resolve) => rl.question(question, (a) => { rl.close(); resolve(a); }));
+  }
+  const openTty = opts.openTty || (() => fs.createReadStream('/dev/tty'));
   return new Promise((resolve) => {
-    rl.question(question, (answer) => {
-      rl.close();
-      resolve(answer);
+    let input;
+    try { input = openTty(); } catch { process.stderr.write(`${NO_TTY_GRANT_MESSAGE}\n`); resolve(''); return; }
+    let settled = false;
+    const refuse = () => {
+      if (settled) return; settled = true;
+      try { input.destroy(); } catch { /* ignore */ }
+      process.stderr.write(`${NO_TTY_GRANT_MESSAGE}\n`); resolve('');
+    };
+    input.once('error', refuse);
+    const rl = readline.createInterface({ input, output: process.stderr });
+    rl.on('error', () => {}); // readline re-emits stream errors; `input`'s handler drives the abort
+    rl.question(question, (a) => {
+      if (settled) return; settled = true;
+      rl.close(); try { input.destroy(); } catch { /* ignore */ }
+      resolve(a);
     });
+    rl.on('close', () => { if (!settled) refuse(); });
   });
 }
 
@@ -123,4 +150,4 @@ async function run(argv, opts = {}) {
   out.write(`wienerdog: granted "${parsed.routine}" → ${recipients.join(', ')}.\n`);
 }
 
-module.exports = { run };
+module.exports = { run, defaultPrompt };

--- a/src/gws/grant.js
+++ b/src/gws/grant.js
@@ -185,11 +185,14 @@ function isSendAllowed(grant, recipients) {
   if (!grant) {
     return { allowed: false, reason: 'no send grant for this routine' };
   }
+  const list = (recipients || []).map((r) => String(r).trim()).filter(Boolean);
+  if (list.length === 0) {
+    return { allowed: false, reason: 'no recipient to check (empty list)' };
+  }
   const allow = new Set((grant.to || []).map((a) => String(a).trim().toLowerCase()));
-  for (const r of recipients) {
-    const norm = String(r).trim().toLowerCase();
-    if (!allow.has(norm)) {
-      return { allowed: false, reason: `recipient ${String(r).trim()} not in allowlist` };
+  for (const r of list) {
+    if (!allow.has(r.toLowerCase())) {
+      return { allowed: false, reason: `recipient ${r} not in allowlist` };
     }
   }
   return { allowed: true, reason: 'all recipients granted' };

--- a/tests/unit/gws-grant.test.js
+++ b/tests/unit/gws-grant.test.js
@@ -7,6 +7,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const crypto = require('node:crypto');
+const { PassThrough } = require('node:stream');
 
 const grant = require('../../src/gws/grant');
 const grantCli = require('../../src/cli/grant');
@@ -44,6 +45,17 @@ function tempEnv() {
 function initPaths(env) {
   execFileSync('node', [bin, 'init', '--yes'], { env, stdio: 'ignore' });
   return getPaths(env);
+}
+
+/** Runs fn with process.stdin.isTTY forced to `value`, restoring it after. */
+async function withStdinTTY(value, fn) {
+  const original = process.stdin.isTTY;
+  process.stdin.isTTY = value;
+  try {
+    await fn();
+  } finally {
+    process.stdin.isTTY = original;
+  }
 }
 
 const BASE_CONFIG =
@@ -90,6 +102,20 @@ test('isSendAllowed allows only when every recipient is granted (case-insensitiv
   // No wildcards / no domain grants.
   assert.equal(grant.isSendAllowed({ routine: 'r', to: ['*@x.com'] }, ['z@x.com']).allowed, false);
   assert.equal(grant.isSendAllowed({ routine: 'r', to: ['x.com'] }, ['z@x.com']).allowed, false);
+});
+
+test('isSendAllowed FAILS CLOSED on an empty or whitespace-only recipient list (WP-086)', () => {
+  const g = { routine: 'r', to: ['a@x.com'] };
+  const empty = grant.isSendAllowed(g, []);
+  assert.equal(empty.allowed, false);
+  assert.match(empty.reason, /empty list/);
+
+  const blank = grant.isSendAllowed(g, ['   ']);
+  assert.equal(blank.allowed, false);
+  assert.match(blank.reason, /empty list/);
+
+  // A valid non-empty allowlisted list is unaffected.
+  assert.equal(grant.isSendAllowed(g, ['a@x.com']).allowed, true);
 });
 
 test('findGrant returns null for a null routine', () => {
@@ -199,6 +225,63 @@ test('grant CLI warns about third-party recipients before prompting', async () =
     process.stdout.write = orig;
   }
   assert.match(lines.join(''), /third-party addresses/);
+});
+
+// --- defaultPrompt controlling-terminal boundary (WP-086) --------------------
+
+test('defaultPrompt: no controlling terminal reachable (openTty errors) refuses and resolves "" — never "grant"', async () => {
+  await withStdinTTY(false, async () => {
+    const openTty = () => {
+      const s = new PassThrough();
+      process.nextTick(() => s.emit('error', new Error("ENXIO: no such device or address, open '/dev/tty'")));
+      return s;
+    };
+    const stderrOrig = process.stderr.write;
+    let stderr = '';
+    process.stderr.write = (chunk, ...rest) => { stderr += chunk.toString(); return stderrOrig.call(process.stderr, chunk, ...rest); };
+    let answer;
+    try {
+      answer = await grantCli.defaultPrompt('Type the word "grant" to confirm: ', { openTty });
+    } finally {
+      process.stderr.write = stderrOrig;
+    }
+    assert.equal(answer, '');
+    assert.match(stderr, /a send grant can only be created at a real terminal/);
+  });
+});
+
+test('defaultPrompt: a real controlling terminal (injected via openTty) can supply "grant"', async () => {
+  await withStdinTTY(false, async () => {
+    const openTty = () => {
+      const s = new PassThrough();
+      s.end('grant\n');
+      return s;
+    };
+    const answer = await grantCli.defaultPrompt('Type the word "grant" to confirm: ', { openTty });
+    assert.equal(answer, 'grant');
+  });
+});
+
+test('grant CLI: a piped/redirected/closed stdin cannot mint a grant (no controlling terminal reachable)', async () => {
+  const { env } = tempEnv();
+  const paths = initPaths(env);
+  await withStdinTTY(false, async () => {
+    const openTty = () => {
+      const s = new PassThrough();
+      process.nextTick(() => s.emit('error', new Error('ENXIO')));
+      return s;
+    };
+    // promptFn wired to the real defaultPrompt (with the injected openTty seam),
+    // simulating `printf 'grant\n' | wienerdog grant send …` from a headless shell:
+    // the piped stdin is never read by the non-TTY branch, so it cannot supply
+    // the confirmation word regardless of its contents.
+    await grantCli.run(['send', '--routine', 'daily-digest', '--to', 'attacker@evil.com'], {
+      paths,
+      promptFn: (q) => grantCli.defaultPrompt(q, { openTty }),
+    });
+  });
+  assert.equal(grant.findGrant(paths, 'daily-digest'), null);
+  assert.doesNotMatch(fs.readFileSync(paths.config, 'utf8'), /wienerdog:grants/);
 });
 
 test('grant CLI rejects a bad address and a missing flag', async () => {


### PR DESCRIPTION
Spec: docs/specs/WP-086-send-grant-boundary-hardening.md

Hardens the send-grant confirmation boundary (Codex audit, **ADR-0007 / Threat T4a**). Two defects: (1) `defaultPrompt` read `process.stdin` with no controlling-terminal check, so `printf 'grant\n' | wienerdog grant send …` satisfied the "typed confirmation" from a headless/piped context — the "no headless job can mint a grant" invariant was false; (2) `isSendAllowed` returned `allowed:true` vacuously on an empty recipient list (fail-open).

Fix: production `defaultPrompt` accepts input only from a real controlling terminal (`stdin.isTTY`, else a `/dev/tty` stream via an injected `openTty` factory — no env-var override); a piped/redirected/closed stdin or EOF resolves to `''`, which can never equal the `grant` confirmation word. `isSendAllowed` fails closed on an empty recipient list. The invariant is narrowed to the honest, defensible claim ("ordinary redirected/piped/closed stdin cannot confirm"), with a same-user PTY recorded as out-of-threat-model (parity with the config.yaml-writable residual).

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table (`src/cli/grant.js`, `src/gws/grant.js`, `tests/unit/gws-grant.test.js`)
- [x] Spec status flipped to In-Review

## Verification output

```
npm test -- --test-name-pattern grant : 66/66 pass
npm test                              : 640/640 pass
npm run lint                          : clean (rebased onto main's WP-089 lint fix)
```

wd-reviewer → **APPROVE** (structurally proved a headless/piped/EOF stdin can never mint a grant; confirmed no env override anywhere).

## Decisions made

- Duplicated ~15 lines of terminal-open logic in `grant.js` rather than reusing `core/prompt.js#confirm()`, per the spec (that helper's env-var TTY seam is unacceptable for the grant boundary).
- Corrected a stale module comment ("driven by real stdin" → "read from a real controlling terminal").

## Discovered issues (out of scope, not fixed)

- none.

---
Generated-by: claude-sonnet (implement) + claude-fable-5 (orchestrate); wd-reviewer: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uxThuapovGTPsbyn86BAf
