### PR TITLE
fix(tarball): member-name preflight + secure temp + completion marker (WP-093)

### DIFF
--- a/docs/specs/WP-093-tarball-extraction-containment.md
+++ b/docs/specs/WP-093-tarball-extraction-containment.md
@@ -1,7 +1,7 @@
 ---
 id: WP-093
 title: Tarball install hardening — secure temp file, member-name preflight, trustworthy completeness marker
-status: Draft
+status: In-Review
 model: opus
 size: M
 depends_on: []

--- a/src/core/tarball.js
+++ b/src/core/tarball.js
@@ -154,13 +154,39 @@ function extractTarball(tgzFile, destDir, opts = {}) {
   }
 }
 
+/** Reject an archive that contains an absolute member or a `..` path segment.
+ *  Name-based containment (portable across tar variants via `tar -tzf`). Throws
+ *  WienerdogError on any unsafe member. @param {string} tgzFile @param {typeof spawnSync} spawn */
+function preflightMembers(tgzFile, spawn) {
+  const r = spawn('tar', ['-tzf', tgzFile]);
+  if (r.error || r.status !== 0) {
+    throw new WienerdogError('could not read the download archive (is `tar` installed?)');
+  }
+  const names = String(r.stdout || '').split('\n').map((s) => s.trim()).filter(Boolean);
+  for (const name of names) {
+    if (path.isAbsolute(name) || name.startsWith('/') || name.startsWith('\\')) {
+      throw new WienerdogError(`refusing to unpack: archive member has an absolute path (${name})`);
+    }
+    if (name.split(/[\\/]/).some((seg) => seg === '..')) {
+      throw new WienerdogError(`refusing to unpack: archive member escapes staging (${name})`);
+    }
+  }
+}
+
+/** Marker file written into a version dir only after a fully verified publish.
+ *  Presence gates the installVersion short-circuit (replaces the old
+ *  bin/wienerdog.js-exists check, which trusted a lone leftover file). */
+const COMPLETE_MARKER = '.wienerdog-complete';
+
 /**
  * Ensure app/<version>/ exists by fetching+verifying+unpacking the tarball.
- * Idempotent: if app/<version>/bin/wienerdog.js already exists, do NOTHING and
- * return {version, target, alreadyPresent:true}. Otherwise: download+verify,
- * write the bytes to a temp .tgz, extract into a per-pid STAGING dir
- * (app/<version>.staging.<pid>), then fs.renameSync it onto app/<version>
- * (atomic publish; mirror vendorSelf). Cleans up the temp .tgz and any leftover
+ * Idempotent: if app/<version>/.wienerdog-complete already exists, do NOTHING
+ * and return {version, target, alreadyPresent:true}. Otherwise: download+verify,
+ * write the bytes to a private temp dir (mkdtemp, 0700) as an exclusive
+ * owner-only .tgz, preflight member names (reject absolute/`..` members),
+ * extract into a per-pid STAGING dir (app/<version>.staging.<pid>), write the
+ * completeness marker into staging, then fs.renameSync it onto app/<version>
+ * (atomic publish; mirror vendorSelf). Cleans up the temp dir and any leftover
  * staging dir. Does NOT repoint `current` and does NOT touch the manifest.
  * @param {import('./paths').WienerdogPaths} paths
  * @param {{version:string, integrity:string,
@@ -174,7 +200,7 @@ async function installVersion(paths, args) {
   if (!isSemver(version)) throw new WienerdogError('registry returned an invalid version');
   const app = appDir(paths);
   const target = path.join(app, version);
-  if (fs.existsSync(path.join(target, 'bin', 'wienerdog.js'))) {
+  if (fs.existsSync(path.join(target, COMPLETE_MARKER))) {
     return { version, target, alreadyPresent: true };
   }
 
@@ -182,13 +208,24 @@ async function installVersion(paths, args) {
     downloadBuffer: args.downloadBuffer,
   });
 
+  const spawn = args.spawn || spawnSync;
   const staging = `${target}.staging.${process.pid}`;
-  const tgzFile = path.join(os.tmpdir(), `wd-tarball-${process.pid}-${Date.now()}.tgz`);
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-tarball-'));
+  const tgzFile = path.join(tmpDir, 'pkg.tgz');
   try {
+    fs.writeFileSync(tgzFile, buf, { mode: 0o600, flag: 'wx' }); // exclusive create, owner-only
+    preflightMembers(tgzFile, spawn);
     fs.rmSync(staging, { recursive: true, force: true });
     fs.mkdirSync(staging, { recursive: true });
-    fs.writeFileSync(tgzFile, buf);
     extractTarball(tgzFile, staging, { spawn: args.spawn });
+    // The archive may have planted a symlink at the marker path (member NAME
+    // is safe so preflightMembers lets it through — the escape is the link
+    // TARGET). rmSync unlinks a symlink WITHOUT following it; the subsequent
+    // exclusive create then cannot follow a link either, since the path is
+    // gone (WP-093 review: link-following write escape).
+    const markerPath = path.join(staging, COMPLETE_MARKER);
+    fs.rmSync(markerPath, { force: true });
+    fs.writeFileSync(markerPath, `${version}\n`, { flag: 'wx' });
     fs.mkdirSync(app, { recursive: true });
     // Recovery: the completeness check above fell through, so any target dir that
     // still exists here is INCOMPLETE (a crash leftover, or the loser of two
@@ -199,12 +236,12 @@ async function installVersion(paths, args) {
       fs.rmSync(target, { recursive: true, force: true });
     }
     try {
-      fs.renameSync(staging, target); // atomic publish of the version dir
+      fs.renameSync(staging, target); // atomic publish of the version dir (marker included)
     } catch {
       throw new WienerdogError('could not finish unpacking the update (the version folder could not be published)');
     }
   } finally {
-    try { fs.rmSync(tgzFile, { force: true }); } catch { /* ignore */ }
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
     try { fs.rmSync(staging, { recursive: true, force: true }); } catch { /* ignore */ }
   }
   return { version, target, alreadyPresent: false };
