### PR TITLE
fix(adapters): fingerprint-guard copied-skill ownership (WP-089)

### DIFF
--- a/docs/specs/WP-089-adapter-skill-dir-ownership.md
+++ b/docs/specs/WP-089-adapter-skill-dir-ownership.md
@@ -1,7 +1,7 @@
 ---
 id: WP-089
 title: Adapter skill-dir ownership — never recursively delete a user directory in the wienerdog-* namespace (content-fingerprint guard)
-status: Draft
+status: In-Review
 model: sonnet
 size: S
 depends_on: []

--- a/src/adapters/shared.js
+++ b/src/adapters/shared.js
@@ -2,6 +2,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { hashDir } = require('../core/manifest');
 
 const BEGIN = '<!-- wienerdog:begin -->';
 const END = '<!-- wienerdog:end -->';
@@ -17,6 +18,25 @@ function recordOnce(manifest, entry) {
   if (!Array.isArray(manifest.entries)) manifest.entries = [];
   const exists = manifest.entries.some((e) => e.kind === entry.kind && e.path === entry.path);
   if (!exists) manifest.entries.push(entry);
+}
+
+/** Record — or UPSERT — a copied-skill manifest entry, refreshing its content
+ *  fingerprint. Unlike recordOnce (which no-ops when a same-kind+path entry
+ *  exists), this updates the recorded `hash` so a legitimately refreshed copy
+ *  carries its CURRENT fingerprint. When `hash` is null (hashDir could not read
+ *  the tree) the entry is recorded WITHOUT a `hash` field — NEVER persist null/''
+ *  (a hash-less entry is treated as unverifiable → preserved, the safe direction).
+ *  @param {object} [manifest] @param {string} linkPath @param {string|null} hash */
+function recordCopiedSkill(manifest, linkPath, hash) {
+  if (!manifest) return;
+  if (!Array.isArray(manifest.entries)) manifest.entries = [];
+  const existing = manifest.entries.find(
+    (e) => e.kind === 'copied-skill' && e.path === linkPath
+  );
+  const entry = existing || { kind: 'copied-skill', path: linkPath };
+  if (typeof hash === 'string') entry.hash = hash;
+  else delete entry.hash;
+  if (!existing) manifest.entries.push(entry);
 }
 
 /**
@@ -304,17 +324,37 @@ function applySkillLinks(skillsDir, targetSkillsDir, dryRun, manifest, out, opts
         out.changed.push(linkPath);
       }
     } else if (stat !== null && stat.isDirectory()) {
-      // A prior copy in the wienerdog-* namespace — refresh if content differs.
-      if (dirsEqual(target, linkPath)) {
-        out.unchanged.push(linkPath);
-      } else {
-        if (!dryRun) {
-          fs.rmSync(linkPath, { recursive: true, force: true });
-          fs.cpSync(target, linkPath, { recursive: true });
+      // A directory in the wienerdog-* namespace. Refresh it ONLY when its on-disk
+      // fingerprint still matches the hash WE recorded for it (proof it is our own
+      // unmodified copy). A mismatch — the user edited/replaced it — or a directory
+      // we never recorded (a pre-existing user dir; a legacy hash-less entry) is NOT
+      // provably ours, so PRESERVE it untouched with a notice; NEVER rmSync+recopy
+      // (that was the destroy-user-edits P0).
+      const recorded =
+        manifest && Array.isArray(manifest.entries)
+          ? manifest.entries.find((e) => e.kind === 'copied-skill' && e.path === linkPath)
+          : null;
+      const onDisk = hashDir(linkPath);
+      if (recorded && typeof recorded.hash === 'string' && onDisk !== null && onDisk === recorded.hash) {
+        // Provably our own unmodified copy → converge it to the current source.
+        const sourceHash = hashDir(target);
+        if (sourceHash !== null && sourceHash !== onDisk) {
+          if (!dryRun) {
+            fs.rmSync(linkPath, { recursive: true, force: true });
+            fs.cpSync(target, linkPath, { recursive: true });
+          }
+          out.changed.push(linkPath);
+          recordCopiedSkill(manifest, linkPath, sourceHash);
+        } else {
+          // Source unchanged (or momentarily unreadable) → leave our copy in place.
+          out.unchanged.push(linkPath);
+          recordCopiedSkill(manifest, linkPath, onDisk);
         }
-        out.changed.push(linkPath);
+      } else {
+        out.notices.push(
+          `left skill directory untouched (not a recorded Wienerdog copy, or modified since — delete it to let sync re-copy): ${linkPath}`
+        );
       }
-      recordOnce(manifest, { kind: 'copied-skill', path: linkPath });
     } else if (stat !== null) {
       // Regular file the user owns — never clobber.
       out.notices.push(`left user file untouched: ${linkPath}`);
@@ -330,7 +370,7 @@ function applySkillLinks(skillsDir, targetSkillsDir, dryRun, manifest, out, opts
       } catch (err) {
         if (err && (err.code === 'EPERM' || err.code === 'EACCES')) {
           fs.cpSync(target, linkPath, { recursive: true });
-          recordOnce(manifest, { kind: 'copied-skill', path: linkPath });
+          recordCopiedSkill(manifest, linkPath, hashDir(linkPath));
         } else {
           throw err;
         }

--- a/src/core/manifest.js
+++ b/src/core/manifest.js
@@ -65,6 +65,40 @@ function sha256File(p) {
   return crypto.createHash('sha256').update(fs.readFileSync(p)).digest('hex');
 }
 
+/** Deterministic sha256 fingerprint of a directory tree, over RAW BYTES.
+ *  Every field is length-framed; node type is a 1-byte tag (d/f/l/s) from the
+ *  Dirent (lstat semantics — never dereferenced). Any traversal/read error →
+ *  return null (fail closed; null can never equal a recorded string hash).
+ *  @param {string} root @returns {string|null} hex digest, or null if unreadable */
+function hashDir(root) {
+  const h = crypto.createHash('sha256');
+  const SEP = Buffer.from('/'); // 0x2F — path join AND framed-path separator (raw byte)
+  const walk = (dirBuf, prefixBuf) => {
+    const ents = fs.readdirSync(dirBuf, { withFileTypes: true, encoding: 'buffer' });
+    ents.sort((x, y) => Buffer.compare(x.name, y.name)); // deterministic byte-wise order
+    for (const e of ents) {
+      const nameBuf = e.name;                                  // RAW entry-name bytes (Buffer)
+      const rpBuf = prefixBuf ? Buffer.concat([prefixBuf, SEP, nameBuf]) : nameBuf;
+      const fullBuf = Buffer.concat([dirBuf, SEP, nameBuf]);   // Buffer path for on-disk reads
+      if (e.isDirectory()) {
+        h.update('d'); h.update(`${rpBuf.length}:`); h.update(rpBuf); walk(fullBuf, rpBuf);
+      } else if (e.isFile()) {
+        const dataBuf = fs.readFileSync(fullBuf);
+        h.update('f'); h.update(`${rpBuf.length}:`); h.update(rpBuf);
+        h.update(`${dataBuf.length}:`); h.update(dataBuf);
+      } else if (e.isSymbolicLink()) {
+        const linkBuf = fs.readlinkSync(fullBuf, { encoding: 'buffer' });
+        h.update('l'); h.update(`${rpBuf.length}:`); h.update(rpBuf);
+        h.update(`${linkBuf.length}:`); h.update(linkBuf);
+      } else {
+        h.update('s'); h.update(`${rpBuf.length}:`); h.update(rpBuf);
+      }
+    }
+  };
+  try { walk(Buffer.from(root), null); } catch { return null; }
+  return h.digest('hex');
+}
+
 /** @param {string} p @returns {boolean} true if p is an existing symlink. */
 function isSymlink(p) {
   try {
@@ -460,4 +494,4 @@ function disposeCoreMechanics(paths, { dryRun = false, vaultPath = null } = {}) 
   return { removed, skippedForVault };
 }
 
-module.exports = { load, record, save, reverse, disposeCoreMechanics, reverseSchedulerEntry, reverseVendoredTree, reverseCopiedSkill };
+module.exports = { load, record, save, reverse, disposeCoreMechanics, reverseSchedulerEntry, reverseVendoredTree, reverseCopiedSkill, hashDir };

--- a/tests/unit/manifest.test.js
+++ b/tests/unit/manifest.test.js
@@ -40,6 +40,121 @@ function makeInstall(paths) {
   return manifest;
 }
 
+const { hashDir } = manifestLib;
+
+/** Fresh empty temp dir. */
+function tempDir(tag) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `wd-hashdir-${tag}-`));
+}
+
+const isPosix = process.platform !== 'win32';
+const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
+
+test('hashDir is deterministic: two independently-built identical trees hash equal', () => {
+  const a = tempDir('detA');
+  const b = tempDir('detB');
+  for (const root of [a, b]) {
+    fs.mkdirSync(path.join(root, 'sub'));
+    fs.writeFileSync(path.join(root, 'top.md'), 'hello\n');
+    fs.writeFileSync(path.join(root, 'sub', 'ref.md'), 'world\n');
+  }
+  const ha = hashDir(a);
+  assert.equal(typeof ha, 'string');
+  assert.match(ha, /^[0-9a-f]{64}$/);
+  assert.equal(ha, hashDir(b), 'identical trees at different roots hash equal');
+});
+
+test('hashDir changes when a single content byte changes', () => {
+  const a = tempDir('byteA');
+  const b = tempDir('byteB');
+  fs.writeFileSync(path.join(a, 'f'), 'abc');
+  fs.writeFileSync(path.join(b, 'f'), 'abd');
+  assert.notEqual(hashDir(a), hashDir(b));
+});
+
+test('hashDir returns null for a non-existent root', () => {
+  assert.equal(hashDir(path.join(os.tmpdir(), 'wd-does-not-exist-xyz-123')), null);
+});
+
+test('hashDir returns null for an unreadable subtree, which never equals an empty tree', (t) => {
+  if (!isPosix || isRoot) return t.skip('needs POSIX permission enforcement (non-root)');
+  const root = tempDir('unread');
+  const locked = path.join(root, 'locked');
+  fs.mkdirSync(locked);
+  fs.writeFileSync(path.join(locked, 'secret'), 'x\n');
+  fs.chmodSync(locked, 0o000);
+  try {
+    const h = hashDir(root);
+    assert.equal(h, null, 'a tree containing an unreadable subtree fails closed to null');
+    const empty = tempDir('empty');
+    assert.notEqual(h, hashDir(empty), 'null (unreadable) never equals an empty-tree digest');
+  } finally {
+    fs.chmodSync(locked, 0o700); // restore so tmp cleanup can proceed
+  }
+});
+
+test('hashDir length-framing: two sibling files vs one file whose content mimics the naive stream', () => {
+  // {a:"", b:""} would, under an unframed `f:<path>\n<content>\n` serializer,
+  // emit the same bytes as a single file `a` whose content is "\nf:b\n".
+  const two = tempDir('collideTwo');
+  fs.writeFileSync(path.join(two, 'a'), '');
+  fs.writeFileSync(path.join(two, 'b'), '');
+  const one = tempDir('collideOne');
+  fs.writeFileSync(path.join(one, 'a'), '\nf:b\n');
+  assert.notEqual(hashDir(two), hashDir(one), 'length-framing keeps the naive-collision pair distinct');
+});
+
+test('hashDir length-framing: empty dir x + empty file y vs one dir whose name holds a newline', (t) => {
+  if (!isPosix) return t.skip('newline in filename is not creatable on Windows');
+  const sep = tempDir('sepEntries');
+  fs.mkdirSync(path.join(sep, 'x'));
+  fs.writeFileSync(path.join(sep, 'y'), '');
+  const merged = tempDir('mergedName');
+  fs.mkdirSync(path.join(merged, 'x\ny')); // a single directory whose name contains a newline
+  assert.notEqual(hashDir(sep), hashDir(merged), 'a newline in a dir name never folds into a sibling');
+});
+
+test('hashDir distinguishes a regular file from a symlink with byte-identical name/target', (t) => {
+  if (!isPosix) return t.skip('symlink creation may be unavailable');
+  const fileTree = tempDir('nodeFile');
+  fs.writeFileSync(path.join(fileTree, 'a'), 'target');
+  const linkTree = tempDir('nodeLink');
+  fs.symlinkSync('target', path.join(linkTree, 'a')); // link target "target" == the file's content
+  assert.notEqual(hashDir(fileTree), hashDir(linkTree), 'the d/f/l node-type tag separates file from symlink');
+});
+
+test('hashDir distinguishes a regular file from a same-name FIFO/special node', (t) => {
+  if (!isPosix) return t.skip('FIFO creation needs POSIX mkfifo');
+  const cp = require('node:child_process');
+  const fifoTree = tempDir('nodeFifo');
+  try {
+    cp.execFileSync('mkfifo', [path.join(fifoTree, 'a')]);
+  } catch {
+    return t.skip('mkfifo unavailable');
+  }
+  const fileTree = tempDir('nodeFileB');
+  fs.writeFileSync(path.join(fileTree, 'a'), '');
+  const hFifo = hashDir(fifoTree);
+  assert.equal(typeof hFifo, 'string', 'a special node hashes to the "s" branch without reading it (no block)');
+  assert.notEqual(hFifo, hashDir(fileTree), 'the special-node "s" tag differs from a regular file');
+});
+
+test('hashDir distinguishes raw-byte names 0x80 vs 0x81 (no UTF-8 folding)', (t) => {
+  if (!isPosix) return t.skip('raw-byte filenames are not creatable on Windows');
+  const t80 = tempDir('raw80');
+  const t81 = tempDir('raw81');
+  try {
+    // Some filesystems (e.g. APFS/HFS+ on macOS) enforce UTF-8 names and reject
+    // raw high bytes with EILSEQ; ext4 and friends accept them.
+    fs.writeFileSync(Buffer.concat([Buffer.from(t80), Buffer.from('/'), Buffer.from([0x80])]), '');
+    fs.writeFileSync(Buffer.concat([Buffer.from(t81), Buffer.from('/'), Buffer.from([0x81])]), '');
+  } catch (err) {
+    if (err && err.code === 'EILSEQ') return t.skip('filesystem forbids non-UTF-8 filenames');
+    throw err;
+  }
+  assert.notEqual(hashDir(t80), hashDir(t81), 'raw Buffer names keep 0x80 and 0x81 distinct');
+});
+
 test('load returns an empty manifest when none exists', () => {
   const paths = tempPaths();
   const manifest = manifestLib.load(paths);

--- a/tests/unit/shared-skill-links.test.js
+++ b/tests/unit/shared-skill-links.test.js
@@ -7,6 +7,7 @@ const os = require('node:os');
 const path = require('node:path');
 
 const shared = require('../../src/adapters/shared');
+const { hashDir } = require('../../src/core/manifest');
 
 /** Fresh temp core skills dir (with one wienerdog-* skill) + empty target dir. */
 function setup() {
@@ -68,7 +69,8 @@ test('EPERM on symlink falls back to copying the folder + records copied-skill',
   assert.ok(out.changed.includes(linkPath));
   assert.deepEqual(
     manifest.entries.filter((e) => e.path === linkPath),
-    [{ kind: 'copied-skill', path: linkPath }]
+    [{ kind: 'copied-skill', path: linkPath, hash: hashDir(linkPath) }],
+    'the copied-skill entry carries the freshly-copied tree fingerprint'
   );
 });
 
@@ -190,6 +192,133 @@ test('dry-run records a symlink entry and reports the change without writing', (
     manifest.entries.filter((e) => e.path === linkPath),
     [{ kind: 'symlink', path: linkPath }]
   );
+});
+
+test('matching-fingerprint refresh with UNCHANGED source: no write, unchanged, hash re-recorded', () => {
+  const { skillsDir, targetSkillsDir } = setup();
+  const manifest = freshManifest();
+  // First copy records the fingerprint.
+  shared.applySkillLinks(skillsDir, targetSkillsDir, false, manifest, freshOut(), { symlink: epermSeam() });
+
+  const linkPath = path.join(targetSkillsDir, 'wienerdog-setup');
+  const recordedBefore = manifest.entries.find(
+    (e) => e.kind === 'copied-skill' && e.path === linkPath
+  );
+  assert.equal(typeof recordedBefore.hash, 'string');
+  const beforeMtime = fs.statSync(path.join(linkPath, 'SKILL.md')).mtimeMs;
+
+  // Second sync: fingerprint matches, source unchanged → no filesystem write.
+  const out = freshOut();
+  const seam = () => { throw new Error('seam must not be called on an existing copy'); };
+  shared.applySkillLinks(skillsDir, targetSkillsDir, false, manifest, out, { symlink: seam });
+
+  assert.deepEqual(out.changed, []);
+  assert.ok(out.unchanged.includes(linkPath));
+  assert.equal(fs.statSync(path.join(linkPath, 'SKILL.md')).mtimeMs, beforeMtime, 'no rewrite');
+  const recordedAfter = manifest.entries.filter(
+    (e) => e.kind === 'copied-skill' && e.path === linkPath
+  );
+  assert.equal(recordedAfter.length, 1, 'no duplicate entry');
+  assert.equal(recordedAfter[0].hash, hashDir(linkPath), 'hash re-recorded idempotently');
+});
+
+test('matching-fingerprint refresh with CHANGED source: rmSync+cpSync, changed, new hash re-recorded', () => {
+  const { skillsDir, targetSkillsDir, coreSkill } = setup();
+  const manifest = freshManifest();
+  shared.applySkillLinks(skillsDir, targetSkillsDir, false, manifest, freshOut(), { symlink: epermSeam() });
+
+  const linkPath = path.join(targetSkillsDir, 'wienerdog-setup');
+  // Bump the packaged source; the copy is left untouched → still fingerprints to recorded.
+  fs.writeFileSync(path.join(coreSkill, 'SKILL.md'), '# skill v2\n');
+
+  const out = freshOut();
+  shared.applySkillLinks(skillsDir, targetSkillsDir, false, manifest, out, { symlink: epermSeam() });
+
+  assert.ok(out.changed.includes(linkPath));
+  assert.equal(fs.readFileSync(path.join(linkPath, 'SKILL.md'), 'utf8'), '# skill v2\n', 'converged to new source');
+  const recorded = manifest.entries.filter(
+    (e) => e.kind === 'copied-skill' && e.path === linkPath
+  );
+  assert.equal(recorded.length, 1);
+  assert.equal(recorded[0].hash, hashDir(linkPath), 'new source fingerprint re-recorded');
+  assert.equal(recorded[0].hash, hashDir(coreSkill), 'matches the packaged source');
+});
+
+test('mismatched fingerprint (user edited our copy) → PRESERVED untouched, notice, hash NOT changed', () => {
+  const { skillsDir, targetSkillsDir } = setup();
+  const manifest = freshManifest();
+  shared.applySkillLinks(skillsDir, targetSkillsDir, false, manifest, freshOut(), { symlink: epermSeam() });
+
+  const linkPath = path.join(targetSkillsDir, 'wienerdog-setup');
+  const recordedHash = manifest.entries.find(
+    (e) => e.kind === 'copied-skill' && e.path === linkPath
+  ).hash;
+  // The user edits our copy — its fingerprint now diverges from what we recorded.
+  const userFile = path.join(linkPath, 'USER-NOTES.md');
+  fs.writeFileSync(userFile, 'the user added this\n');
+
+  const out = freshOut();
+  const seam = () => { throw new Error('seam must not be probed for an existing dir'); };
+  shared.applySkillLinks(skillsDir, targetSkillsDir, false, manifest, out, { symlink: seam });
+
+  // Left byte-for-byte intact: the user's file survives, nothing refreshed.
+  assert.equal(fs.readFileSync(userFile, 'utf8'), 'the user added this\n');
+  assert.deepEqual(out.changed, []);
+  assert.deepEqual(out.unchanged, []);
+  assert.ok(out.notices.some((n) => n.includes(linkPath)), 'reported via out.notices');
+  const recorded = manifest.entries.filter(
+    (e) => e.kind === 'copied-skill' && e.path === linkPath
+  );
+  assert.equal(recorded.length, 1);
+  assert.equal(recorded[0].hash, recordedHash, 'recorded hash NOT changed');
+});
+
+test('no recorded entry (user pre-existing wienerdog-foo/) → PRESERVED, notice, not adopted', () => {
+  const { skillsDir, targetSkillsDir } = setup();
+  // A user's own directory sits in the namespace; nothing recorded for it.
+  const linkPath = path.join(targetSkillsDir, 'wienerdog-setup');
+  fs.mkdirSync(linkPath, { recursive: true });
+  fs.writeFileSync(path.join(linkPath, 'user-owned.md'), 'mine\n');
+  const out = freshOut();
+  const manifest = freshManifest();
+  const seam = () => { throw new Error('seam must not be probed for an existing dir'); };
+
+  shared.applySkillLinks(skillsDir, targetSkillsDir, false, manifest, out, { symlink: seam });
+
+  assert.equal(fs.readFileSync(path.join(linkPath, 'user-owned.md'), 'utf8'), 'mine\n', 'never rmSync-ed');
+  assert.deepEqual(out.changed, []);
+  assert.ok(out.notices.some((n) => n.includes(linkPath)));
+  assert.equal(
+    manifest.entries.filter((e) => e.path === linkPath).length,
+    0,
+    'a user directory is never adopted into the manifest'
+  );
+});
+
+test('legacy hash-less copied-skill entry → PRESERVED, notice, never rmSync (unverifiable)', () => {
+  const { skillsDir, targetSkillsDir } = setup();
+  const linkPath = path.join(targetSkillsDir, 'wienerdog-setup');
+  fs.mkdirSync(linkPath, { recursive: true });
+  fs.writeFileSync(path.join(linkPath, 'SKILL.md'), '# maybe ours, maybe not\n');
+  // A legacy manifest entry from before fingerprints existed — no hash field.
+  const manifest = freshManifest();
+  manifest.entries.push({ kind: 'copied-skill', path: linkPath });
+  const out = freshOut();
+  const seam = () => { throw new Error('seam must not be probed for an existing dir'); };
+
+  shared.applySkillLinks(skillsDir, targetSkillsDir, false, manifest, out, { symlink: seam });
+
+  assert.equal(
+    fs.readFileSync(path.join(linkPath, 'SKILL.md'), 'utf8'),
+    '# maybe ours, maybe not\n',
+    'a hash-less (unverifiable) entry is preserved, never deleted'
+  );
+  assert.deepEqual(out.changed, []);
+  assert.ok(out.notices.some((n) => n.includes(linkPath)));
+  // The legacy entry is left as-is (still hash-less; not adopted with a fresh hash).
+  const recorded = manifest.entries.filter((e) => e.kind === 'copied-skill' && e.path === linkPath);
+  assert.equal(recorded.length, 1);
+  assert.equal(recorded[0].hash, undefined);
 });
 
 test('a pre-existing correct symlink is adopted into the manifest (recorded, reported unchanged)', () => {


### PR DESCRIPTION
Spec: docs/specs/WP-089-adapter-skill-dir-ownership.md

Adds a tamper-resistant ownership check so `sync` never destroys a user's edit to a copied `wienerdog-*` skill dir (the Windows symlink-unavailable copy fallback). A raw-byte, length-framed, node-type-tagged (`d`/`f`/`l`/`s`) sha256 `hashDir` fingerprint (defined once in `manifest.js`, exported, imported by `shared.js`) is recorded on each `copied-skill` entry; the forward `applySkillLinks` directory branch refreshes only when the on-disk tree still fingerprints to the recorded hash, else preserves untouched with a notice. `hashDir` fails closed (returns `null`) on any read error; a `recordCopiedSkill` UPSERT keeps the recorded hash current.

This is the fingerprint design chosen after the compare-to-source simplification was evaluated and rejected (it shared a file↔symlink node-type collision and introduced a manifest-ordering false-delete). It converged clean over the Codex design-review loop.

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table (`src/adapters/shared.js`, `src/core/manifest.js`, `tests/unit/manifest.test.js`, `tests/unit/shared-skill-links.test.js`)
- [x] Spec status flipped to In-Review

## Verification output

```
npm test : 661 pass / 1 skip / 0 fail
npm run lint : clean (markdownlint, shellcheck, PSScriptAnalyzer, frontmatter)
```

The 1 skip is a platform guard: the raw-byte `0x80`/`0x81` filename AC can't create the file on APFS (EILSEQ); it runs and asserts on ext4 (Linux CI). wd-reviewer → **APPROVE** with an independent injectivity analysis finding no residual collision; the file-vs-symlink and FIFO-vs-file node-type tests prove the classes closed.

## Decisions made

- Raw-byte name/target handling end to end (no decode step) so distinct non-UTF-8 names can't fold to the same replacement char.

## Discovered issues (out of scope, not fixed)

- none. (Same-user TOCTOU and crash-partial-copy orphan are documented accepted residuals in the spec, not defects.)

---
Generated-by: claude-opus (implement) + claude-fable-5 (orchestrate); wd-reviewer: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uxThuapovGTPsbyn86BAf
