### PR TITLE
fix(dream): rebase skill-invocation indices under byte-budget truncation (WP-087)

### DIFF
--- a/docs/specs/WP-087-dream-truncation-index-rebase.md
+++ b/docs/specs/WP-087-dream-truncation-index-rebase.md
@@ -1,7 +1,7 @@
 ---
 id: WP-087
 title: Rebase skill-invocation indices when a dream extract is byte-budget truncated
-status: Draft
+status: In-Review
 model: sonnet
 size: S
 depends_on: []

--- a/src/core/dream/scratch.js
+++ b/src/core/dream/scratch.js
@@ -35,7 +35,24 @@ function truncateExtractToFit(extract, targetBytes) {
   const msgs = extract.messages;
   const build = (k) => {
     const keptMsgs = k === 0 ? [] : msgs.slice(msgs.length - k);
-    return { ...extract, truncated: true, started: keptMsgs.length ? keptMsgs[0].ts : null, messages: keptMsgs };
+    const dropped = msgs.length - keptMsgs.length; // leading messages removed
+    const out = { ...extract, truncated: true, started: keptMsgs.length ? keptMsgs[0].ts : null, messages: keptMsgs };
+    if (Array.isArray(extract.skill_invocations)) {
+      // Front-truncation: subtract the dropped-leading count from index/resultIndex
+      // and drop any invocation whose window fell into the removed prefix. Same
+      // helper WP-080 uses under the message COUNT cap — keeping the two truncation
+      // paths consistent so security-load-bearing indices always match `messages`.
+      // Then apply the SAME right-edge (upper-bound) filter the count-cap path uses
+      // at transcripts/index.js:135-136: a trailing invocation whose raw index ===
+      // messages.length rebases to keptMsgs.length (one past the end) and must be
+      // dropped — rebaseInvocations only checks the lower bound (>= 0).
+      out.skill_invocations = transcripts
+        .rebaseInvocations(extract.skill_invocations, dropped)
+        .filter(
+          (si) => si.index < keptMsgs.length && (si.resultIndex === null || si.resultIndex < keptMsgs.length),
+        );
+    }
+    return out;
   };
   let lo = 0,
     hi = msgs.length,

--- a/tests/unit/dream-collect.test.js
+++ b/tests/unit/dream-collect.test.js
@@ -10,6 +10,7 @@ const { getPaths } = require('../../src/core/paths');
 const { readDreamConfig } = require('../../src/core/dream/config');
 const { readWatermarks, writeWatermarks } = require('../../src/core/dream/watermarks');
 const { collectExtracts, cleanScratch, MIN_TRUNCATE_BYTES } = require('../../src/core/dream/scratch');
+const { MAX_MESSAGES } = require('../../src/core/transcripts');
 
 /** Fresh temp home + resolved paths. */
 function tempPaths() {
@@ -224,6 +225,176 @@ test('dream-collect: capacity sub-floor budget drops the session whole and does 
   assert.equal(result.dropped[0].session_id, 'c1');
   // Whole-dropped session must NOT advance the watermark (retried next run).
   assert.equal(result.maxMtime.claude, null);
+});
+
+// ---- byte-budget truncation rebases skill_invocations (WP-087) ----
+
+test('dream-collect: byte-budget truncation rebases skill_invocations and drops ones fallen into the removed prefix', () => {
+  const paths = tempPaths();
+  const sessionId = 'sk1';
+  const dir = path.join(paths.claudeDir, 'projects', 'proj');
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${sessionId}.jsonl`);
+  const ts = '2026-01-01T10:00:00.000Z';
+  const big = 'x'.repeat(4000); // at MAX_MSG_CHARS so capMessage doesn't shrink it
+  const lines = [];
+  for (let i = 0; i < 30; i++) {
+    lines.push(JSON.stringify({ type: 'user', sessionId, cwd: '/p', timestamp: ts, message: { role: 'user', content: big } }));
+  }
+  lines.push(
+    JSON.stringify({
+      type: 'assistant',
+      sessionId,
+      cwd: '/p',
+      timestamp: ts,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'look' }, { type: 'tool_use', id: 'toolu_early', name: 'Skill', input: { skill: 'early' } }] },
+    })
+  );
+  lines.push(
+    JSON.stringify({
+      type: 'user',
+      sessionId,
+      cwd: '/p',
+      timestamp: ts,
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_early', is_error: false, content: [{ type: 'text', text: 'done-early' }] }] },
+    })
+  );
+  for (let i = 0; i < 30; i++) {
+    lines.push(JSON.stringify({ type: 'user', sessionId, cwd: '/p', timestamp: ts, message: { role: 'user', content: big } }));
+  }
+  // 'late' is the LAST raw event in the file, so it survives any byte truncation
+  // that keeps at least one message (k >= 1) — robust regardless of exact k.
+  lines.push(
+    JSON.stringify({
+      type: 'assistant',
+      sessionId,
+      cwd: '/p',
+      timestamp: ts,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'run-late' }, { type: 'tool_use', id: 'toolu_late', name: 'Skill', input: { skill: 'late' } }] },
+    })
+  );
+  lines.push(
+    JSON.stringify({
+      type: 'user',
+      sessionId,
+      cwd: '/p',
+      timestamp: ts,
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_late', is_error: false, content: [{ type: 'text', text: 'done-late' }] }] },
+    })
+  );
+  fs.writeFileSync(file, lines.join('\n') + '\n');
+  const when = new Date('2026-01-05T00:00:00Z');
+  fs.utimesSync(file, when, when);
+
+  // ~240KB+ of padding vs. a 60KB budget forces truncation to a small newest-suffix.
+  const result = collectExtracts(paths, { claude: null, codex: null }, 60_000);
+
+  assert.equal(result.entries.length, 1);
+  assert.equal(result.entries[0].truncatedToFit, true);
+  const extract = JSON.parse(fs.readFileSync(path.join(result.scratchDir, `claude-${sessionId}.json`), 'utf8'));
+  assert.ok(extract.messages.length < 64);
+
+  const skills = extract.skill_invocations.map((si) => si.skill);
+  assert.ok(!skills.includes('early')); // window fell entirely in the dropped prefix
+
+  const late = extract.skill_invocations.find((si) => si.skill === 'late');
+  assert.ok(late, 'late invocation must survive truncation');
+  assert.ok(late.index >= 0 && late.index < extract.messages.length);
+  assert.ok(late.resultIndex >= 0 && late.resultIndex < extract.messages.length);
+  assert.equal(extract.messages[late.resultIndex].text, 'done-late');
+});
+
+test('dream-collect: byte-budget truncation drops a trailing invocation whose rebased index would equal messages.length (right edge)', () => {
+  const paths = tempPaths();
+  const sessionId = 'sk2';
+  const dir = path.join(paths.claudeDir, 'projects', 'proj');
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${sessionId}.jsonl`);
+  const ts = '2026-01-01T10:00:00.000Z';
+  const big = 'x'.repeat(4000);
+  const lines = [];
+  for (let i = 0; i < 30; i++) {
+    lines.push(JSON.stringify({ type: 'user', sessionId, cwd: '/p', timestamp: ts, message: { role: 'user', content: big } }));
+  }
+  // Final raw event: an assistant turn carrying a Skill tool_use with nothing after
+  // it (no paired tool_result, no later message). Its raw index === raw messages
+  // count, so after rebasing it lands on keptMsgs.length — one past the last valid
+  // slot — and must be dropped by the upper-bound filter.
+  lines.push(
+    JSON.stringify({
+      type: 'assistant',
+      sessionId,
+      cwd: '/p',
+      timestamp: ts,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'tail' }, { type: 'tool_use', id: 'toolu_bar', name: 'Skill', input: { skill: 'bar' } }] },
+    })
+  );
+  fs.writeFileSync(file, lines.join('\n') + '\n');
+  const when = new Date('2026-01-05T00:00:00Z');
+  fs.utimesSync(file, when, when);
+
+  const result = collectExtracts(paths, { claude: null, codex: null }, 60_000);
+
+  assert.equal(result.entries.length, 1);
+  assert.equal(result.entries[0].truncatedToFit, true);
+  const extract = JSON.parse(fs.readFileSync(path.join(result.scratchDir, `claude-${sessionId}.json`), 'utf8'));
+  assert.deepEqual(extract.skill_invocations, []);
+});
+
+test('dream-collect: a session hitting the MAX_MESSAGES count cap in parse() AND THEN byte-budget truncation keeps its invocation in range', () => {
+  const paths = tempPaths();
+  const sessionId = 'sk3';
+  const dir = path.join(paths.claudeDir, 'projects', 'proj');
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${sessionId}.jsonl`);
+  const ts = '2026-01-01T10:00:00.000Z';
+  const lines = [];
+  // Enough small padding messages that, once the invocation + result are appended,
+  // parse() applies its MAX_MESSAGES count cap FIRST (front-truncating and
+  // rebasing — WP-080, untouched by this WP).
+  const padCount = MAX_MESSAGES + 50;
+  for (let i = 0; i < padCount; i++) {
+    lines.push(JSON.stringify({ type: 'user', sessionId, cwd: '/p', timestamp: ts, message: { role: 'user', content: `pad${i}` } }));
+  }
+  // The invocation + its result are the LAST raw messages: they survive parse()'s
+  // count cap as the newest tail, remaining the last two messages of the capped
+  // extract, so they also survive any further byte-budget truncation (k2 >= 1).
+  lines.push(
+    JSON.stringify({
+      type: 'assistant',
+      sessionId,
+      cwd: '/p',
+      timestamp: ts,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'run-mid' }, { type: 'tool_use', id: 'toolu_mid', name: 'Skill', input: { skill: 'mid' } }] },
+    })
+  );
+  lines.push(
+    JSON.stringify({
+      type: 'user',
+      sessionId,
+      cwd: '/p',
+      timestamp: ts,
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_mid', is_error: false, content: [{ type: 'text', text: 'done-mid' }] }] },
+    })
+  );
+  fs.writeFileSync(file, lines.join('\n') + '\n');
+  const when = new Date('2026-01-05T00:00:00Z');
+  fs.utimesSync(file, when, when);
+
+  // Budget well below the ~2000-message capped extract's serialized size, but above
+  // MIN_TRUNCATE_BYTES → forces a SECOND (byte) truncation on top of the count cap.
+  const result = collectExtracts(paths, { claude: null, codex: null }, 50_000);
+
+  assert.equal(result.entries.length, 1);
+  assert.equal(result.entries[0].truncatedToFit, true);
+  const extract = JSON.parse(fs.readFileSync(path.join(result.scratchDir, `claude-${sessionId}.json`), 'utf8'));
+  assert.ok(extract.messages.length < MAX_MESSAGES);
+  assert.equal(extract.skill_invocations.length, 1);
+  const mid = extract.skill_invocations[0];
+  assert.equal(mid.skill, 'mid');
+  assert.ok(mid.index >= 0 && mid.index < extract.messages.length);
+  assert.ok(mid.resultIndex >= 0 && mid.resultIndex < extract.messages.length);
+  assert.equal(extract.messages[mid.resultIndex].text, 'done-mid');
 });
 
 test('dream-collect: re-running empties stale scratch, cleanScratch removes it', () => {


### PR DESCRIPTION
Spec: docs/specs/WP-087-dream-truncation-index-rebase.md

Fixes a security-load-bearing correctness gap in the dream pipeline (Codex audit, **Threat T1 / ADR-0020**). `truncateExtractToFit` kept the newest *k* messages but spread the original extract, leaving `skill_invocations` `index`/`resultIndex` unrebased; the truncated extract was written to scratch and later fed to `validate.js`'s `invocationWindowTainted`, which read those stale indices against the shifted `messages` array. A mis-windowed invocation can let an external `tool_result` fall outside the window, so an untrusted learning is mis-judged trusted and could authorize a skill revision.

Fix: after dropping oldest messages, rebase `skill_invocations` by the dropped count via the existing exported `transcripts.rebaseInvocations`, then apply the same upper-bound filter as the count-cap path (`transcripts/index.js:135-136`) so a trailing invocation at `index === keptMsgs.length` is dropped. Rebasing happens inside `build(k)` so the binary-search byte measurement sees the same array that gets written.

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table (`src/core/dream/scratch.js`, `tests/unit/dream-collect.test.js`)
- [x] Spec status flipped to In-Review

## Verification output

```
npm test -- --test-name-pattern "collect|dream" : 168 pass
npm test                                        : 639/639 pass
npm run lint                                    : clean
```

wd-reviewer → **APPROVE** (reverted the fix and confirmed all 3 new tests fail without it — genuine regression tests).

## Decisions made

- Reused the already-exported `rebaseInvocations` (WP-080) rather than re-implementing; kept the change surgical (only the per-candidate object construction, binary search untouched).

## Discovered issues (out of scope, not fixed)

- none.

---
Generated-by: claude-sonnet (implement) + claude-fable-5 (orchestrate); wd-reviewer: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uxThuapovGTPsbyn86BAf