@@ -213,5 +250,5 @@ async function installVersion(paths, args) {
 module.exports = {
   REGISTRY, PKG, latestManifestUrl, tarballUrl, parseManifest,
   fetchLatestManifest, downloadVerified, verifyIntegrity, extractTarball,
-  installVersion,
+  preflightMembers, COMPLETE_MARKER, installVersion,
 };

--- a/tests/unit/tarball.test.js
+++ b/tests/unit/tarball.test.js
@@ -175,6 +175,32 @@ test('extractTarball throws WienerdogError when tar exits non-zero', () => {
 });
 
 // ---------------------------------------------------------------------------
+// preflightMembers
+// ---------------------------------------------------------------------------
+
+test('preflightMembers rejects a `..`-escaping member name', () => {
+  const spawn = () => ({ status: 0, stdout: 'package/bin/x.js\n../evil\n' });
+  assert.throws(() => tarball.preflightMembers('/whatever.tgz', spawn), WienerdogError);
+});
+
+test('preflightMembers rejects an absolute member name', () => {
+  const spawn = () => ({ status: 0, stdout: 'package/bin/x.js\n/etc/passwd\n' });
+  assert.throws(() => tarball.preflightMembers('/whatever.tgz', spawn), WienerdogError);
+});
+
+test('preflightMembers passes an archive with only safe relative names', () => {
+  const spawn = () => ({ status: 0, stdout: 'package/bin/x.js\npackage/src/y.js\n' });
+  assert.doesNotThrow(() => tarball.preflightMembers('/whatever.tgz', spawn));
+});
+
+test('preflightMembers throws WienerdogError when `tar -tzf` fails', () => {
+  assert.throws(
+    () => tarball.preflightMembers('/whatever.tgz', () => ({ error: new Error('ENOENT') })),
+    WienerdogError,
+  );
+});
+
+// ---------------------------------------------------------------------------
 // installVersion
 // ---------------------------------------------------------------------------
 
@@ -265,6 +291,151 @@ test('installVersion rejects a non-semver version before any download', async ()
     WienerdogError,
   );
   assert.equal(called, false, 'no download attempted for an invalid version');
+});
+
+test('installVersion rejects an archive with an unsafe member and extracts nothing', async () => {
+  const paths = tempPaths();
+  const { tgz, integrity } = buildFixtureTarball('0.4.0');
+  let extractCalled = false;
+  const spawn = (cmd, spawnArgs) => {
+    if (spawnArgs[0] === '-tzf') return { status: 0, stdout: 'package/bin/x.js\n../evil\n' };
+    if (spawnArgs[0] === '-xzf') { extractCalled = true; return { status: 0 }; }
+    return { error: new Error('unexpected tar invocation') };
+  };
+  await assert.rejects(
+    () => tarball.installVersion(paths, {
+      version: '0.4.0', integrity,
+      downloadBuffer: async () => fs.readFileSync(tgz),
+      spawn,
+    }),
+    WienerdogError,
+  );
+  assert.equal(extractCalled, false, 'extraction never runs after a failed member preflight');
+  assert.equal(fs.existsSync(path.join(vendor.appDir(paths), '0.4.0')), false, 'nothing published');
+});
+
+test('installVersion short-circuits only on the .wienerdog-complete marker, not a lone bin/wienerdog.js', async () => {
+  const paths = tempPaths();
+  const { tgz, integrity, binBody } = buildFixtureTarball('0.4.0');
+  const target = path.join(vendor.appDir(paths), '0.4.0');
+  // Plant a version dir with bin/wienerdog.js but NO completeness marker — the
+  // "lone file" scenario the old short-circuit incorrectly trusted.
+  fs.mkdirSync(path.join(target, 'bin'), { recursive: true });
+  fs.writeFileSync(path.join(target, 'bin', 'wienerdog.js'), '// stale, unverified\n');
+  assert.equal(fs.existsSync(path.join(target, tarball.COMPLETE_MARKER)), false, 'marker absent (partial)');
+
+  let downloaded = false;
+  const r = await tarball.installVersion(paths, {
+    version: '0.4.0', integrity,
+    downloadBuffer: async () => { downloaded = true; return fs.readFileSync(tgz); },
+  });
+  assert.equal(downloaded, true, 'proceeds to download+verify despite a lone bin/wienerdog.js');
+  assert.equal(r.alreadyPresent, false);
+  assert.equal(fs.readFileSync(path.join(target, 'bin', 'wienerdog.js'), 'utf8'), binBody, 'stale file replaced');
+});
+
+test('installVersion writes .wienerdog-complete with the version after publish; re-run is a no-op via the marker', async () => {
+  const paths = tempPaths();
+  const { tgz, integrity } = buildFixtureTarball('0.4.0');
+  const target = path.join(vendor.appDir(paths), '0.4.0');
+
+  await tarball.installVersion(paths, { version: '0.4.0', integrity, downloadBuffer: async () => fs.readFileSync(tgz) });
+  assert.equal(fs.readFileSync(path.join(target, tarball.COMPLETE_MARKER), 'utf8'), '0.4.0\n');
+
+  let called = false;
+  const r2 = await tarball.installVersion(paths, {
+    version: '0.4.0', integrity,
+    downloadBuffer: async () => { called = true; return fs.readFileSync(tgz); },
+  });
+  assert.equal(r2.alreadyPresent, true, 'gated on the marker, not the bin file');
+  assert.equal(called, false, 'no download on the marker-gated idempotent path');
+});
+
+test('installVersion writes the tgz under a private mkdtemp dir, mode 0600, and cleans it up', async () => {
+  const paths = tempPaths();
+  const { tgz, integrity } = buildFixtureTarball('0.4.0');
+  const buf = fs.readFileSync(tgz);
+
+  // tempPaths() itself mkdtemps a `wd-tarball-*` dir (as the fake HOME root) —
+  // snapshot before the install so we only assert on installVersion's OWN temp
+  // dir, not that pre-existing one.
+  const before = new Set(fs.readdirSync(os.tmpdir()).filter((n) => n.startsWith('wd-tarball-')));
+
+  let observedTgzPath;
+  let observedMode;
+  const spawn = (cmd, spawnArgs) => {
+    if (spawnArgs[0] === '-tzf') {
+      observedTgzPath = spawnArgs[1];
+      // Observed DURING the call: the tgz must already exist, mode 0600, under
+      // an unpredictable wd-tarball-* dir in os.tmpdir().
+      const st = fs.statSync(observedTgzPath);
+      observedMode = st.mode & 0o777;
+      return spawnSync('tar', spawnArgs);
+    }
+    if (spawnArgs[0] === '-xzf') {
+      return spawnSync('tar', spawnArgs);
+    }
+    return { error: new Error('unexpected tar invocation') };
+  };
+
+  const r = await tarball.installVersion(paths, {
+    version: '0.4.0', integrity,
+    downloadBuffer: async () => buf,
+    spawn,
+  });
+
+  assert.equal(r.alreadyPresent, false);
+  assert.ok(observedTgzPath, 'spawn observed the tgz path via argv');
+  assert.equal(path.basename(observedTgzPath), 'pkg.tgz');
+  assert.match(path.basename(path.dirname(observedTgzPath)), /^wd-tarball-/);
+  assert.equal(path.dirname(path.dirname(observedTgzPath)), os.tmpdir());
+  assert.equal(observedMode, 0o600, 'tgz written owner-only, exclusive create (0600)');
+
+  const after = fs.readdirSync(os.tmpdir()).filter((n) => n.startsWith('wd-tarball-'));
+  const newDirs = after.filter((n) => !before.has(n));
+  for (const d of newDirs) {
+    assert.equal(fs.existsSync(path.join(os.tmpdir(), d)), false, `temp dir ${d} cleaned up after installVersion`);
+  }
+});
+
+test('installVersion is not fooled by a malicious archive planting .wienerdog-complete as a symlink to an external file (WP-093 P1)', async () => {
+  const paths = tempPaths();
+  const { tgz, integrity, binBody } = buildFixtureTarball('0.4.0');
+
+  // A file OUTSIDE staging that a hostile archive tries to clobber by making
+  // the marker a symlink pointing at it. The member NAME (".wienerdog-complete")
+  // is safe, so preflightMembers lets it through — the escape is the link TARGET.
+  const externalFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'wd-external-')), 'victim.txt');
+  const externalBody = 'do-not-touch\n';
+  fs.writeFileSync(externalFile, externalBody);
+
+  const spawn = (cmd, spawnArgs) => {
+    if (spawnArgs[0] === '-tzf') return spawnSync('tar', spawnArgs);
+    if (spawnArgs[0] === '-xzf') {
+      const r = spawnSync('tar', spawnArgs);
+      // simulate the real extraction step ALSO planting a symlinked marker,
+      // as a malicious tarball member would.
+      const destDir = spawnArgs[spawnArgs.indexOf('-C') + 1];
+      fs.symlinkSync(externalFile, path.join(destDir, tarball.COMPLETE_MARKER));
+      return r;
+    }
+    return { error: new Error('unexpected tar invocation') };
+  };
+
+  const target = path.join(vendor.appDir(paths), '0.4.0');
+  const r = await tarball.installVersion(paths, {
+    version: '0.4.0', integrity,
+    downloadBuffer: async () => fs.readFileSync(tgz),
+    spawn,
+  });
+
+  assert.equal(r.alreadyPresent, false);
+  assert.equal(fs.readFileSync(externalFile, 'utf8'), externalBody, 'external file NOT modified/truncated');
+  const markerPath = path.join(target, tarball.COMPLETE_MARKER);
+  const st = fs.lstatSync(markerPath);
+  assert.equal(st.isSymbolicLink(), false, 'published marker is a regular file, not a symlink');
+  assert.equal(fs.readFileSync(markerPath, 'utf8'), '0.4.0\n', 'published marker contains the version');
+  assert.equal(fs.readFileSync(path.join(target, 'bin', 'wienerdog.js'), 'utf8'), binBody, 'legit tree still published');
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Spec: docs/specs/WP-093-tarball-extraction-containment.md

