### PR TITLE
fix(adapters): shell-quote hook command paths (WP-090)

### DIFF
--- a/docs/specs/WP-090-hook-command-shell-quoting.md
+++ b/docs/specs/WP-090-hook-command-shell-quoting.md
@@ -1,7 +1,7 @@
 ---
 id: WP-090
 title: Shell-quote hook command paths so an install path with spaces/metacharacters produces valid hooks
-status: Draft
+status: In-Review
 model: opus
 size: M
 depends_on: [WP-089]
@@ -86,6 +86,7 @@ The adapters pass the raw path in `events`, e.g. `claude.js`:
 | modify | src/adapters/shared.js | add `shellQuoteCommand`; store the quoted command; prune prior unquoted/separator-variants of our command; record the quoted string in the manifest `commands` |
 | modify | tests/unit/claude-adapter.test.js | test: a path with a space registers ONE quoted hook; a second run is a no-op; a prior bare entry is converged |
 | modify | tests/unit/codex-adapter.test.js | same for the Codex adapter path |
+| modify | tests/integration/bootstrap-seam.test.js | its 3 bare-path hook-command assertions (SessionStart under Claude settings.json / Codex hooks.json) are updated to expect the quoted canonical form — a direct, mechanical consequence of the always-quote contract below (orchestrator-authorized scope addition; see Implementation notes) |
 
 ### Exact contracts
 
@@ -163,7 +164,14 @@ Crucial consistency requirements:
   the bare hook, which this same-session quoted entry supersedes only after a
   `sync`). Flag this pre-existing-manifest residual under "Decisions made" — do not
   attempt a manifest migration here.
-- No golden fixture pins the hook command string; `bootstrap-seam` must still pass.
+- No golden fixture pins the hook command string. However, the always-quote
+  contract necessarily changes the canonical stored command from the bare path to
+  the single-quoted form, so `tests/integration/bootstrap-seam.test.js`'s three
+  bare-path hook-command assertions (SessionStart under Claude `settings.json` and
+  Codex `hooks.json`) must be updated to expect the quoted form — the same `q()`
+  mirror-helper pattern used in the two unit test files. This is an
+  orchestrator-authorized scope addition (that file is added to the Deliverables
+  table); do NOT weaken the contract to conditional quoting to avoid it.
 
 ## Security checklist
 

--- a/src/adapters/shared.js
+++ b/src/adapters/shared.js
@@ -145,6 +145,18 @@ function toPosixCommand(command) {
   return String(command).replace(/\\/g, '/');
 }
 
