### PR TITLE
fix(init): only chmod a secrets dir we created (WP-092)

### DIFF
--- a/docs/specs/WP-092-init-secrets-chmod-guard.md
+++ b/docs/specs/WP-092-init-secrets-chmod-guard.md
@@ -1,7 +1,7 @@
 ---
 id: WP-092
 title: init only chmods the secrets dir it created — never a pre-existing user path
-status: Draft
+status: In-Review
 model: sonnet
 size: S
 depends_on: []

--- a/src/cli/init.js
+++ b/src/cli/init.js
@@ -123,14 +123,17 @@ async function run(argv) {
 
   const manifest = manifestLib.load(paths);
 
+  let createdSecrets = false;
   for (const d of dirs) {
     if (!dirExists(d)) {
       fs.mkdirSync(d, { recursive: true, mode: d === paths.secrets ? 0o700 : undefined });
       manifestLib.record(manifest, { kind: 'dir', path: d });
+      if (d === paths.secrets) createdSecrets = true;
     }
   }
-  // Enforce 0700 on secrets even if umask reduced the create-time mode.
-  fs.chmodSync(paths.secrets, 0o700);
+  // Enforce 0700 only on a secrets dir WE created (defeats a restrictive umask on the
+  // fresh dir). A pre-existing user path is never re-permissioned by init.
+  if (createdSecrets) fs.chmodSync(paths.secrets, 0o700);
 
   if (needConfig) {
     const content = renderConfig(harnesses);

--- a/tests/unit/init.test.js
+++ b/tests/unit/init.test.js
@@ -156,6 +156,27 @@ test('secrets directory is created with mode 0700', { skip: process.platform ===
   run(['init', '--yes'], env);
   const mode = fs.statSync(path.join(core, 'secrets')).mode & 0o777;
   assert.equal(mode, 0o700);
+  const manifest = JSON.parse(fs.readFileSync(path.join(core, 'install-manifest.json'), 'utf8'));
+  assert.ok(
+    manifest.entries.some((e) => e.kind === 'dir' && e.path === path.join(core, 'secrets')),
+    'manifest should record the freshly-created secrets dir'
+  );
+});
+
+test('a pre-existing secrets directory is left at its own mode (never chmod\'d)', { skip: process.platform === 'win32' }, () => {
+  const { core, env } = tempEnv();
+  const secrets = path.join(core, 'secrets');
+  fs.mkdirSync(secrets, { recursive: true });
+  fs.chmodSync(secrets, 0o755);
+  const r = run(['init', '--yes'], env);
+  assert.equal(r.status, 0);
+  const mode = fs.statSync(secrets).mode & 0o777;
+  assert.equal(mode, 0o755, 'init must not re-permission a secrets dir it did not create');
+  const manifest = JSON.parse(fs.readFileSync(path.join(core, 'install-manifest.json'), 'utf8'));
+  assert.ok(
+    !manifest.entries.some((e) => e.kind === 'dir' && e.path === secrets),
+    'manifest should not record a dir entry for a pre-existing secrets dir'
+  );
 });
 
 test('a second init makes zero changes and says so', () => {


### PR DESCRIPTION
Spec: docs/specs/WP-092-init-secrets-chmod-guard.md

`init` chmod'd `secrets/` to 0700 unconditionally, changing the permissions of a pre-existing directory it did not create. Now a `createdSecrets` flag gates the chmod so it fires only when `init` created the dir this run; a pre-existing `secrets/` is left at its own mode. Fresh-install behavior (0700 applied, robust against umask) is unchanged.

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table (`src/cli/init.js`, `tests/unit/init.test.js`)
- [x] Spec status flipped to In-Review

## Verification output

```
npm test : 649 pass / 0 fail  (incl. "pre-existing secrets dir is left at its own mode (never chmod'd)")
npm run lint : clean
```

wd-reviewer → **APPROVE** (both guard branches exercised; boundary clean).

## Decisions made

- none.

## Discovered issues (out of scope, not fixed)

- none.

---
Generated-by: claude-sonnet (implement) + claude-fable-5 (orchestrate); wd-reviewer: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uxThuapovGTPsbyn86BAf