Hardens the npm-less tarball install path (ADR-0016). A `preflightMembers` pass runs `tar -tzf` and rejects any absolute or `..`-escaping member name (fail-closed via `WienerdogError`) BEFORE extraction; the temp tarball now lives in a `mkdtemp` 0700 dir written 0600 with exclusive create (`flag:'wx'`), closing the predictable-name TOCTOU; and a `.wienerdog-complete` marker (written into staging before the atomic rename) replaces the `bin/wienerdog.js`-presence short-circuit, so a partial/crashed publish is never trusted.

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table (`src/core/tarball.js`, `tests/unit/tarball.test.js`)
- [x] Spec status flipped to In-Review

## Verification output

```
npm test : 656 pass / 0 fail
npm test -- --test-name-pattern tarball : 59 pass / 0 fail
npm run lint : clean
```

wd-reviewer → **APPROVE** (preflight confirmed to run before extract; TOCTOU closed; a partial publish can never carry the marker).

## Decisions made

- Completion marker written into staging before the atomic `renameSync` (keeps publish atomic — the spec's suggested option).
- Exported `preflightMembers` and `COMPLETE_MARKER` for direct unit testing.

## Discovered issues (out of scope, not fixed)

- **Named residual (per the spec):** the symlink/hardlink tar *link-member* vector (a safe member name whose link target escapes staging) is deliberately NOT closed here — it is cross-`tar`-fragile and parked for a wd-researcher spike. This WP scopes to name-based `../`/absolute escapes + the temp-file TOCTOU only.
- The two out-of-scope installer follow-ups noted in the spec DoD remain for their own WPs.

---
Generated-by: claude-sonnet (implement) + claude-fable-5 (orchestrate); wd-reviewer: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uxThuapovGTPsbyn86BAf