+/** Wrap a (forward-slash-normalized) script path so bash runs it as ONE argument
+ *  even when it contains spaces or shell metacharacters. Single-quotes are the
+ *  strongest bash quoting (no interpolation); an embedded ' is closed, escaped,
+ *  reopened. Valid on POSIX bash AND the bash the Windows harnesses shell out to
+ *  (WP-077). Idempotent input → identical output, so prune/present comparisons and
+ *  the recorded manifest command all use this one canonical form.
+ *  @param {string} rawCommand @returns {string} */
+function shellQuoteCommand(rawCommand) {
+  const p = toPosixCommand(rawCommand);
+  return `'${p.replace(/'/g, `'\\''`)}'`;
+}
+
 /**
  * Merge command hooks into a JSON file's `.hooks`, dedup by command path.
  * @param {string} settingsPath  target JSON file (Claude settings.json OR Codex hooks.json)
@@ -176,13 +188,16 @@ function applySettings(settingsPath, events, dryRun, manifest, out) {
 
   let changed = false;
   for (const [event, rawCommand] of events) {
-    const command = toPosixCommand(rawCommand);
+    const command = shellQuoteCommand(rawCommand);
     if (!Array.isArray(settings.hooks[event])) settings.hooks[event] = [];
 
-    // Prune stale separator-variants of OUR command (e.g. a broken backslash entry
-    // written by a pre-fix version). Match strictly on the normalized path being ours
-    // while the raw string differs — a user's unrelated hook never normalizes to our
-    // path, so it is never touched. Drop a group whose hooks array is emptied.
+    // Prune stale variants of OUR command (a bare, backslash, or forward-slash-
+    // unquoted entry written by a pre-fix version). Match strictly on the
+    // re-quoted path being ours while the raw string differs — a user's
+    // unrelated hook never re-quotes to our path, so it is never touched. An
+    // already-canonical entry re-quotes to itself, so `h.command !== command`
+    // excludes it here; it is picked up by the `present` check below instead.
+    // Drop a group whose hooks array is emptied.
     const before = settings.hooks[event];
     const pruned = [];
     for (const group of before) {
@@ -191,7 +206,7 @@ function applySettings(settingsPath, events, dryRun, manifest, out) {
         continue;
       }
       const keptHooks = group.hooks.filter(
-        (h) => !(h && toPosixCommand(h.command) === command && h.command !== command)
+        (h) => !(h && shellQuoteCommand(h.command) === command && h.command !== command)
       );
       if (keptHooks.length !== group.hooks.length) {
         changed = true;
@@ -228,7 +243,7 @@ function applySettings(settingsPath, events, dryRun, manifest, out) {
     kind: 'settings-entry',
     path: settingsPath,
     createdFile,
-    commands: events.map(([, c]) => toPosixCommand(c)),
+    commands: events.map(([, c]) => shellQuoteCommand(c)),
   });
 }
 

--- a/tests/integration/bootstrap-seam.test.js
+++ b/tests/integration/bootstrap-seam.test.js
@@ -36,6 +36,13 @@ function hookCommands(filePath, event) {
   return (parsed.hooks[event] || []).flatMap((g) => g.hooks.map((h) => h.command));
 }
 
+/** Mirror of shared.js's shellQuoteCommand (WP-090): hook commands are stored
+ *  shell-quoted so a path with a space/metacharacter is one bash argument.
+ *  @param {string} p @returns {string} */
+function q(p) {
+  return `'${String(p).replace(/\\/g, '/').replace(/'/g, `'\\''`)}'`;
+}
+
 test('Claude present, plain init: skills + hooks registered, NO memory', () => {
   const root = tempRoot();
   const wd = path.join(root, 'wd');
@@ -66,7 +73,7 @@ test('Claude present, plain init: skills + hooks registered, NO memory', () => {
 
   const startAbs = path.join(wd, 'bin', 'session-start.sh');
   assert.ok(
-    hookCommands(path.join(claudeDir, 'settings.json'), 'SessionStart').includes(startAbs),
+    hookCommands(path.join(claudeDir, 'settings.json'), 'SessionStart').includes(q(startAbs)),
     'session-start.sh registered'
   );
 
@@ -111,7 +118,7 @@ test('Claude present, init --fresh-vault: everything incl. digest + managed bloc
 
   const startAbs = path.join(wd, 'bin', 'session-start.sh');
   assert.ok(
-    hookCommands(path.join(claudeDir, 'settings.json'), 'SessionStart').includes(startAbs),
+    hookCommands(path.join(claudeDir, 'settings.json'), 'SessionStart').includes(q(startAbs)),
     'session-start.sh registered'
   );
   if (process.platform !== 'win32') {
@@ -148,7 +155,7 @@ test('Codex present, plain init: skills + hooks under <CODEX_HOME>/skills, NO me
 
   const startAbs = path.join(wd, 'bin', 'session-start.sh');
   assert.ok(
-    hookCommands(path.join(codexDir, 'hooks.json'), 'SessionStart').includes(startAbs),
+    hookCommands(path.join(codexDir, 'hooks.json'), 'SessionStart').includes(q(startAbs)),
     'session-start.sh registered in hooks.json'
   );
 

--- a/tests/unit/claude-adapter.test.js
+++ b/tests/unit/claude-adapter.test.js
@@ -38,6 +38,13 @@ function freshManifest() {
   return { version: 1, createdAt: new Date().toISOString(), entries: [] };
 }
 
+/** Mirror of shared.js's shellQuoteCommand (WP-090), for building the expected
+ *  stored/recorded command string in assertions without importing an internal.
+ *  @param {string} p @returns {string} */
+function q(p) {
+  return `'${String(p).replace(/\\/g, '/').replace(/'/g, `'\\''`)}'`;
+}
+
 test('managed block, new file: matches the golden byte-for-byte', () => {
   const paths = setup();
   const claudeMd = path.join(paths.claudeDir, 'CLAUDE.md');
@@ -86,14 +93,14 @@ test('settings.json merge preserves existing hooks and dedups', () => {
   const allCommands = (event) =>
     (settings.hooks[event] || []).flatMap((g) => g.hooks.map((h) => h.command));
   assert.ok(allCommands('SessionStart').includes('/usr/local/bin/other.sh'), 'unrelated hook survives');
-  assert.equal(allCommands('SessionStart').filter((c) => c === startAbs).length, 1);
-  assert.equal(allCommands('SessionEnd').filter((c) => c === endAbs).length, 1);
+  assert.equal(allCommands('SessionStart').filter((c) => c === q(startAbs)).length, 1);
+  assert.equal(allCommands('SessionEnd').filter((c) => c === q(endAbs)).length, 1);
 
   // Second run: no duplicates.
   applyClaudeAdapter(paths, { manifest });
   settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-  assert.equal(allCommands('SessionStart').filter((c) => c === startAbs).length, 1);
-  assert.equal(allCommands('SessionEnd').filter((c) => c === endAbs).length, 1);
+  assert.equal(allCommands('SessionStart').filter((c) => c === q(startAbs)).length, 1);
+  assert.equal(allCommands('SessionEnd').filter((c) => c === q(endAbs)).length, 1);
   assert.ok(allCommands('SessionStart').includes('/usr/local/bin/other.sh'));
 });
 
@@ -122,21 +129,110 @@ test('backslash-seeded SessionEnd converges to exactly one forward-slash entry (
   const allCommands = (event) =>
     (settings.hooks[event] || []).flatMap((g) => g.hooks.map((h) => h.command));
 
-  // Exactly one SessionEnd entry, forward-slash, no backslash variant remaining.
-  assert.deepEqual(allCommands('SessionEnd'), [endAbs]);
+  // Exactly one SessionEnd entry, forward-slash AND shell-quoted, no backslash
+  // variant remaining (WP-090 converges the WP-077 bare forward-slash form too).
+  assert.deepEqual(allCommands('SessionEnd'), [q(endAbs)]);
   assert.ok(!allCommands('SessionEnd')[0].includes('\\'), 'no backslash in the command');
   // Unrelated user hook survives untouched.
   assert.ok(allCommands('SessionStart').includes('/usr/local/bin/other.sh'), 'unrelated hook survives');
 
-  // Recorded manifest commands are the forward-slash forms.
+  // Recorded manifest commands are the quoted forward-slash forms.
   const entry = manifest.entries.find((e) => e.kind === 'settings-entry' && e.path === settingsPath);
   assert.ok(entry.commands.every((c) => !c.includes('\\')), 'manifest records forward-slash commands');
+  assert.ok(entry.commands.includes(q(endAbs)), 'manifest records the quoted canonical SessionEnd command');
 
   // Second apply is a no-op: settings file reported unchanged, still one entry.
   const res = applyClaudeAdapter(paths, { manifest });
   assert.ok(res.unchanged.includes(settingsPath), 'idempotent second run leaves settings unchanged');
   settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-  assert.deepEqual(allCommands('SessionEnd'), [endAbs]);
+  assert.deepEqual(allCommands('SessionEnd'), [q(endAbs)]);
+});
+
+test('an install root containing a space registers shell-quoted hooks end-to-end (WP-090)', () => {
+  // WIENERDOG_HOME with a space in it (e.g. "My Files"), exercising the real
+  // adapter rather than calling applySettings directly.
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-claude-'));
+  const env = {
+    HOME: root,
+    WIENERDOG_HOME: path.join(root, 'My Files', 'wd'),
+    CLAUDE_CONFIG_DIR: path.join(root, 'claude'),
+  };
+  const paths = getPaths(env);
+  fs.mkdirSync(paths.state, { recursive: true });
+  fs.mkdirSync(paths.claudeDir, { recursive: true });
+  fs.writeFileSync(path.join(paths.state, 'digest.md'), FIXED_DIGEST);
+
+  const settingsPath = path.join(paths.claudeDir, 'settings.json');
+  const startAbs = path.join(paths.core, 'bin', 'session-start.sh');
+  const manifest = freshManifest();
+
+  applyClaudeAdapter(paths, { manifest });
+  const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+  const allCommands = (event) =>
+    (settings.hooks[event] || []).flatMap((g) => g.hooks.map((h) => h.command));
+
+  assert.deepEqual(allCommands('SessionStart'), [q(startAbs)], 'quoted single-argument command');
+
+  // Second run: idempotent, no-op.
+  const res = applyClaudeAdapter(paths, { manifest });
+  assert.ok(res.unchanged.includes(settingsPath), 'idempotent second run leaves settings unchanged');
+});
+
+test('applySettings shell-quotes a hook command whose path contains a space; second run is a no-op', () => {
+  const { applySettings } = require('../../src/adapters/shared');
+  const paths = setup();
+  const settingsPath = path.join(paths.claudeDir, 'settings.json');
+  const spacedAbs = path.join(paths.core, 'My Files', 'bin', 'session-start.sh');
+  const manifest = freshManifest();
+  const out = { changed: [], unchanged: [], notices: [] };
+
+  applySettings(settingsPath, [['SessionStart', spacedAbs]], false, manifest, out);
+  let settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+  const allCommands = (event) =>
+    (settings.hooks[event] || []).flatMap((g) => g.hooks.map((h) => h.command));
+
+  assert.deepEqual(allCommands('SessionStart'), [q(spacedAbs)], 'single quoted, single-argument command');
+  assert.ok(allCommands('SessionStart')[0].startsWith("'") && allCommands('SessionStart')[0].endsWith("'"));
+
+  const entry = manifest.entries.find((e) => e.kind === 'settings-entry' && e.path === settingsPath);
+  assert.deepEqual(entry.commands, [q(spacedAbs)], 'manifest records the quoted command');
+
+  // Second run: idempotent, no-op.
+  const out2 = { changed: [], unchanged: [], notices: [] };
+  applySettings(settingsPath, [['SessionStart', spacedAbs]], false, manifest, out2);
+  assert.ok(out2.unchanged.includes(settingsPath), 'second run reports unchanged');
+  settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+  assert.deepEqual(allCommands('SessionStart'), [q(spacedAbs)], 'still exactly one quoted entry');
+});
+
+test('applySettings converges a pre-existing bare (unquoted) entry to exactly one quoted entry, leaving unrelated hooks untouched', () => {
+  const { applySettings } = require('../../src/adapters/shared');
+  const paths = setup();
+  const settingsPath = path.join(paths.claudeDir, 'settings.json');
+  const startAbs = path.join(paths.core, 'bin', 'session-start.sh');
+  const preExisting = {
+    hooks: {
+      SessionStart: [
+        { matcher: '*', hooks: [{ type: 'command', command: startAbs, timeout: 10 }] },
+        { matcher: '*', hooks: [{ type: 'command', command: '/usr/local/bin/other.sh', timeout: 5 }] },
+      ],
+    },
+  };
+  fs.writeFileSync(settingsPath, `${JSON.stringify(preExisting, null, 2)}\n`);
+  const manifest = freshManifest();
+  const out = { changed: [], unchanged: [], notices: [] };
+
+  applySettings(settingsPath, [['SessionStart', startAbs]], false, manifest, out);
+  const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+  const allCommands = (event) =>
+    (settings.hooks[event] || []).flatMap((g) => g.hooks.map((h) => h.command));
+
+  assert.deepEqual(
+    allCommands('SessionStart').filter((c) => c === startAbs || c === q(startAbs)),
+    [q(startAbs)],
+    'bare entry pruned; exactly one quoted entry remains'
+  );
+  assert.ok(allCommands('SessionStart').includes('/usr/local/bin/other.sh'), 'unrelated user hook untouched');
 });
 
 test('hook scripts are copied to core/bin mode 0755', () => {

--- a/tests/unit/codex-adapter.test.js
+++ b/tests/unit/codex-adapter.test.js
@@ -46,6 +46,13 @@ function freshManifest() {
   return { version: 1, createdAt: new Date().toISOString(), entries: [] };
 }
 
+/** Mirror of shared.js's shellQuoteCommand (WP-090), for building the expected
+ *  stored/recorded command string in assertions without importing an internal.
+ *  @param {string} p @returns {string} */
+function q(p) {
+  return `'${String(p).replace(/\\/g, '/').replace(/'/g, `'\\''`)}'`;
+}
+
 test('AGENTS.md managed block, new file: matches the golden byte-for-byte', () => {
   const paths = setup();
   const agentsMd = path.join(paths.codexDir, 'AGENTS.md');
@@ -100,8 +107,8 @@ test('hooks.json merge preserves existing hooks and dedups; /hooks trust notice 
 
   const allCommands = (event) => (hooks.hooks[event] || []).flatMap((g) => g.hooks.map((h) => h.command));
   assert.ok(allCommands('Stop').includes('/usr/local/bin/other-stop.sh'), 'unrelated hook survives');
-  assert.equal(allCommands('SessionStart').filter((c) => c === startAbs).length, 1);
-  assert.equal(allCommands('Stop').filter((c) => c === stopAbs).length, 1);
+  assert.equal(allCommands('SessionStart').filter((c) => c === q(startAbs)).length, 1);
+  assert.equal(allCommands('Stop').filter((c) => c === q(stopAbs)).length, 1);
   assert.ok(res.notices.some((n) => n.includes('/hooks')), 'expected the /hooks trust notice');
   assert.ok(
     res.notices.some((n) => n.includes('/skills') && n.includes('$wienerdog-setup')),
@@ -111,8 +118,8 @@ test('hooks.json merge preserves existing hooks and dedups; /hooks trust notice 
   // Second run: no duplicates.
   applyCodexAdapter(paths, { manifest });
   hooks = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
-  assert.equal(allCommands('SessionStart').filter((c) => c === startAbs).length, 1);
-  assert.equal(allCommands('Stop').filter((c) => c === stopAbs).length, 1);
+  assert.equal(allCommands('SessionStart').filter((c) => c === q(startAbs)).length, 1);
+  assert.equal(allCommands('Stop').filter((c) => c === q(stopAbs)).length, 1);
   assert.ok(allCommands('Stop').includes('/usr/local/bin/other-stop.sh'));
 });
 
@@ -139,24 +146,84 @@ test('backslash-seeded Stop converges to exactly one forward-slash entry (WP-077
   const startAbs = path.join(paths.core, 'bin', 'session-start.sh');
   const allCommands = (event) => (hooks.hooks[event] || []).flatMap((g) => g.hooks.map((h) => h.command));
 
-  // Exactly one Stop command for our path, forward-slash, no backslash variant left.
-  assert.equal(allCommands('Stop').filter((c) => c === stopAbs).length, 1);
+  // Exactly one Stop command for our path, forward-slash AND shell-quoted, no
+  // backslash variant left (WP-090 converges the WP-077 bare form too).
+  assert.equal(allCommands('Stop').filter((c) => c === q(stopAbs)).length, 1);
   assert.ok(!allCommands('Stop').some((c) => c.includes('\\')), 'no backslash in any Stop command');
   // Unrelated user hook survives untouched.
   assert.ok(allCommands('Stop').includes('/usr/local/bin/other-stop.sh'), 'unrelated Stop hook survives');
-  // SessionStart registered with forward slashes.
-  assert.ok(allCommands('SessionStart').includes(startAbs), 'SessionStart forward-slash command present');
+  // SessionStart registered with forward slashes, shell-quoted.
+  assert.ok(allCommands('SessionStart').includes(q(startAbs)), 'SessionStart quoted forward-slash command present');
   assert.ok(!allCommands('SessionStart').some((c) => c.includes('\\')), 'no backslash in any SessionStart command');
 
-  // Recorded manifest commands are the forward-slash forms.
+  // Recorded manifest commands are the quoted forward-slash forms.
   const entry = manifest.entries.find((e) => e.kind === 'settings-entry' && e.path === hooksPath);
   assert.ok(entry.commands.every((c) => !c.includes('\\')), 'manifest records forward-slash commands');
+  assert.ok(entry.commands.includes(q(stopAbs)), 'manifest records the quoted Stop command');
 
   // Second apply is a no-op: hooks file reported unchanged, still one Stop entry for us.
   const res = applyCodexAdapter(paths, { manifest });
   assert.ok(res.unchanged.includes(hooksPath), 'idempotent second run leaves hooks unchanged');
   hooks = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
-  assert.equal(allCommands('Stop').filter((c) => c === stopAbs).length, 1);
+  assert.equal(allCommands('Stop').filter((c) => c === q(stopAbs)).length, 1);
+});
+
+test('an install root containing a space registers shell-quoted hooks end-to-end (WP-090)', () => {
+  // WIENERDOG_HOME with a space in it (e.g. "My Files"), exercising the real
+  // adapter rather than calling applySettings directly.
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-codex-'));
+  const env = {
+    HOME: root,
+    WIENERDOG_HOME: path.join(root, 'My Files', 'wd'),
+    CODEX_HOME: path.join(root, 'codex'),
+  };
+  const paths = getPaths(env);
+  fs.mkdirSync(paths.state, { recursive: true });
+  fs.mkdirSync(paths.codexDir, { recursive: true });
+  fs.writeFileSync(path.join(paths.state, 'digest.md'), FIXED_DIGEST);
+
+  const hooksPath = path.join(paths.codexDir, 'hooks.json');
+  const startAbs = path.join(paths.core, 'bin', 'session-start.sh');
+  const manifest = freshManifest();
+
+  applyCodexAdapter(paths, { manifest });
+  const hooks = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
+  const allCommands = (event) => (hooks.hooks[event] || []).flatMap((g) => g.hooks.map((h) => h.command));
+
+  assert.deepEqual(allCommands('SessionStart'), [q(startAbs)], 'quoted single-argument command');
+
+  // Second run: idempotent, no-op.
+  const res = applyCodexAdapter(paths, { manifest });
+  assert.ok(res.unchanged.includes(hooksPath), 'idempotent second run leaves hooks unchanged');
+});
+
+test('applySettings converges a pre-existing bare (unquoted) Codex entry to exactly one quoted entry, leaving unrelated hooks untouched', () => {
+  const { applySettings } = require('../../src/adapters/shared');
+  const paths = setup();
+  const hooksPath = path.join(paths.codexDir, 'hooks.json');
+  const stopAbs = path.join(paths.core, 'bin', 'codex-session-end.sh');
+  const preExisting = {
+    hooks: {
+      Stop: [
+        { hooks: [{ type: 'command', command: stopAbs, timeout: 10 }] },
+        { hooks: [{ type: 'command', command: '/usr/local/bin/other-stop.sh', timeout: 30 }] },
+      ],
+    },
+  };
+  fs.writeFileSync(hooksPath, `${JSON.stringify(preExisting, null, 2)}\n`);
+  const manifest = freshManifest();
+  const out = { changed: [], unchanged: [], notices: [] };
+
+  applySettings(hooksPath, [['Stop', stopAbs]], false, manifest, out);
+  const hooks = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
+  const allCommands = (event) => (hooks.hooks[event] || []).flatMap((g) => g.hooks.map((h) => h.command));
+
+  assert.deepEqual(
+    allCommands('Stop').filter((c) => c === stopAbs || c === q(stopAbs)),
+    [q(stopAbs)],
+    'bare entry pruned; exactly one quoted entry remains'
+  );
+  assert.ok(allCommands('Stop').includes('/usr/local/bin/other-stop.sh'), 'unrelated user hook untouched');
 });
 
 test('skills symlink into <codexDir>/skills points at the core skill dir', () => {
@@ -324,8 +391,8 @@ test('Codex-only machine: full setup + working dream from rollout files alone', 
   const stopAbs = path.join(core, 'bin', 'codex-session-end.sh');
   const sessionStartCmds = (hooks.hooks.SessionStart || []).flatMap((g) => g.hooks.map((h) => h.command));
   const stopCmds = (hooks.hooks.Stop || []).flatMap((g) => g.hooks.map((h) => h.command));
-  assert.ok(sessionStartCmds.includes(startAbs));
-  assert.ok(stopCmds.includes(stopAbs));
+  assert.ok(sessionStartCmds.includes(q(startAbs)));
+  assert.ok(stopCmds.includes(q(stopAbs)));
 
   const skillLink = path.join(codexHome, 'skills', 'wienerdog-setup');
   if (process.platform !== 'win32') {


### PR DESCRIPTION
Spec: docs/specs/WP-090-hook-command-shell-quoting.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

Files touched (all in the Deliverables table):
- `src/adapters/shared.js` — add `shellQuoteCommand`; store the quoted command; prune prior unquoted/separator-variants; record the quoted string in the manifest `commands`.
- `tests/unit/claude-adapter.test.js` — space-path → one quoted hook + no-op second run; bare→quoted convergence; unrelated hook untouched.
- `tests/unit/codex-adapter.test.js` — same for the Codex path.
- `tests/integration/bootstrap-seam.test.js` — 3 bare-path SessionStart assertions updated to the quoted canonical form (orchestrator-authorized scope addition; see Decisions made).

## Summary

Both harnesses run hooks as bash commands. The command was stored as the **bare** path. WP-077 normalized backslashes to forward slashes (character-valid for bash) but did **not** fix **tokenization**: a legitimate install path with a space — e.g. `/Users/ada/My Files/.wienerdog/app/current/bin/session-end.sh` — is word-split by bash, which runs `/Users/ada/My` and ENOENTs every session.

Fix: `shellQuoteCommand(rawCommand)` runs `toPosixCommand` then single-quotes the path with the `'\''` escape idiom — the strongest bash quoting, valid on POSIX bash and the bash the Windows harnesses shell out to. It is now the single canonical form used by the stored `command`, the `present` check, the prune predicate, and the recorded manifest `commands`, so:
- idempotency holds (second `sync` = unchanged);
- a prior **bare**/backslash/forward-slash-unquoted entry re-quotes to our path and is pruned, converging to exactly one quoted entry;
- an unrelated user hook never re-quotes to our path, so it is untouched;
- uninstall's set-membership match still works (stored command == recorded command).

The always-quote contract is kept exactly as the spec's Exact Contracts specify — **no** conditional quoting.

## Verification output

`npm test`:
```
ℹ tests 677
ℹ suites 0
ℹ pass 676
ℹ fail 0
ℹ cancelled 0
ℹ skipped 1
ℹ todo 0
```

`npm test -- --test-name-pattern "adapter|settings|hook"`:
```
✔ an install root containing a space registers shell-quoted hooks end-to-end (WP-090)
✔ applySettings shell-quotes a hook command whose path contains a space; second run is a no-op
✔ applySettings converges a pre-existing bare (unquoted) entry to exactly one quoted entry, leaving unrelated hooks untouched
✔ an install root containing a space registers shell-quoted hooks end-to-end (WP-090)   [codex]
✔ applySettings converges a pre-existing bare (unquoted) Codex entry to exactly one quoted entry, leaving unrelated hooks untouched
ℹ tests 61
ℹ pass 61
ℹ fail 0
```

`npm run lint`:
```
--- markdownlint ---
Summary: 0 error(s)
--- shellcheck ---
--- PSScriptAnalyzer ---
--- frontmatter check ---
frontmatter check passed: 15 spec(s), 4 agent(s)

lint passed
```

## Decisions made

- **Scope correction (orchestrator-authorized):** the spec originally claimed `bootstrap-seam` integration "must still pass" unchanged. That is inconsistent with the spec's own Exact Contracts — the always-quote contract necessarily changes the canonical stored command string, and `tests/integration/bootstrap-seam.test.js` had 3 bare-path SessionStart equality assertions that can never match a quoted command (independent of whether the path has a space). Per orchestrator authorization I added that file to the Deliverables table, corrected the stale claim in the spec's Implementation notes, and updated the 3 assertions to the quoted form using the same `q()` mirror-helper pattern as the unit tests. This is the correct resolution rather than weakening the contract to conditional quoting.
- **`shellQuoteCommand` kept internal** (not exported from `shared.js`) — not required by the spec or tests; the three test files mirror the quoting with a tiny local `q()` helper. Avoids widening the module's public surface unnecessarily.
- **Pre-existing-manifest residual (flagged per spec):** already-installed machines carry **bare** recorded `commands`; the recorded form changes to quoted only for new installs / after the next `sync`. Uninstall on a not-yet-re-synced machine leaves the bare hook (which the quoted entry supersedes only after a `sync`). No manifest migration is attempted here — explicitly out of scope per the spec.

## Discovered issues (out of scope, not fixed)

None remaining.

---
Generated-by: claude-opus-4-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uxThuapovGTPsbyn86BAf