### PR TITLE
fix(manifest): delete manifest last, hash-guard file deletes, contain tree removal (WP-088)

### DIFF
--- a/docs/specs/ROADMAP.md
+++ b/docs/specs/ROADMAP.md
@@ -106,7 +106,7 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 | [WP-085](WP-085-gws-mime-crlf-sanitization.md) | Reject CR/LF in Gmail MIME header fields (close the send-grant header-injection bypass) | M7 | sonnet | Draft | — |
 | [WP-086](WP-086-send-grant-boundary-hardening.md) | Harden the send-grant boundary — require a terminal to mint a grant; fail closed on empty recipients | M7 | sonnet | Draft | — |
 | [WP-087](WP-087-dream-truncation-index-rebase.md) | Rebase skill-invocation indices under byte-budget truncation | M3 | sonnet | Draft | — |
-| [WP-088](WP-088-manifest-reverse-crash-safety.md) | Uninstall crash-safety — delete manifest last, hash-guard file deletes, contain tree removal (delete copied skill only if it fingerprints to the recorded hash) | M7 | opus | Draft | WP-089 |
+| [WP-088](WP-088-manifest-reverse-crash-safety.md) | Uninstall crash-safety — defer the deferred-deletion set (manifest, core, config.yaml) until the sweep succeeds; hash-guard file deletes; contain tree removal (delete copied skill only if it fingerprints to the recorded hash) | M7 | opus | In-Review | WP-089 |
 | [WP-089](WP-089-adapter-skill-dir-ownership.md) | Adapter skill-dir ownership — fingerprint-guard skill-dir refresh instead of blind rmSync | M7 | sonnet | Draft | — |
 | [WP-090](WP-090-hook-command-shell-quoting.md) | Shell-quote hook command paths (space/metachar install paths produce valid hooks) | M7 | opus | Draft | WP-089 |
 | [WP-091](WP-091-managed-block-line-anchoring.md) | Anchor managed-block sentinels to full lines; fail closed on ambiguous markers | M7 | opus | Draft | WP-088, WP-090 |
@@ -694,10 +694,15 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 > hash WE recorded for that exact path (proof it is our own unmodified copy) —
 > otherwise it is left untouched with a notice, never `rmSync`+recopied. This keeps
 > auto-refresh working for our own copies across version bumps while never deleting a
-> directory that is not provably ours. **WP-088** (manifest.js + uninstall.js) deletes
-> the uninstall manifest LAST — in `uninstall.js`, only after BOTH the reversal loop
-> and the mechanics sweep succeed (round-2 fix: end-of-`reverse()` was insufficient) —
-> generalizes the config-only per-FILE `sha256File` hash-guard so any hashed file
+> directory that is not provably ours. **WP-088** (manifest.js + uninstall.js) defers a
+> **deferred-deletion set** — the uninstall manifest, the core dir, AND config.yaml —
+> deleting them LAST in `uninstall.js`, only after BOTH the reversal loop and the
+> mechanics sweep succeed (round-2 fix: end-of-`reverse()` was insufficient; 2026-07-13
+> redesign added config.yaml after a P1 where deleting it early made a retry lose the
+> nested-vault path and recursively delete the user's nested vault — manifest is now
+> deleted BEFORE config.yaml so "manifest-present ⟹ config-present" holds at every crash
+> point, and a matching P1 where `reverse()` rmdir'd the core → ENOTEMPTY wedged the
+> retry). It also generalizes the config-only per-FILE `sha256File` hash-guard so any hashed file
 > modified since install is preserved not deleted (un-hashed shims/hooks remain a
 > follow-up), contains vendored-tree removal to the app root `core/app` (rejecting the
 > equal-to-`core` P0), and contains copied-skill removal to the harness skills root +
@@ -860,7 +865,7 @@ graph LR
   WP086[WP-086 send-grant boundary hardening]
   WP087[WP-087 dream truncation index rebase]
   WP089[WP-089 adapter skill-dir ownership: fingerprint-guard refresh]
-  WP089 --> WP088[WP-088 manifest reverse crash-safety + hash-guard + fingerprint-guard copied-skill delete]
+  WP089 --> WP088[WP-088 manifest reverse crash-safety: defer manifest+core+config.yaml + hash-guard + fingerprint-guard copied-skill delete]
   WP089 --> WP090[WP-090 hook command shell-quoting]
   WP088 --> WP091[WP-091 managed-block full-line anchoring]
   WP090 --> WP091

--- a/docs/specs/WP-088-manifest-reverse-crash-safety.md
+++ b/docs/specs/WP-088-manifest-reverse-crash-safety.md
@@ -1,7 +1,7 @@
 ---
 id: WP-088
-title: Uninstall crash-safety — delete the manifest last, hash-guard file deletes, contain vendored-tree removal, fingerprint-guard copied-skill removal
-status: Draft
+title: Uninstall crash-safety — defer the deferred-deletion set (manifest, core, config.yaml) until the sweep succeeds; hash-guard file deletes; contain vendored-tree removal; fingerprint-guard copied-skill removal
+status: In-Review
 model: opus
 size: M
 depends_on: [WP-089]
@@ -19,8 +19,25 @@ replays that manifest in reverse to remove exactly what was added, leaving the
 user's memory **vault** untouched (THREAT-MODEL T5; ADR-0019). `uninstall`
 **refuses to run without the manifest** (`src/cli/uninstall.js` checks it exists).
 
-Four verified gaps in `src/core/manifest.js` `reverse()` (and its `uninstall.js`
-orchestration) undermine that promise:
+**The coherent principle behind this WP — the deferred-deletion set.** Making
+uninstall *retryable* (deleting the ledger last) exposed a class of bug: anything a
+safe RETRY needs to COMPLETE uninstall, but that `reverse()` deletes early, becomes
+unrecoverable on the retry. Everything in that "must survive until the crash-prone
+`disposeCoreMechanics` sweep succeeds" set must be deferred and deleted LAST. That
+set is exactly **three** things, all physically inside the canonical core:
+(1) `install-manifest.json` — the retry ledger (uninstall refuses without it);
+(2) the canonical core dir `paths.core` — `reverse()`'s `dir` branch never rmdirs it,
+uninstall.js disposes it post-manifest; and
+(3) `config.yaml` when UNMODIFIED — its `vault:` line is the **only** source of the
+vault path `disposeCoreMechanics` needs to protect a vault nested inside the core, on
+**every** retry. A CUSTOMIZED `config.yaml` (recorded-hash mismatch) is kept forever
+(ADR-0019) and is never in the deferred-delete set. **Holistic check (see the
+dedicated note below): config.yaml is the ONLY remaining member beyond the manifest
+and the core** — `disposeCoreMechanics`'s single external input is `vaultPath`, sourced
+solely from config.yaml, and the default vault lives outside the core (never swept).
+
+Five verified gaps in `src/core/manifest.js` `reverse()` (and its `uninstall.js`
+orchestration) undermine the reversibility promise:
 
 1. **Crash-consistency (P0):** `reverse()` deletes `install-manifest.json`
    **first**, before the reversal loop runs. A crash / power loss / thrown error
@@ -79,9 +96,32 @@ orchestration) undermine that promise:
    `contains(root, path)` is WRONG for (a): it accepts any depth AND is reflexive
    (accepts the root itself).
 
+5. **Nested-vault path unrecoverable on retry — config.yaml deleted too early (P1,
+   the reason for this amendment):** `uninstall.js` reads the configured vault path from
+   `config.yaml` (`readVaultPath`, line ~57) and passes it as `vaultPath` to
+   `disposeCoreMechanics`, which uses it to PROTECT a vault nested inside the core (a
+   supported legacy / hand-edited install: ADR-0019's containment guard). But
+   `config.yaml` is recorded as an ordinary `kind:'file'` entry with a hash
+   (`init.js:141`), so when it is UNMODIFIED `reverse()` **deletes it** during the
+   reversal loop — before the mechanics sweep. Within a single process this is
+   survivable (uninstall.js captures `vaultPath` at line 57 *before* `reverse()` runs).
+   But on a **retry after a partial crash** (attempt 1 deleted config.yaml then crashed
+   during/after the sweep; the manifest survived by design so the retry proceeds), the
+   fresh process re-reads `config.yaml`, finds it gone, and `readVaultPath` returns
+   `null` → falls back to the DEFAULT `paths.vault`. `disposeCoreMechanics` no longer
+   knows the vault is nested → it **recursively deletes the user's nested vault**.
+   **User-data loss on retry — the exact failure the manifest-last design was meant to
+   make impossible.** config.yaml is therefore a member of the deferred-deletion set:
+   it must survive `reverse()` and be deleted LAST (only when unmodified), after the
+   sweep and after the manifest.
+
 **Product invariants that bound this WP:** Wienerdog is just files (ADR-0004);
 `reverse()` is synchronous filesystem code. The vault is always preserved
-(ADR-0019); this WP does not change vault handling.
+(ADR-0019) — including a legacy vault nested inside the core. This WP does not
+change the vault-file/vault-dir preservation logic; it only ensures the
+*information* needed to protect a nested vault (config.yaml's `vault:` path)
+survives long enough to do so on every retry, and it never deletes the vault
+itself.
 
 ## Current state
 
@@ -152,81 +192,363 @@ remove `<core>/skills/`; that dir is removed by `reverse()`'s own `dir`/`file`
 entries. `uninstall.js` refuses to run when `paths.manifest` is absent (`fileExists`
 check at the top). `fs` is imported there.
 
+**config.yaml, and how uninstall.js gets the vault path (the P1 above).**
+`config.yaml` lives at `paths.config = path.join(paths.core, 'config.yaml')`
+(`paths.js:39`) and is recorded by `init` as a hashed file entry
+`{kind:'file', path: paths.config, hash: sha256(content)}` (`init.js:141`, re-synced
+to the current content whenever init/adopt rewrite it, so a clean install's on-disk
+hash MATCHES the recorded hash → `reverse()` currently deletes it). `uninstall.js`
+derives the vault path exactly once per process:
+`const vaultPath = readVaultPath(paths.config) || paths.vault;` (line 57) —
+`readVaultPath` greps the `vault:` line out of config.yaml, returning `null` when the
+file is missing/unreadable or the value is `null`, in which case the DEFAULT
+`paths.vault` (`~/wienerdog`, outside the core) is used. `vaultPath` is the ONLY
+input `disposeCoreMechanics` uses to decide whether a swept mechanics dir contains the
+vault. **Nothing else in the whole uninstall reads config.yaml or otherwise sources a
+vault path** (verified: `readVaultPath` is the single caller; `disposeCoreMechanics`
+takes `vaultPath` as a parameter and reads no file). That is what makes config.yaml —
+and config.yaml alone, besides the manifest and the core dir — a member of the
+deferred-deletion set.
+
 ## Deliverables (permission boundary — touch ONLY these)
 
 <!-- Always allowed without listing: this spec file, docs/specs/ROADMAP.md, package-lock.json. -->
 
 | Action | Path | Notes |
 |--------|------|-------|
-| modify | src/core/manifest.js | (1) `reverse()` NO LONGER deletes the manifest (keep `removedSet` seeded with `paths.manifest`); (2) generalize the config-only `sha256File` hash-mismatch preservation to every `kind:'file'` with a `hash`; (3) add ONE local `sameResolvedDir` helper; require `reverseVendoredTree`'s target to resolve EQUAL to `paths.core/app`, and `reverseCopiedSkill`'s target to be a strict child (parent EQUALS a harness skills root) in the `wienerdog-*` namespace whose on-disk tree still fingerprints (via the WP-089 `hashDir`) to `entry.hash`; pass `appRoot` and `skillsRoots` in from `reverse()`. Do NOT redefine `hashDir` (WP-089 defines it in this module). No new `require`/top-level import. |
-| modify | src/cli/uninstall.js | delete the manifest ONLY after both `reverse()` and `disposeCoreMechanics()` complete, then sweep the now-empty core (idempotent second `disposeCoreMechanics`); merge its removed-core into the summary |
-| modify | tests/unit/manifest.test.js | tests for reverse-does-not-delete-manifest, hashed-file preserve-on-mismatch, equal-to-core vendored-tree refusal, out-of-app vendored-tree refusal, copied-skill refusal for a deeper descendant (parent ≠ skills root) / outside the `wienerdog-*` namespace / a copy whose on-disk fingerprint DIFFERS from `entry.hash` (preserved) / a legacy hash-less entry (preserved) / an unreadable copy (hashDir null → preserved), and a legitimate copied-skill removal (parent equals a harness skills root + `wienerdog-*` + fingerprint matches `entry.hash`) |
-| modify | tests/unit/uninstall.test.js | tests: the manifest survives a throw during `disposeCoreMechanics` (recovery ledger intact for retry); a clean uninstall deletes the manifest last and removes the empty core |
+| modify | src/core/manifest.js | (1) `reverse()` NO LONGER deletes the manifest (keep `removedSet` seeded with `paths.manifest`); **(1b) add a SINGLE GLOBAL deferred-member guard at the TOP of the entry loop, BEFORE the kind dispatch, that protects all three deferred members — `paths.manifest`, `paths.core`, `paths.config` — from EVERY kind and from path normalization (realpath-aware via a 1-line `resolvesTo` closure: `p` string-equals target, or `sameResolvedDir` to it). Manifest/core → skip. config → decide inline: unmodified `kind:'file'` (recorded hash matches) → `deferredConfig = paths.config` + `removedSet.add`; customized → keep-forever notice + skip; any other/adversarial kind targeting config → protect (skip). REMOVE the now-redundant per-branch `paths.core` dir-skip and `paths.manifest` file-skip and the file-branch config-defer;** (2) generalize the config-only `sha256File` hash-mismatch preservation to every `kind:'file'` with a `hash` (the generic guard now covers only OTHER files — config is handled in the global guard); (3) **`reverse()`'s return shape becomes `{removed, skipped, preserved, deferredConfig, deferredConfigHash}`; `deferredConfig` is the canonical `paths.config` for an unmodified config (else `null`), and `deferredConfigHash` carries that config's recorded hash forward so uninstall.js can re-verify it at the (later) delete site (else `null`); also export `sha256File` for that re-verify;** (4) add ONE local `sameResolvedDir` helper; require `reverseVendoredTree`'s target to resolve EQUAL to `paths.core/app`, and `reverseCopiedSkill`'s target to be a strict child (parent EQUALS a harness skills root) in the `wienerdog-*` namespace whose on-disk tree still fingerprints (via the WP-089 `hashDir`) to `entry.hash`; pass `appRoot` and `skillsRoots` in from `reverse()`; (5) the `dir` branch body is UNCHANGED (core is handled by the global guard, never reaches the `dir` branch). Do NOT redefine `hashDir` (WP-089 defines it in this module). No new `require`/top-level import. |
+| modify | src/cli/uninstall.js | consume `deferredConfig` from `reverse()`; on the live path delete the deferred-deletion set LAST — **manifest first, then `deferredConfig` (unmodified config.yaml)** — only after both `reverse()` and the first `disposeCoreMechanics()` complete. **The manifest delete must be CONFIRMED GONE before touching config, using rmSync's OWN outcome (NOT `fs.existsSync`, which is ambiguous on a lookup error): with `{force:true}`, ENOENT is success and a real failure throws, so `rmSync` returning without throwing proves the manifest is gone. On a throw, `throw new WienerdogError(...)` (already imported) and do NOT delete config — leaving both files present keeps a retry vault-safe.** **Prove-before-delete AT THE DELETE SITE: before `rmSync(deferredConfig)`, RE-VERIFY the carried-forward `deferredConfigHash` against a fresh `sha256File(deferredConfig)` — delete only if it STILL matches; if config was edited during the (slow) sweep (mismatch) or is missing/unreadable, PRESERVE it with a keep-notice and do not count it removed. This closes the TOCTOU the deferral opened (check in `reverse()`, delete much later).** Then sweep the now-empty core (idempotent second `disposeCoreMechanics`); count `deferredConfig` in the live removed total ONLY when the re-verify passed (`configDeleted`); add it to the dry-run headline count (headline count is not claimed to equal the live total — mechanics/core stay separate disclosure lines). Do not change `readVaultPath`, the confirmation prompt, or the vault messaging. |
+| modify | tests/unit/manifest.test.js | tests for reverse-does-not-delete-manifest, **GLOBAL-GUARD cross-kind regression (write a REAL manifest JSON file, load it via `manifestLib.load`, run `reverse()` on the REAL filesystem with NO fs stubs, then assert the target deferred member still exists on disk and is NOT in `removed`): (i) a self-referential `{kind:'file', path: paths.manifest}` entry → real ledger intact; (ii) `{kind:'scheduler-entry', path: paths.manifest}` → ledger intact; (iii) `{kind:'symlink', path: <symlinked deferred member>}` → not unlinked; (iv) a `settings-entry` at `paths.config` → config not rewritten/deleted; (iv-b) a `managed-block` entry at `paths.config` → config not rewritten/deleted (BOTH mutation branches tested explicitly, not one-or-the-other); (v) `{kind:'file', path: '<core>/./config.yaml'}` normalized alias → config NOT deleted and (when hash matches) returned as `deferredConfig === paths.config`; (vi) `{kind:'scheduler-entry', path: paths.config}` → config intact; (vii) DOCUMENTED-RESIDUAL regression: a `{kind:'scheduler-entry', path: <a non-deferred path>, unload: <argv that would touch a deferred member>}` → assert the `unload` argv IS invoked (via the schedulerSpawn chokepoint / a spy) as designed and that this is the ACCEPTED out-of-scope residual — the test pins the behavior + scoping, NOT a false "guard blocks it"**, **reverse-does-not-delete an unmodified config.yaml but returns it in `deferredConfig`; reverse KEEPS a customized (hash-mismatched) config.yaml (in `skipped`, `deferredConfig` null)**, hashed-file preserve-on-mismatch, equal-to-core vendored-tree refusal, out-of-app vendored-tree refusal, copied-skill refusal for a deeper descendant (parent ≠ skills root) / outside the `wienerdog-*` namespace / a copy whose on-disk fingerprint DIFFERS from `entry.hash` (preserved) / a legacy hash-less entry (preserved) / an unreadable copy (hashDir null → preserved), and a legitimate copied-skill removal (parent equals a harness skills root + `wienerdog-*` + fingerprint matches `entry.hash`) |
+| modify | tests/unit/uninstall.test.js | tests: (a) the manifest AND config.yaml both survive a throw during `disposeCoreMechanics` (recovery ledger + vault-path source intact for retry); (b) **NEW retry-with-nested-vault: with config.yaml pointing at a vault nested under a mechanics dir, attempt 1 crashes in `disposeCoreMechanics`; a real retry re-reads the still-present config.yaml, derives the nested vault path, and the nested vault SURVIVES the crashed-then-retried uninstall (reported via `skippedForVault`)**; (c) a clean uninstall deletes the manifest last, then the unmodified config, and removes the empty core; (d) a clean uninstall with a CUSTOMIZED config keeps config.yaml and the core (existing customized-config-kept rule still holds); (e) **NEW manifest-delete-FAILURE injection: stub ONLY the manifest deletion to throw — e.g. wrap `fs.rmSync` so it throws (with a real `err.code`) when called for `paths.manifest` and delegates to the real `rmSync` otherwise — while the REAL manifest file remains on disk and the real filesystem is observed. Do NOT stub any verification (there is no separate existence check to stub — the gate is rmSync's own outcome, so stubbing it would be tautological). Assert `run()` rejects with `WienerdogError`, config.yaml is NOT deleted (still on disk with `deferredConfig`'s content), and a subsequent real retry with a nested vault leaves the nested vault intact (vault-safe on the delete-failure path)**; (f) **NEW deferred-config TOCTOU re-verify: config.yaml is unmodified at `reverse()` time (deferred), but is MUTATED after `reverse()` and before the deferred delete (simulate by editing it inside an instrumented `disposeCoreMechanics`) → the delete-site hash re-verify PRESERVES it (file survives with the new content, keep-notice emitted), NOT deleted; the unchanged-config happy path (test (c)) still deletes it** |
+| modify | tests/unit/scheduler-schedule.test.js | **Collateral (implementation review, 2026-07-13):** the "add then manifest.reverse still removes config.yaml" test asserted the SUPERSEDED behavior (reverse() deleting config inline). Config is now a deferred-deletion-set member — reverse() returns it in `deferredConfig` and never deletes it. Update the single assertion to the new contract (`deferredConfig === paths.config`, config still on disk after `reverse()`); intent (a re-synced hash is recognized as our unmodified file, not a user edit) is preserved. |
+| modify | tests/unit/gws-grant.test.js | **Collateral (implementation review, 2026-07-13):** same as above — the `saveGrant ... uninstall stays clean` test asserted `reverse()` deletes config.yaml. Update its single assertion to the deferred-deletion contract (`deferredConfig === paths.config`, config still on disk after `reverse()`), preserving intent. |
 
 ### Exact contracts
 
-**(1) Delete the manifest last — in `uninstall.js`, after mechanics disposal.**
-`reverse()` must **no longer delete the manifest at all**. Remove the eager
-`fs.rmSync(paths.manifest, …)` block (current lines ~308–314) entirely, but KEEP
-`removedSet` seeded with `paths.manifest` so the enclosing-core "is it empty?"
-accounting inside the reversal loop is byte-for-byte unchanged:
+**(1) Defer the deferred-deletion set — delete manifest, then config.yaml, LAST in
+`uninstall.js`, after the mechanics sweep.** `reverse()` must not DIRECTLY delete or damage
+any of the three deferred members — the manifest, the core dir, and config.yaml — via an
+entry's PATH, and this is **enforced structurally by a SINGLE GLOBAL GUARD at the top of the
+entry loop, BEFORE the kind dispatch**. The guard covers **every entry kind** (file / dir /
+symlink / managed-block / settings-entry / scheduler-entry / …) and **path normalization**
+(a `<core>/./config.yaml` alias, a symlinked manifest, etc.) — because it screens
+`entry.path` before any reverser runs. This replaces the previous per-branch skips, which
+were incomplete: a malformed/hand-edited/adversarial manifest can point ANY kind's PATH at a
+deferred member — e.g. `{kind:'scheduler-entry', path: paths.manifest}` reaches
+`reverseSchedulerEntry` and `rmSync`s the ledger; a `symlink` entry unlinks a symlink-valued
+core/manifest/config; a `managed-block`/`settings-entry` can rewrite or (created-empty)
+delete a deferred file; a `{kind:'file'}` with a normalized config path bypasses an
+exact-string config check. The global guard closes ALL of these path-based routes at once.
+It is realpath-aware (`resolvesTo` = string-equality OR `sameResolvedDir`) and handles
+config's defer-vs-keep decision inline (from the recorded hash), so config protection does
+not depend on the entry being a `kind:'file'`. The precise, defensible invariant:
+**the global guard prevents any entry from DIRECTLY deleting/damaging a deferred member via
+its `entry.path`, for every entry kind and for normalized/symlink path aliases.** It does
+NOT (and cannot) police INDIRECT side effects such as a `scheduler-entry`'s executable
+`unload` argv — that is an explicitly out-of-scope, pre-existing residual (see Non-goals /
+Residuals below); it is not a WP-088 regression and does not weaken the crash-safety
+guarantees for a Wienerdog-authored (non-adversarial) manifest.
+
+*In `reverse()`:* remove the eager `fs.rmSync(paths.manifest, …)` block entirely
+(already done on the branch), KEEP `removedSet` seeded with `paths.manifest`, add the
+GLOBAL deferred-member guard at the top of the entry loop (and REMOVE the now-redundant
+per-branch `paths.core` dir-skip and `paths.manifest` file-skip),
+and add a `deferredConfig` slot. The return shape gains `deferredConfig`. The guard's
+config handling is the subtle part: it defers an unmodified config (sets `deferredConfig`
+to the CANONICAL `paths.config`), keeps a customized one (ADR-0019), and protects config
+from any non-file/adversarial kind — all inline, realpath-aware:
 
 ```js
 function reverse(paths, manifest, { dryRun = false } = {}) {
   const removed = []; const skipped = []; const preserved = [];
+  let deferredConfig = null;                 // unmodified config.yaml → deleted last by uninstall.js
   // Seed with the manifest path so the core dir still counts as (virtually) empty.
   // The manifest FILE is NOT touched here — uninstall.js deletes it only after the
   // whole uninstall (reversal loop + mechanics sweep) has succeeded, so a crash at
   // any point leaves a replayable ledger (uninstall refuses without it).
   const removedSet = new Set([paths.manifest]);
-  for (const entry of [...manifest.entries].reverse()) { /* …reversal loop, unchanged… */ }
-  return { removed, skipped, preserved };
+  // …appRoot / skillsRoots as today…
+  // Realpath-aware equality (string fallback when a side is unresolvable): true iff `p`
+  // is `target` or resolves to it. Applies to files and dirs (`sameResolvedDir` is just
+  // realpath equality). Catches symlinked/normalized aliases of any deferred member.
+  const resolvesTo = (p, target) => p === target || sameResolvedDir(p, target);
+
+  for (const entry of [...manifest.entries].reverse()) {
+    // ── GLOBAL DEFERRED-MEMBER GUARD (before kind dispatch) ──────────────────────────
+    // reverse() must NEVER delete/damage the three deferred members — the manifest, the
+    // core dir, and config.yaml — regardless of entry KIND or path normalization. A
+    // malformed/hand-edited/adversarial manifest can point ANY kind at a deferred member
+    // (e.g. {kind:'scheduler-entry', path: paths.manifest} deletes the ledger; a
+    // {kind:'file', path:'<core>/./config.yaml'} normalized alias bypasses an exact-string
+    // config check; a symlink/managed-block/settings-entry can unlink/rewrite one). This
+    // single guard blocks every PATH-based route for every kind at once. (It does NOT
+    // police INDIRECT side effects — e.g. a scheduler-entry's executable `unload` argv —
+    // which is an out-of-scope, pre-existing residual; see Non-goals / Residuals.)
+    if (resolvesTo(entry.path, paths.manifest) || resolvesTo(entry.path, paths.core)) {
+      // Manifest → retry ledger (uninstall.js deletes it LAST via the rmSync-outcome gate);
+      // core → deferred to disposeCoreMechanics. Never touched here by any kind. (removedSet
+      // already holds paths.manifest; a normal manifest's sole core entry is {kind:'dir',
+      // path: paths.core} — this is where it is skipped.)
+      skipped.push(entry.path); continue;
+    }
+    if (resolvesTo(entry.path, paths.config)) {
+      // config.yaml is deferred/kept here for EVERY kind — its `vault:` line is what
+      // disposeCoreMechanics reads on every retry to protect a nested vault; reverse()
+      // never deletes it. Decide defer-vs-keep from the recorded hash of the LEGITIMATE
+      // file entry (Wienerdog records config only as {kind:'file', path, hash}):
+      if (entry.kind === 'file' && isFile(entry.path) && entry.hash) {
+        if (sha256File(entry.path) === entry.hash) {
+          // UNMODIFIED → deferred: uninstall.js deletes it LAST (after the sweep, after the
+          // manifest). Store the CANONICAL path (not a normalized alias); add to removedSet.
+          deferredConfig = paths.config;
+          removedSet.add(paths.config);
+          continue;                          // the deferred member — not in removed/skipped
+        }
+        // CUSTOMIZED (hash mismatch) → kept forever (ADR-0019). Keeps the core alive.
+        process.stderr.write(`wienerdog: keeping ${entry.path} — modified since install\n`);
+      }
+      // Customized config, OR any non-file/hash-less/adversarial entry targeting config →
+      // PROTECT it: never delete/rewrite. (deferredConfig is set only by the legitimate
+      // unmodified file entry above; if the manifest is too corrupt to have one, config
+      // simply stays — safe, uninstall.js keeps the core — a bounded degraded outcome.)
+      skipped.push(entry.path); continue;
+    }
+    // ── end global guard ─────────────────────────────────────────────────────────────
+    if (entry.kind === 'file') {
+      if (!isFile(entry.path)) { skipped.push(entry.path); continue; }
+      if (entry.hash && sha256File(entry.path) !== entry.hash) {   // contract (2): keep a modified hashed file
+        process.stderr.write(`wienerdog: keeping ${entry.path} — modified since install\n`);
+        skipped.push(entry.path); continue;
+      }
+      if (!dryRun) fs.rmSync(entry.path, { force: true });
+      removedSet.add(entry.path); removed.push(entry.path);
+    } else if (/* …dir / symlink / managed-block / settings-entry / scheduler-entry /
+                  vendored-tree / copied-skill / vault-* … */) { /* unchanged */ }
+  }
+  return { removed, skipped, preserved, deferredConfig };
 }
 ```
 
-Then in `src/cli/uninstall.js` `run()`, on the LIVE (non-dry-run) path, delete the
-manifest only after both `reverse()` and the first `disposeCoreMechanics()` return,
-then sweep the emptied core with a second (idempotent) `disposeCoreMechanics()`:
+Note `deferredConfig` is set even under `dryRun` (reverse never deletes it either way);
+uninstall.js decides what to physically delete.
+
+**The per-branch skips are REMOVED, superseded by the global guard.** The prior
+file-branch `paths.manifest` skip and dir-branch `paths.core` skip are deleted — the
+global guard is the single enforcement point, so the `dir` branch no longer needs a core
+special-case (a `{kind:'dir', path: paths.core}` entry never reaches it), and the file
+branch no longer needs a manifest special-case or the exact-string config-defer branch
+(both handled globally, realpath-aware). One guard, one source of truth: this avoids the
+false impression that per-branch protection suffices and prevents divergence between
+branches. `resolvesTo` is a 1-line local closure over the existing `sameResolvedDir`
+(no new import). `removedSet` stays seeded with `paths.manifest` (accounting unchanged).
+
+*In `src/cli/uninstall.js` `run()`, LIVE (non-dry-run) path.* The ordering is
+**reverse → first sweep → delete manifest → delete config.yaml → second sweep**, and
+within the deferred set the **manifest is deleted BEFORE config.yaml** — a hard
+ordering constraint, see the rationale below:
 
 ```js
-const { removed, skipped, preserved } = manifestLib.reverse(paths, manifest, { dryRun: false });
-// First sweep: removes state/logs/schedules/secrets. The core is NOT removed yet —
-// the manifest file still sits in it, so its emptiness check fails (correct).
+const { removed, skipped, preserved, deferredConfig } =
+  manifestLib.reverse(paths, manifest, { dryRun: false });
+// First sweep: removes state/logs/schedules/secrets, protecting a nested vault via
+// vaultPath (read from the STILL-PRESENT config.yaml at line 57). The core is NOT
+// removed yet — manifest + config.yaml still sit in it, so its emptiness check fails.
 const { removed: mech, skippedForVault } = manifestLib.disposeCoreMechanics(paths, {
   dryRun: false,
   vaultPath,
 });
-// Recovery ledger removed ONLY now — every crash-prone step above has completed.
-try { fs.rmSync(paths.manifest, { force: true }); } catch { /* already gone */ }
-// Second sweep: mechanics are already gone (idempotent); with the manifest deleted
-// the core is now empty, so this removes it (symlink-aware, vault-aware). Reuses
-// the vetted removal logic rather than duplicating it.
+// Delete the deferred set LAST — MANIFEST FIRST, then config.yaml. Every crash-prone
+// step above has completed. Manifest-before-config is load-bearing (see rationale), and
+// the manifest delete must be CONFIRMED before config is touched. The confirmation is
+// rmSync's OWN outcome: `{force:true}` does NOT throw on ENOENT (already-gone = success)
+// but DOES throw on a real failure (EACCES/EPERM/IO). So "rmSync returned without
+// throwing" is proof the manifest is gone — no post-hoc existence check (which would be
+// ambiguous: fs.existsSync returns false on a LOOKUP ERROR — EACCES on the path, or a
+// dangling symlink it follows — even while the manifest actually persists, which would
+// reopen the exact P1: manifest-present + config-gone → retry reads no config → default
+// vault → nested vault deleted).
+try {
+  fs.rmSync(paths.manifest, { force: true });
+} catch (e) {
+  // Real deletion failure, manifest still present → ABORT before touching config, leaving
+  // BOTH files present so every retry stays vault-safe. Loud, actionable error.
+  throw new WienerdogError(
+    `could not remove the install manifest (${e?.code || 'unknown error'}) — uninstall partially completed; ` +
+      `left config.yaml and ${paths.core} in place so a retry stays safe. ` +
+      `Fix the permission/IO issue, then re-run: npx wienerdog@latest uninstall`
+  );
+}
+// rmSync returned without throwing ⇒ the manifest is gone (or was already absent). The
+// retry gate is now closed → only now is it safe to delete an unmodified config.
+// PROVE-BEFORE-DELETE AT THE DELETE SITE (re-verify hash): config was proven unmodified
+// in reverse(), but is deleted here AFTER the (slow, recursive) sweep — a TOCTOU window.
+// Re-hash config.yaml and delete ONLY if it STILL matches the carried-forward
+// `deferredConfigHash`; if it was edited during the sweep (mismatch) or is missing/
+// unreadable, PRESERVE it with a keep-notice and do not count it removed.
+let configDeleted = false;
+if (deferredConfig) {
+  let currentHash = null;
+  try { currentHash = manifestLib.sha256File(deferredConfig); } catch { currentHash = null; }
+  if (currentHash !== null && currentHash === deferredConfigHash) {
+    try { fs.rmSync(deferredConfig, { force: true }); configDeleted = true; } catch { /* best-effort */ }
+  } else {
+    process.stderr.write(`wienerdog: keeping ${deferredConfig} — modified since install\n`);
+  }
+}
+// Second sweep: mechanics already gone (idempotent); with manifest + unmodified config
+// deleted the core is now empty, so this removes it (symlink-aware, vault-aware). A
+// kept CUSTOMIZED config leaves the core non-empty → core preserved (unchanged).
 const { removed: coreSwept } = manifestLib.disposeCoreMechanics(paths, {
   dryRun: false,
   vaultPath,
 });
 ```
 
-Update the printed summary to count `coreSwept` (the removed core) alongside
-`removed`/`mech`; the existing `!fs.existsSync(paths.core)` / `skippedForVault`
-branches at the end of `run()` still work unchanged (the second sweep removes the
-core exactly when the first would have). The **dry-run** path is unchanged: it
-already prints the core line manually and never deletes anything — leave it as-is
-(a single `disposeCoreMechanics(dryRun:true)` for reporting).
+`WienerdogError` is already imported in `uninstall.js` (line 6) — no new import. The
+abort leaves the mechanics already swept (the first `disposeCoreMechanics` completed and
+protected any nested vault), the manifest and config.yaml present, and the core present:
+a subsequent `npx wienerdog@latest uninstall` re-reads the intact config, re-derives the
+correct vault path, and completes once the permission cause is fixed.
+
+**Why manifest BEFORE config.yaml AND confirmed-gone (the invariant "manifest-present ⟹
+config-present").** A retry proceeds only while the manifest exists (uninstall refuses
+without it). A retry that proceeds to a sweep needs config.yaml to derive the
+nested-vault path. So config.yaml must exist at *every* point where the manifest still
+exists — whether that point is reached by a crash OR by a failed manifest delete.
+Ordering alone is not enough: `rmSync(paths.manifest, {force:true})` can THROW on a
+permission/IO error and leave the file, so a naive `try { rmSync(manifest) } catch {}`
+followed by an unconditional config delete would yield manifest-present + config-gone —
+the exact P1 data-loss window (retry reads `null` → default vault → nested vault
+deleted). Two guarantees close it: (1) delete the manifest FIRST, before config.yaml is
+touched; (2) gate the config delete on **rmSync returning without throwing** — with
+`{force:true}`, ENOENT (already gone) is success and any real failure throws, so a clean
+return is proof the manifest is gone. On a throw, ABORT with a loud `WienerdogError`,
+leaving both files present. Do NOT use a post-hoc `fs.existsSync(paths.manifest)` as the
+gate: `existsSync` returns `false` on a LOOKUP error too (EACCES on the path, or a
+dangling symlink it follows), so "existsSync === false" does not prove absence — it could
+report the manifest gone while it actually persists, deleting config and reopening the P1.
+The rmSync-outcome gate has no such ambiguity. Together these make "manifest-present ⟹
+config-present" hold at every crash point AND every failure point. A crash between the two deletions likewise leaves
+the manifest gone → the retry refuses → no sweep runs → the nested vault is never at risk
+from a stale/default vault path. Within the current process `vaultPath` was captured at
+line 57 and is unaffected by deleting the file, so the second sweep still protects the
+nested vault correctly.
+
+**Every retry re-reads config.yaml.** `vaultPath` is derived at the top of each process
+(`readVaultPath(paths.config) || paths.vault`, line 57). Because config.yaml is never
+deleted while the manifest exists, any legitimate retry (manifest present) re-reads the
+real (possibly nested) vault path. That is the whole point of deferring it.
+
+*Summary count.* Total removed = `removed.length + mech.length + coreSwept.length +
+(configDeleted ? 1 : 0)` — `configDeleted` is true only when the delete-site hash
+re-verify passed and the `rmSync` succeeded (a config edited during the sweep is
+preserved and NOT counted). The existing `!fs.existsSync(paths.core)` / `skippedForVault`
+branches at the end of `run()` still work unchanged (the second sweep removes the core
+exactly when the first would have). **The printed "Skipped" filter is unchanged and
+remains correct:** an unmodified config is in `deferredConfig` (deleted → never in
+`skipped`); a customized config is in `skipped` and still exists after the final sweep →
+shown as "a customized config … kept"; the swept `<core>`/`<core>/state` in `skipped` no
+longer exist → dropped. `reverse()`'s `skipped` RETURN value is unchanged — only the
+CLI's printed summary filters.
+
+*Dry-run path.* Still deletes nothing (both the manifest and config.yaml remain on disk
+after a dry-run). Its headline "would be removed" count MUST now include the deferred
+config, which moved out of `reverse()`'s `removed`, so it is not silently dropped from the
+plan: `removed.length + (deferredConfig ? 1 : 0)` (destructure `deferredConfig` in the
+dry-run branch too). **This headline count is NOT the full live "Removed N" total, and the
+spec does not claim it is.** The two use different bases by existing design: the dry-run
+*headline* counts the manifest-tracked items `reverse()` would remove (now including the
+deferred config), while the mechanics dirs (`mech`) and the core-removal are disclosed as
+**separate prose lines** (the ADR-0019 dry-run disclosure requirement), NOT folded into
+the headline number. The live run instead reports one combined `Removed N` =
+`removed + mech + coreSwept + deferredConfig`. What dry-run guarantees (M1 exactness) is
+that every item it *lists* — the reverse-removed set incl. config, each mechanics dir,
+and the core line — is exactly what the live run removes; it does not guarantee the
+headline integer equals the live integer. `deferredConfig` is counted exactly once (a
+customized config has `deferredConfig === null` and stays in `skipped`, never counted as
+removed). Everything else in the dry-run branch is unchanged — it prints the core line
+manually and does a single `disposeCoreMechanics(dryRun:true)` for reporting.
 
 Rationale for the second `disposeCoreMechanics` call: it is idempotent by design
 ("subdirs already gone are skipped") and already contains the symlink-aware,
-vault-aware empty-core removal. Calling it again after the manifest is gone reuses
-that logic verbatim instead of duplicating ~10 lines of core-removal in
+vault-aware empty-core removal. Calling it again after the manifest + config are gone
+reuses that logic verbatim instead of duplicating ~10 lines of core-removal in
 `uninstall.js`. `disposeCoreMechanics` itself is **not modified**.
+
+**Holistic check — is config.yaml the only remaining deferred member?** Yes. A safe
+retry of the whole uninstall depends on: the manifest (retry gate — deferred), the core
+dir (deferred), and the vault path. `disposeCoreMechanics`'s sole external input is
+`vaultPath`, and `vaultPath` is sourced ONLY from config.yaml's `vault:` line
+(`readVaultPath` is its single caller; nothing else in uninstall reads config or a vault
+path). Everything else `reverse()` deletes — shims, hook scripts, symlinks,
+managed-block edits, settings-entries, scheduler-entries, the vendored app tree, copied
+skills, empty authored dirs — feeds neither the retry gate nor the vault protection. The
+DEFAULT vault (`~/wienerdog`) is outside the core and never swept; `vault-file`/
+`vault-dir` entries are preserved, not deleted. So **config.yaml is the only member of
+the deferred-deletion set beyond the manifest and the core dir.**
+
+**How a crashed uninstall is retried (the retry-launch mechanism).** "Retryable" here
+means the *state* on disk lets a fresh uninstall complete safely — it does NOT mean the
+local `wienerdog` command still exists. `reverse()` removes the shim (`writeShim`) and the
+vendored app tree (`reverseVendoredTree`) as part of its normal job, so after a crash the
+local executable is very likely gone. **The retry is therefore launched via
+`npx wienerdog@latest uninstall`** — npx fetches the package code, and the on-disk retry
+gate (the manifest) plus config.yaml still drive a correct, vault-safe run. (If the crash
+happened before `reverse()` reached the shim, a local `wienerdog uninstall` also works,
+but `npx` is the reliable path and is what the abort error message and docs point to.)
+This is deliberately option (a): we do NOT defer the shim/app tree into the
+deferred-deletion set, because removing them is uninstall's actual job — deferring them
+would defeat the purpose. Only state that a retry must READ (manifest, core, config.yaml)
+is deferred; the executable is re-obtained out-of-band via npx.
+
+*Accepted caveat.* `npx wienerdog@latest uninstall` is a reliable retry ONLY under the
+same user/environment as the crashed install AND a package version whose path/manifest
+resolution matches it. `@latest` alone does not guarantee that — a newer version could, in
+principle, resolve `paths`/the manifest differently. In practice the crashed install and
+the retry run as the same user on the same machine, and `getPaths()` is stable across
+versions, so this holds; we accept it as a caveat rather than pinning a version. A user who
+hit a version skew can instead re-run the exact installed version (or simply
+`rm -rf ~/.wienerdog` — the residual is Wienerdog's own folder).
+
+**Accepted residual windows (vault-safe, non-data-loss).** Deferring config introduces two
+narrow post-gate windows. Both are **vault-safe** (a retry refuses once the manifest is
+gone, so no default-vault sweep can run) and are accepted, not silently ignored:
+
+1. *Manifest deleted, then config delete throws/crashes, OR a crash lands after config
+   deletion but before/inside the second sweep.* State: manifest gone → normal `uninstall`
+   (and `npx` retry) hard-refuses ("no install manifest found"). Any nested vault already
+   survived the FIRST sweep (which completed before the manifest was deleted). The leftover
+   is at most `~/.wienerdog/` holding an unmodified `config.yaml` and/or an otherwise-empty
+   core — Wienerdog-authored mechanics, no user data. `disposeCoreMechanics` already
+   suppresses its own core-removal errors (best-effort), so within a single process this is
+   only reachable by process termination between two adjacent unlink/rmdir calls.
+2. *The manifest-delete-FAILURE abort (P1 guard).* State: manifest present, config present,
+   core present, mechanics already swept. A retry proceeds normally (manifest gate passes),
+   re-reads the intact config, and completes once the permission/IO cause is fixed. No
+   residual beyond the (recoverable) failed run.
+
+**Resolution:** window (1)'s leftover is removed by the user with a plain
+`rm -rf ~/.wienerdog` (it is just Wienerdog's own folder, and the reassurance line already
+tells users the vault lives elsewhere). We do NOT relax uninstall's refuse-without-manifest
+invariant to auto-clean an orphaned core — that invariant is load-bearing (a manifest-less
+recursive core delete is exactly what ADR-0019 guards against), so a self-healing
+orphan-core sweep is explicitly **out of scope** for this WP (a candidate future WP). The
+point of documenting these is that they are bounded (a leftover empty-ish core dir), never
+a lost vault.
 
 **(2) Generalized hash-guard for file deletes.** Replace the config-only condition
 with a general one: any `kind:'file'` entry that has a recorded `hash` which no
 longer matches the on-disk content is **preserved** with a notice; entries with no
 `hash` keep today's delete behavior.
 
+The deferred members (manifest and config) never reach this branch — the contract-(1)
+GLOBAL guard intercepts them before the kind dispatch, realpath-aware, so the file branch
+needs NO manifest skip and NO config special-case. It is purely the generic hashed-file
+guard for every OTHER file:
+
 ```js
 if (entry.kind === 'file') {
+  // (manifest/config already handled by the contract-(1) global guard above.)
   if (!isFile(entry.path)) { skipped.push(entry.path); continue; }
   if (entry.hash && sha256File(entry.path) !== entry.hash) {
     // We recorded this file's content at write time; it differs now → the user (or
@@ -239,10 +561,12 @@ if (entry.kind === 'file') {
 }
 ```
 
-This preserves the exact `config.yaml` behavior (it has a hash) and extends the
-same fail-safe to any future hashed file. Un-hashed machine-generated files
-(shims, hook scripts) are unchanged. `sha256File` is the existing single-file hash
-helper (`manifest.js:64`) — it is untouched by this WP.
+This generic guard extends the prove-before-delete fail-safe to any FUTURE hashed file
+(a hashed file the user edited is kept, not deleted). `config.yaml`'s own defer/keep is
+NOT here — the global guard (contract (1)) owns it, so its ADR-0019 "customized kept
+forever / unmodified deferred" behavior is centralized and realpath-aware. Every un-hashed
+machine-generated file (shims, hook scripts) is unchanged. `sha256File` is the existing
+single-file hash helper (`manifest.js:64`) — untouched by this WP.
 
 **(3) Contain recursive-tree removals — per kind, NOT to `paths.core`.**
 
@@ -282,9 +606,15 @@ function reverseVendoredTree(entry, dryRun, removed, skipped, removedSet, appRoo
 fingerprint matches the recorded hash.** Copied skills are OUTSIDE `paths.core`.
 Require ALL of: (a) the target's **parent directory resolves equal to** one of the
 harness skills roots — a strict child, so `<claudeDir>/skills/user-content/wienerdog-x`
-(a deeper descendant) is refused; (b) its basename is `wienerdog-*`; and (c) the
+(a deeper descendant) is refused; (b) its basename is `wienerdog-*`; (b2) **the path
+is itself a REAL directory via `lstat` (which does NOT follow symlinks) — a symlink at
+the copied-skill path is definitionally not the directory we copied even when it points
+at an identical tree, so it must fail the ownership proof and be preserved (else `isDir`,
+which follows symlinks, would let a user's replacement symlink pass the fingerprint and
+be deleted)**; and (c) the
 on-disk tree still fingerprints (via the WP-089 `hashDir`) to `entry.hash`
-(delete-only-if-fingerprint-matches). A hash-less entry, a fingerprint mismatch, or
+(delete-only-if-fingerprint-matches). A hash-less entry, a fingerprint mismatch,
+a symlink at the path, or
 an unreadable tree (`hashDir` → `null`) is preserved, not deleted:
 
 ```js
@@ -346,15 +676,76 @@ this repo's tests — update the tests accordingly.
   checker agree byte-for-byte.
 - Do NOT change vault-file/vault-dir preservation, the **body** of
   `disposeCoreMechanics` (it is only CALLED a second time, not edited), the
-  `dir`/`symlink`/`managed-block`/`settings-entry`/`scheduler-entry` reversers, the
-  `contains` helper, or `sha256File`.
+  `symlink`/`managed-block`/`settings-entry`/`scheduler-entry` reversers, the `dir`
+  reverser body, the `contains` helper, or `sha256File`. Deferred-member protection is
+  NOT added inside any of these reversers — it lives entirely in the ONE global guard at
+  the top of the loop, which `continue`s before any reverser runs for a deferred member.
 - `reverse()` must keep `removedSet` seeded with `paths.manifest` so the
   enclosing-core "is it empty?" accounting inside the loop is byte-for-byte the same
   as today; only the real manifest deletion moves OUT of `reverse()` (into
   `uninstall.js`, after mechanics disposal).
-- In `uninstall.js`, do not change the dry-run branch, the confirmation prompt, the
-  vault-preservation messaging, or `readVaultPath`; only the live-path ordering
-  (reverse → dispose → delete manifest → dispose-again) and the summary count change.
+- **GLOBAL deferred-member guard (P1, spec-review round 5, 2026-07-13):** the FIRST thing
+  in the entry loop, BEFORE the kind dispatch, is a guard that protects all three deferred
+  members (`paths.manifest`, `paths.core`, `paths.config`) from EVERY kind and from path
+  normalization. It supersedes and REPLACES the earlier per-branch skips (the round-4
+  file-branch manifest skip and the dir-branch core skip). Rationale: the per-branch skips
+  covered only `kind:'file'`/`dir`; a malformed/hand-edited/adversarial manifest can point
+  ANY kind at a deferred member — `{kind:'scheduler-entry', path: paths.manifest}` reaches
+  `reverseSchedulerEntry` and `rmSync`s the ledger; a `symlink` entry unlinks a
+  symlink-valued core/manifest/config; a `managed-block`/`settings-entry` can rewrite/delete
+  a deferred file; a `{kind:'file', path:'<core>/./config.yaml'}` normalized alias bypasses
+  an exact-string config check. The single guard closes all of these. It uses `resolvesTo`
+  (a 1-line local closure: `p === target || sameResolvedDir(p, target)`) so a symlinked or
+  normalized alias of ANY member is caught regardless of kind. `sameResolvedDir` is plain
+  realpath equality (works for files too); the string fallback covers an unresolvable side.
+- **config.yaml defer/keep is INSIDE the global guard (realpath-aware):** when an entry
+  resolves to `paths.config`, the guard — not the file branch — decides: a `kind:'file'`
+  entry carrying the recorded `hash` that MATCHES on disk is UNMODIFIED → set `deferredConfig
+  = paths.config` (the CANONICAL path, never a normalized alias), `removedSet.add(paths.config)`,
+  then `continue` (uninstall.js deletes it LAST, after the manifest, never before); a hash
+  MISMATCH is CUSTOMIZED → keep-forever notice + `skipped`; any non-file / hash-less /
+  config-missing / adversarial entry targeting config is simply PROTECTED (`skipped`, never
+  deleted or rewritten). `deferredConfig` is set only by the legitimate unmodified file
+  entry; if a corrupt manifest lacks one, config just stays (safe: uninstall.js keeps the
+  core — a bounded degraded outcome). `reverse()`'s return shape becomes
+  `{removed, skipped, preserved, deferredConfig, deferredConfigHash}` (the unmodified
+  config's recorded hash, carried forward for uninstall.js's delete-site re-verify);
+  update every caller (uninstall.js live +
+  dry-run branches) and every test that destructures it. Guard `sha256File` with `isFile`
+  so a missing/normalized-missing config path never throws.
+- **`reverse()` must NEVER `rmdirSync(paths.core)` — now enforced by the global guard.**
+  Why it must not: with the manifest deferred, the `removedSet` seed makes the core look
+  virtually empty once its other entries are reversed, so an unguarded `dir` branch would
+  `rmdirSync(paths.core)` while the ledger is still physically present → `ENOTEMPTY`. Not
+  merely cosmetic: on a **retry after a partial mechanics sweep** (attempt 1 removed
+  `state/` then crashed before deleting the manifest), `state/` is gone, the tracked files
+  are gone, so the core IS virtually empty and the rmdir throws **before**
+  `disposeCoreMechanics`/manifest-deletion — wedging every retry forever. Enforcement: the
+  global deferred-member guard `continue`s on any entry resolving to `paths.core` (the
+  normal manifest's sole core entry, `{kind:'dir', path: paths.core}`, is skipped there)
+  BEFORE the `dir` branch runs, so the `dir` branch never meets the core and needs no
+  special-case of its own. Core disposal belongs **entirely** to `uninstall.js`'s
+  post-manifest step. The `--dry-run` core line is unaffected (`uninstall.js` prints it
+  manually, not from `reverse()`'s `removed` list).
+- In `uninstall.js`, do not change the confirmation prompt, the vault-preservation
+  messaging, or `readVaultPath`. What DOES change: (a) the live-path ordering — reverse
+  → dispose → **delete manifest → (confirm manifest gone; else throw) → delete
+  `deferredConfig`** → dispose-again; (b) the live summary count adds
+  `(deferredConfig ? 1 : 0)`; (c) the **dry-run branch must destructure `deferredConfig`
+  and add it to its headline "would be removed" count** (the unmodified config moved out
+  of `reverse()`'s `removed`) so config is not silently dropped from the plan — the
+  dry-run headline is NOT claimed to equal the live `Removed N` total (mechanics dirs and
+  the core stay separate disclosure lines, as today). No other dry-run change.
+- **Manifest-delete-failure guard (P1, spec-review 2026-07-13):** `uninstall.js` must
+  delete config ONLY after the manifest delete is CONFIRMED by rmSync's own outcome —
+  `fs.rmSync(paths.manifest, {force:true})` returning WITHOUT throwing (`force:true` ⇒
+  ENOENT/already-gone is success; a real EACCES/EPERM/IO failure throws). Do NOT gate on a
+  post-hoc `fs.existsSync(paths.manifest)`: `existsSync` returns `false` on a lookup error
+  (EACCES on the path, dangling symlink it follows) too, so it can falsely report the
+  manifest gone while it persists → deletes config → manifest-present + config-gone → the
+  exact P1 data-loss window on retry. On an rmSync throw, `throw new WienerdogError(...)`
+  (already imported) leaving both files intact. Never delete config while the manifest may
+  still be present.
 - Compute `appRoot`/`skillsRoots` inline in `manifest.js` from `paths`
   (`path.join(paths.core,'app')`, `paths.claudeDir`, `paths.codexDir`) — do NOT add
   a `require('./vendor')` or `require('../adapters/…')` to `manifest.js` (wrong
@@ -371,9 +762,11 @@ this repo's tests — update the tests accordingly.
       (fail closed).
 - [ ] `reverseCopiedSkill` recursively deletes ONLY a `wienerdog-*`-named path whose
       PARENT resolves equal to a harness skills root (`<claudeDir>/skills` or
-      `<codexDir>/skills`) AND whose on-disk tree still fingerprints (via the WP-089
+      `<codexDir>/skills`), which is itself a REAL directory (`lstat`, not following
+      symlinks), AND whose on-disk tree still fingerprints (via the WP-089
       `hashDir`) to `entry.hash`; a deeper descendant (`skills/user-content/wienerdog-x`),
-      a non-`wienerdog-*` name, a hash-less entry, a fingerprint mismatch, or an
+      a non-`wienerdog-*` name, a SYMLINK at the path (even to an identical tree),
+      a hash-less entry, a fingerprint mismatch, or an
       unreadable tree (`hashDir` → `null`) is preserved — and every LEGITIMATE
       copied-skill uninstall (fingerprint matches) still succeeds (the guard does not
       reject the normal case).
@@ -389,18 +782,86 @@ this repo's tests — update the tests accordingly.
 - [ ] The install manifest is deleted only AFTER both `reverse()` and
       `disposeCoreMechanics()` complete, so a crash during the mechanics sweep leaves
       a replayable recovery ledger (uninstall can be re-run).
+- [ ] An UNMODIFIED `config.yaml` is NOT deleted by `reverse()`; it is deleted by
+      `uninstall.js` LAST, AFTER the manifest. A crash during the sweep leaves BOTH the
+      manifest and config.yaml on disk, so a retry re-derives the correct (possibly
+      nested) vault path. There is no crash window in which the manifest exists but
+      config.yaml is gone (manifest-before-config ordering).
+- [ ] With a vault nested inside the core (config.yaml `vault:` points under a mechanics
+      dir), a crashed-then-retried uninstall NEVER deletes the nested vault: `vaultPath`
+      is re-read from the surviving config.yaml on every attempt, and
+      `disposeCoreMechanics` skips the containing dir (`skippedForVault`).
+- [ ] config.yaml is deleted ONLY after the manifest delete is confirmed by rmSync's OWN
+      outcome — `rmSync(paths.manifest, {force:true})` returning without throwing (NOT a
+      `fs.existsSync` check, which is ambiguous on a lookup error and could falsely report
+      the manifest gone). If the delete throws (permission/IO, file remains),
+      `uninstall.js` throws `WienerdogError` and does NOT delete config — leaving
+      manifest-present + config-present, so a retry stays vault-safe. There is no code path
+      (crash OR delete-failure OR lookup-error) that yields manifest-present + config-gone.
+- [ ] The post-gate residual windows (manifest-gone/config-throws;
+      crash-after-config-before-second-sweep) are vault-safe and documented as accepted
+      residuals: the leftover is at most an empty-ish `~/.wienerdog` the user removes with
+      `rm -rf`; no nested vault is ever lost. A crashed uninstall is retried via
+      `npx wienerdog@latest uninstall` (the local shim/app tree are gone by design).
+- [ ] The global guard prevents any entry from DIRECTLY deleting/damaging a deferred member
+      (manifest, core, config) via its `entry.path`, for every entry kind and for
+      normalized/symlink path aliases: a SINGLE guard before the kind dispatch `continue`s on
+      any entry resolving (string-or-realpath) to `paths.manifest`, `paths.core`, or
+      `paths.config`. Proven by cross-kind regression tests — scheduler-entry / symlink /
+      settings-entry / managed-block / normalized-path file entries each with `path` at a
+      deferred member do NOT delete/damage it. (INDIRECT side effects via a scheduler-entry's
+      executable `unload` argv are an explicit out-of-scope residual — see Non-goals /
+      Residuals — not covered by this guard and not a WP-088 regression.)
 
 ## Acceptance criteria
 
 - [ ] `reverse()` alone does NOT delete `install-manifest.json` (a unit test asserts
       the file remains after `reverse()` returns).
-- [ ] After a full `uninstall.js run()` (live), `install-manifest.json` is gone and
-      the empty core is removed; but if `disposeCoreMechanics` throws mid-sweep, the
-      manifest still exists (proved by a test that injects a throwing dispose and
-      asserts the manifest file remains — recovery ledger intact for retry).
+- [ ] Cross-kind global-guard regression: for a REAL manifest JSON file (written to disk,
+      loaded via `manifestLib.load`, `reverse()` run on the real filesystem with NO stubs),
+      each of a self-referential `{kind:'file', path: paths.manifest}`, a
+      `{kind:'scheduler-entry', path: paths.manifest}`, a `{kind:'symlink'}` at a symlinked
+      deferred member, a `settings-entry` at `paths.config` AND (separately) a `managed-block`
+      at `paths.config` (BOTH mutation branches, not one-or-the-other), a normalized
+      `{kind:'file', path: '<core>/./config.yaml'}`, and a `{kind:'scheduler-entry', path:
+      paths.config}` leaves that deferred member intact on disk and NOT in `removed`; the
+      normalized unmodified-config alias additionally yields `deferredConfig === paths.config`
+      (canonical).
+- [ ] Documented-residual regression (scheduler `unload`): a `scheduler-entry` with a
+      non-deferred `path` and an `unload` argv that would touch a deferred member has its
+      `unload` INVOKED as designed (asserted via the schedulerSpawn chokepoint / spy); the test
+      documents this as the ACCEPTED out-of-scope residual (the guard screens `entry.path`, not
+      `unload`), NOT a guard-blocks-it assertion.
+- [ ] After a full `uninstall.js run()` (live), `install-manifest.json` is gone, an
+      unmodified `config.yaml` is gone, and the empty core is removed; but if
+      `disposeCoreMechanics` throws mid-sweep, BOTH the manifest and config.yaml still
+      exist (proved by a test that injects a throwing dispose and asserts both files
+      remain — recovery ledger + vault-path source intact for retry).
+- [ ] `reverse()` alone does NOT delete an unmodified `config.yaml`; it returns it in
+      `deferredConfig` (a unit test asserts the file remains after `reverse()` returns and
+      `deferredConfig === paths.config`). A customized (hash-mismatched) `config.yaml` is
+      kept in `skipped` with `deferredConfig === null` (ADR-0019 rule intact), and a
+      clean live uninstall with a customized config keeps config.yaml and the core.
+- [ ] A crashed-then-retried uninstall with a nested vault preserves the nested vault
+      (the config-deferral regression test): attempt 1 crashes in `disposeCoreMechanics`;
+      a real retry re-reads config.yaml, derives the nested vault path, and the nested
+      vault (and its files) survive.
+- [ ] Manifest-delete-FAILURE injection: a test stubs ONLY the manifest deletion to throw
+      (wrap `fs.rmSync` to throw with a real `err.code` for `paths.manifest`, delegate
+      otherwise) while the real manifest file remains and the real filesystem is observed;
+      it does NOT stub any verification (the gate is rmSync's own outcome). Assert `run()`
+      rejects with `WienerdogError`, config.yaml is NOT deleted (untouched on disk), and a
+      subsequent real retry with a nested vault leaves the nested vault intact.
+- [ ] Deferred-config TOCTOU re-verify: a config.yaml unmodified at `reverse()` time but
+      EDITED during the mechanics sweep (mutated inside an instrumented
+      `disposeCoreMechanics`) is PRESERVED at the delete site (the carried-forward
+      `deferredConfigHash` no longer matches) — it survives with the new content and a
+      keep-notice, is NOT deleted, and is not counted removed; an unchanged deferred config
+      is still deleted (happy path).
 - [ ] A `kind:'file'` entry with a `hash` that mismatches current content is kept
       (in `skipped`, not `removed`) with the "modified since install" notice; the
-      same entry with a matching hash is removed. `config.yaml` behavior is unchanged.
+      same entry with a matching hash is removed (and, for `config.yaml` specifically, a
+      matching hash means DEFERRED — reported in `deferredConfig`, removed by uninstall.js).
 - [ ] A `vendored-tree` entry equal to `paths.core`, or a descendant of (not equal to)
       `paths.core/app`, is skipped with the refusal notice and not removed; the
       legitimate `paths.core/app` entry is removed.
@@ -411,7 +872,14 @@ this repo's tests — update the tests accordingly.
       preserved (in `skipped`) with the "keeping … not the Wienerdog skill we recorded"
       notice; a legitimate `<claudeDir>/skills/wienerdog-x` entry whose on-disk tree
       fingerprints to `entry.hash` is removed.
-- [ ] `dryRun` still removes nothing and reports the same `removed`/`skipped` shape.
+- [ ] `dryRun` still removes nothing (config.yaml and the manifest both remain on disk
+      after a dry-run) and its headline "would be removed" count INCLUDES the deferred
+      config so config is not dropped from the plan. The dry-run headline is NOT claimed
+      to equal the live `Removed N` total — the mechanics dirs and the core-removal are
+      disclosed as separate lines (ADR-0019). M1 exactness = every item dry-run LISTS
+      (reverse-removed incl. config, each mechanics dir, the core line) is exactly what
+      the live run removes; `deferredConfig` is counted once (customized config → null →
+      stays in `skipped`, never counted as removed).
 - [ ] Existing uninstall/manifest tests pass (adjust the two helper call sites/tests
       for the new `appRoot`/`skillsRoots` params).
 
@@ -423,8 +891,23 @@ npm test
 npm run lint
 ```
 
-## Out of scope (do NOT do these)
+## Out of scope / Non-goals / Residuals (do NOT do these)
 
+- **RESIDUAL (accepted, out of scope): a `scheduler-entry`'s executable `unload` argv.**
+  The manifest stores an `unload` argv for each `scheduler-entry`, and `reverseSchedulerEntry`
+  EXECUTES it by design to unregister the OS schedule (launchctl bootout / schtasks /delete;
+  `manifest.js:227-236`). This pre-dates WP-088 (WP-013 / WP-075). A fully adversarial manifest
+  could therefore put an arbitrary command — including one that deletes the manifest or
+  config — into `unload`, an INDIRECT route the global deferred-member guard (which screens
+  `entry.path`) cannot see. WP-088 does **not** police `unload` commands: that is impossible to
+  do soundly (it is an arbitrary argv) and is the wrong scope. **Defensible invariant:** forging
+  an `unload` argv requires WRITE access to `~/.wienerdog` (the user's home), which already grants
+  arbitrary code execution by many means — so an attacker who can forge the manifest is already
+  game-over. Manifest-integrity against a home-dir-write adversary is a separate, pre-existing
+  concern, not a WP-088 regression. WP-088's crash-safety guarantees hold for the NON-adversarial
+  (Wienerdog-authored) manifest and for every DIRECT path-based deletion route. The cross-kind
+  tests PIN this residual (the `unload` runs as designed; the test documents it as accepted, not
+  as something the guard blocks).
 - Making `writeShim` / `copyHookScript` / `sync stageDir` **record hashes** and
   refuse to OVERWRITE a pre-existing non-Wienerdog file at write time — a separate
   follow-up (the write-time half of prove-before-overwrite). This WP only makes the
@@ -440,6 +923,153 @@ npm run lint
   (it is only called a second time by `uninstall.js`, not edited).
 
 ## Superseded review dispositions
+
+Deferred-deletion-set redesign (2026-07-13) — rationale and the two P1s:
+
+- **Redesign rationale.** WP-088's manifest-last change made uninstall *retryable*.
+  Retryability exposed a class of bug: anything a safe RETRY needs to COMPLETE uninstall,
+  but that `reverse()` deletes before the crash-prone `disposeCoreMechanics` sweep,
+  becomes unrecoverable on the retry. The coherent fix is to treat this as a single
+  **deferred-deletion set** — the manifest, the core dir, AND config.yaml — all deferred
+  until the sweep succeeds, rather than patching each leak point in isolation. Two P1s
+  are instances of this one class:
+- **P1 (core rmdir → ENOTEMPTY wedge; already fixed on the branch, c0f32de):**
+  `reverse()`'s `dir` branch rmdir'd `paths.core` while the deferred manifest was still
+  physically inside it → `ENOTEMPTY`, wedging every retry after a partial sweep. FIXED —
+  the `dir` branch never rmdirs `paths.core`; core disposal is uninstall.js's
+  post-manifest job. (See Implementation notes, 2026-07-13.)
+- **P1 (nested-vault path unrecoverable on retry; RESOLVED by this amendment):**
+  `uninstall.js` reads the vault path from config.yaml (`readVaultPath`) to protect a
+  vault nested inside the core, but `reverse()` deleted config.yaml when unmodified. On a
+  retry (fresh process, config.yaml gone) `readVaultPath` returned `null` → the DEFAULT
+  vault path → `disposeCoreMechanics` recursively deleted the user's nested vault.
+  RESOLVED — config.yaml joins the deferred-deletion set: `reverse()` returns an
+  unmodified config in `deferredConfig` (never deletes it); `uninstall.js` deletes it
+  LAST, AFTER the manifest, so the invariant "manifest-present ⟹ config-present" holds at
+  every crash point and every retry re-derives the correct (possibly nested) vault path.
+  A customized config.yaml is still kept forever (ADR-0019), never in the deferred set.
+- **Holistic check (2026-07-13):** config.yaml is the ONLY member of the deferred set
+  beyond the manifest and core. `disposeCoreMechanics`'s sole external input is
+  `vaultPath`, sourced solely from config.yaml (`readVaultPath` is its only caller);
+  nothing else `reverse()` deletes feeds the retry gate or the vault protection, and the
+  default vault lives outside the core (never swept).
+
+Codex spec-review of the redesign (2026-07-13, round 2) — one P1 + three P2s:
+
+- **P1 (swallowed manifest-delete failure recreated the data-loss window):** RESOLVED
+  (final gate settled in round 3, below). The first draft did
+  `try { rmSync(manifest) } catch {}` then unconditionally deleted config.
+  `rmSync(force:true)` throws (leaving the file) on a permission/IO error, so this could
+  yield manifest-present + config-gone → a retry passes the manifest gate, reads no config
+  → default vault → nested vault deleted — the exact P1 the redesign exists to close. FIX:
+  `uninstall.js` deletes config ONLY after the manifest delete is CONFIRMED gone; if it is
+  not, throw `WienerdogError` leaving BOTH files present (retry-safe). Added a
+  manifest-delete-failure injection acceptance test.
+- **P2 (operational retryability — command re-entry):** RESOLVED (option a). `reverse()`
+  removes the shim + vendored app tree, so after a crash there is no local executable. The
+  spec now states the retry is launched via `npx wienerdog@latest uninstall` (npx supplies
+  the code; the on-disk manifest gate + config still drive a correct run) and makes the
+  "retryable" claims precise: only READ-state (manifest, core, config) is deferred, not the
+  executable. Deferring the shim/app tree was rejected — removing them is uninstall's job.
+- **P2 (post-gate cleanup-wedge windows):** RESOLVED by explicit documentation as accepted
+  residuals. manifest-gone/config-throws and crash-after-config-before-second-sweep are
+  vault-safe (retry refuses without the manifest); the leftover is at most an empty-ish
+  `~/.wienerdog` the user removes with `rm -rf`. Relaxing uninstall's refuse-without-manifest
+  invariant to auto-clean an orphaned core is explicitly out of scope (a manifest-less
+  recursive core delete is what ADR-0019 guards against).
+- **P2 (dry-run count exactness):** RESOLVED by correcting the claim. The dry-run headline
+  counts reverse-removed + `deferredConfig`; the mechanics dirs and the core are disclosed
+  as separate lines (as today), so the headline is NOT claimed to equal the live
+  `Removed N` total. M1 exactness is redefined precisely: every item dry-run LISTS equals
+  what the live run removes; `deferredConfig` is counted once.
+- **Probes (b) second-sweep uses in-process captured `vaultPath`, and (e)
+  customized-config-kept:** confirmed SOUND by the reviewer — left as-is.
+
+Codex spec-review round 3 (2026-07-13) — P1 confirmation-gate hole:
+
+- **P1 (confirmation gate conflated "absent" with "could-not-verify"):** RESOLVED. Round 2
+  gated config deletion on `!fs.existsSync(paths.manifest)` after the delete. `existsSync`
+  returns `false` not only on genuine absence but on a LOOKUP error (EACCES on the path, a
+  dangling symlink it follows), so "existsSync === false" does not prove the manifest is
+  gone — if it could not verify while the manifest persists, config would still be deleted
+  → manifest-present + config-gone → the exact P1 reopens. FIX: drop `existsSync`; gate on
+  `rmSync`'s OWN outcome — `fs.rmSync(paths.manifest, {force:true})` returning WITHOUT
+  throwing (with `{force:true}`, ENOENT/already-gone is success, and a real EACCES/EPERM/IO
+  failure throws). On a throw, `throw new WienerdogError(...)` leaving both files present.
+  No `existsSync`, no symlink/lookup-error ambiguity. Tightened the failure-injection test
+  to stub ONLY the manifest deletion (never the verification, which no longer exists as a
+  separate step). All round-2 resolutions (P2 command re-entry, cleanup-wedge residuals,
+  dry-run count, and the SOUND probes b/e) confirmed still in force by round 3.
+- **Accepted caveat (npx retry):** `npx wienerdog@latest uninstall` is a reliable retry
+  only under the same user/environment AND a version whose `paths`/manifest resolution
+  matches the crashed install; `@latest` alone does not guarantee that. Accepted (same
+  user/machine, `getPaths()` stable) rather than pinning a version; documented in the
+  crash-recovery note.
+
+Codex spec-review round 4 (2026-07-13) — P1 defensive deferred-set invariant:
+
+- **P1 (`reverse()` could delete the ledger via a self-referential manifest entry):**
+  RESOLVED. The contract said `reverse()` defers the manifest, but its `kind:'file'`
+  pseudocode did not EXCLUDE `entry.path === paths.manifest`. A malformed/hand-edited/
+  adversarial manifest carrying `{kind:'file', path: paths.manifest}` (a valid JSON entry,
+  processed first by `[...entries].reverse()`) would be deleted inline by the generic
+  hashless-file branch — bypassing the manifest-last deferral AND the confirmation gate; a
+  crash then leaves the manifest absent → retry refuses at the top-level gate → the exact
+  wedge deferral exists to eliminate. FIX (round 4): a file-branch `paths.manifest` skip —
+  **superseded in round 5 by a global guard** (the per-branch skip covered only
+  `kind:'file'`; see below). Added a unit test. The reviewer confirmed the round-3
+  rmSync-outcome gate is genuinely closed across every target-type and crash interleaving,
+  and the failure-injection test faithful.
+
+Codex spec-review round 5 (2026-07-13) — P1 the per-branch skips were incomplete:
+
+- **P1 (other reverse() branches can still delete/damage a deferred member):** RESOLVED.
+  The round-4 per-branch skips (`paths.core` in the `dir` branch, `paths.manifest` in the
+  `file` branch) covered only those two kinds. A manifest entry of a DIFFERENT kind pointing
+  at a deferred member still hit the danger: `{kind:'scheduler-entry', path: paths.manifest}`
+  → `reverseSchedulerEntry` `rmSync`s the ledger (retry wedge); the same targeting
+  `paths.config` recreates manifest-present + config-gone (nested-vault data loss); a
+  `symlink` unlinks a symlink-valued member; `managed-block`/`settings-entry` rewrite/delete
+  a deferred file; and even within `kind:'file'`, config's protection was exact-string only,
+  so a normalized `<core>/./config.yaml` alias reached the generic `rmSync`. FIX: replace the
+  per-branch skips with a SINGLE GLOBAL GUARD at the top of the entry loop, before the kind
+  dispatch, that `continue`s on any entry resolving (string-or-realpath, via `resolvesTo`) to
+  `paths.manifest`, `paths.core`, or `paths.config` — covering ALL kinds and normalized
+  paths at once. config's defer-vs-keep decision moves INTO the guard (realpath-aware, from
+  the recorded hash; canonical `deferredConfig`). Per-branch skips removed (single source of
+  truth). Tightened the round-4 test to a real-JSON/no-stub observation and added cross-kind
+  regression coverage (scheduler-entry / symlink / settings-entry / managed-block /
+  normalized-path file each targeting a deferred member). Also applied `e?.code ||
+  'unknown error'` in the abort message (cosmetic diagnostics). Everything else (rmSync-outcome
+  gate, ordering, cleanup-wedge residuals, dry-run count, customized-config-kept, in-process
+  vaultPath, npx-retry caveat) confirmed SOUND and unchanged. After this, the global guard
+  blocks every DIRECT path-based route for every kind and for normalized/symlink aliases
+  (right-sized in round 6; the earlier "regardless of entry kind" phrasing was scoped down
+  to exclude indirect `unload` side effects — see round 6).
+
+Codex spec-review round 6 (2026-07-13) — right-size the claim + document the one residual:
+
+- **P1 (as stated: scope, not mechanism) — indirect `scheduler-entry` `unload` route:**
+  The global guard screens `entry.path`, so it closes every DIRECT path-based deletion for
+  every kind and alias — CONFIRMED SOUND by the reviewer. But a `scheduler-entry` also carries
+  an executable `unload` argv that `reverseSchedulerEntry` RUNS by design (launchctl bootout /
+  schtasks /delete; `manifest.js:227-236`, pre-dates WP-088 — WP-013/075). An adversarial
+  manifest could put a command that deletes the manifest/config in `unload`, an INDIRECT route
+  the path guard cannot see. RESOLUTION (per the reviewer's "contain OR explicitly exclude with
+  a defensible invariant"): we do NOT try to police `unload` (impossible and wrong scope).
+  Instead the claim is right-sized everywhere from "structurally incapable regardless of entry
+  kind" to the accurate **"the global guard prevents any entry from DIRECTLY deleting/damaging a
+  deferred member via its PATH, for every kind and for normalized/symlink aliases"**, and the
+  `unload` route is recorded as an explicit out-of-scope residual (see Non-goals / Residuals)
+  with a defensible invariant: forging `unload` requires WRITE access to `~/.wienerdog`, which
+  ALREADY grants arbitrary code execution by many means — so a home-dir-write adversary is
+  already game-over, and manifest-integrity against such an adversary is a separate, pre-existing
+  concern. WP-088's crash-safety holds for the Wienerdog-authored manifest and for all direct
+  path-based deletion. This is a documentation/scoping change only; the guard is unchanged.
+- **P2 (test wording):** the cross-kind tests now name BOTH mutation branches explicitly (a
+  `settings-entry` AND a `managed-block`, each targeting a deferred member) and add a
+  scheduler-`unload` regression that PINS the documented residual (the `unload` runs as designed
+  and the test asserts it is the accepted out-of-scope behavior, not a false "guard blocks it").
 
 Crash-safety / containment dispositions (in force):
 
@@ -489,7 +1119,7 @@ Fingerprint (copied-skill ownership) dispositions (in force):
 
 1. All verification steps pass locally; output pasted into the PR body.
 2. Branch `wp/088-manifest-reverse-crash-safety`; conventional commits; PR titled
-   `fix(manifest): delete manifest last, hash-guard file deletes, contain tree removal (WP-088)`.
+   `fix(manifest): defer manifest+config deletion, hash-guard file deletes, contain tree removal (WP-088)`.
 3. PR template filled, including "Decisions made" (or "none") and `Generated-by:`.
 4. This spec's `status:` flipped to `In-Review` in the same PR.
 </content>

--- a/src/cli/uninstall.js
+++ b/src/cli/uninstall.js
@@ -60,12 +60,20 @@ async function run(argv) {
   for (const entry of manifest.entries) console.log(`  [${entry.kind}] ${entry.path}`);
 
   if (dryRun) {
-    const { removed, skipped, preserved } = manifestLib.reverse(paths, manifest, { dryRun: true });
+    const { removed, skipped, preserved, deferredConfig } = manifestLib.reverse(paths, manifest, {
+      dryRun: true,
+    });
     const { removed: mech, skippedForVault } = manifestLib.disposeCoreMechanics(paths, {
       dryRun: true,
       vaultPath,
     });
-    console.log(`\n--dry-run: ${removed.length} item(s) would be removed, ${skipped.length} skipped.`);
+    // The unmodified config moved out of reverse()'s `removed` into deferredConfig
+    // (uninstall.js deletes it live), so include it in the headline "would be
+    // removed" count — otherwise it is silently dropped from the plan. The
+    // mechanics dirs and the core stay separate disclosure lines (ADR-0019), so
+    // this headline is NOT claimed to equal the live `Removed N` total.
+    const headline = removed.length + (deferredConfig ? 1 : 0);
+    console.log(`\n--dry-run: ${headline} item(s) would be removed, ${skipped.length} skipped.`);
     if (preserved.length > 0) {
       const vaultFiles = manifest.entries.filter((e) => e.kind === 'vault-file').length;
       if (skippedForVault.length > 0) {
@@ -90,12 +98,82 @@ async function run(argv) {
     }
   }
 
-  const { removed, skipped, preserved } = manifestLib.reverse(paths, manifest, { dryRun: false });
+  const { removed, skipped, preserved, deferredConfig, deferredConfigHash } = manifestLib.reverse(
+    paths,
+    manifest,
+    { dryRun: false }
+  );
+  // First sweep: removes state/logs/schedules/secrets, protecting a nested vault
+  // via vaultPath (read from the STILL-PRESENT config.yaml at line 57). The core
+  // is NOT removed yet — the manifest + config.yaml still sit in it, so its
+  // emptiness check fails (correct). The recovery ledger has survived every
+  // crash-prone step above.
   const { removed: mech, skippedForVault } = manifestLib.disposeCoreMechanics(paths, {
     dryRun: false,
     vaultPath,
   });
-  console.log(`\nRemoved ${removed.length + mech.length} item(s).`);
+  // Delete the deferred set LAST — MANIFEST FIRST, then config.yaml. Every
+  // crash-prone step above has completed. Manifest-before-config is load-bearing:
+  // a retry proceeds only while the manifest exists, and a retry that reaches a
+  // sweep needs config.yaml for the nested-vault path, so config.yaml must exist
+  // at every point the manifest still does ("manifest-present ⟹ config-present").
+  // The manifest delete must be CONFIRMED before config is touched. The
+  // confirmation is rmSync's OWN outcome: `{force:true}` does NOT throw on ENOENT
+  // (already-gone = success) but DOES throw on a real failure (EACCES/EPERM/IO).
+  // So "rmSync returned without throwing" proves the manifest is gone — no
+  // post-hoc existence check (which fs.existsSync makes ambiguous: it returns
+  // false on a LOOKUP error too, which would reopen the P1 nested-vault window).
+  try {
+    fs.rmSync(paths.manifest, { force: true });
+  } catch (e) {
+    // Real deletion failure, manifest still present → ABORT before touching
+    // config, leaving BOTH files present so every retry stays vault-safe.
+    throw new WienerdogError(
+      `could not remove the install manifest (${e?.code || 'unknown error'}) — uninstall partially completed; ` +
+        `left config.yaml and ${paths.core} in place so a retry stays safe. ` +
+        `Fix the permission/IO issue, then re-run: npx wienerdog@latest uninstall`
+    );
+  }
+  // rmSync returned without throwing ⇒ the manifest is gone (or was already
+  // absent). The retry gate is now closed → only now is it safe to delete an
+  // unmodified config.
+  let configDeleted = false;
+  if (deferredConfig) {
+    // Prove-before-delete AT THE DELETE SITE: config was proven unmodified back in
+    // reverse(), but it is deleted here, AFTER the (potentially slow, recursive)
+    // mechanics sweep. If the user EDITED config.yaml during that window it is now
+    // customized — deleting it would destroy their edit (a TOCTOU the deferral
+    // opened). Re-verify the carried-forward hash; delete only if it STILL matches,
+    // else PRESERVE with a keep-notice. A missing/unreadable file also aborts the
+    // delete (nothing to prove → keep).
+    let currentHash = null;
+    try {
+      currentHash = manifestLib.sha256File(deferredConfig);
+    } catch {
+      currentHash = null;
+    }
+    if (currentHash !== null && currentHash === deferredConfigHash) {
+      try {
+        fs.rmSync(deferredConfig, { force: true });
+        configDeleted = true;
+      } catch {
+        /* best-effort */
+      }
+    } else {
+      process.stderr.write(`wienerdog: keeping ${deferredConfig} — modified since install\n`);
+    }
+  }
+  // Second sweep: mechanics are already gone (idempotent); with the manifest +
+  // unmodified config deleted the core is now empty, so this removes it
+  // (symlink-aware, vault-aware). A kept CUSTOMIZED config leaves the core
+  // non-empty → core preserved (unchanged).
+  const { removed: coreSwept } = manifestLib.disposeCoreMechanics(paths, {
+    dryRun: false,
+    vaultPath,
+  });
+  console.log(
+    `\nRemoved ${removed.length + mech.length + coreSwept.length + (configDeleted ? 1 : 0)} item(s).`
+  );
   if (preserved.length > 0) {
     const vaultFiles = manifest.entries.filter((e) => e.kind === 'vault-file').length;
     if (skippedForVault.length > 0) {
@@ -107,9 +185,15 @@ async function run(argv) {
       console.log(`\nYour memory vault at ${vaultPath} was left untouched (${vaultFiles} files) — your notes are yours.`);
     }
   }
-  if (skipped.length > 0) {
-    console.log(`Skipped ${skipped.length} item(s) (already gone or a customized config kept):`);
-    for (const s of skipped) console.log(`  ${s}`);
+  // reverse() now defers core/state removal to disposeCoreMechanics, so its
+  // `skipped` array carries <core> and <core>/state — items the sweep above has
+  // since removed. Report as "skipped" only what genuinely REMAINS on disk after
+  // the whole uninstall, so the summary never contradicts "fully removed" below.
+  // A kept customized config.yaml or a preserved skill still exists → still shown.
+  const skippedShown = skipped.filter((s) => fs.existsSync(s));
+  if (skippedShown.length > 0) {
+    console.log(`Skipped ${skippedShown.length} item(s) (a customized config or other file kept in place):`);
+    for (const s of skippedShown) console.log(`  ${s}`);
   }
   if (!fs.existsSync(paths.core)) {
     console.log(`\nWienerdog is fully removed — the canonical core (${paths.core}) is gone.`);

--- a/src/core/manifest.js
+++ b/src/core/manifest.js
@@ -249,17 +249,38 @@ function reverseSchedulerEntry(entry, dryRun, removed, skipped, removedSet) {
   removed.push(entry.path);
 }
 
+/** True iff `a` and `b` resolve (via realpath) to the SAME directory. Fail-closed
+ *  when either side is unresolvable. @param {string} a @param {string} b
+ *  @returns {boolean} */
+function sameResolvedDir(a, b) {
+  try {
+    return fs.realpathSync(a) === fs.realpathSync(b);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Reverse a 'vendored-tree' entry: recursively remove the vendored app tree
- * (entirely Wienerdog-authored, regenerable by `sync`). Adds the path to
- * removedSet so the enclosing core dir still counts as empty. In dev mode the
- * tree holds only the `current` symlink; removing it never touches the checkout.
+ * (entirely Wienerdog-authored, regenerable by `sync`) ONLY when the target
+ * resolves EQUAL to the app root `paths.core/app` — the sole value `vendorSelf`
+ * ever records. Equality rejects the equal-to-core case (core is app's PARENT,
+ * never equal to app) and any manipulated descendant; anything else is preserved
+ * with a refusal notice. Adds the path to removedSet so the enclosing core dir
+ * still counts as empty. In dev mode the tree holds only the `current` symlink;
+ * removing it never touches the checkout.
  * @param {ManifestEntry} entry
  * @param {boolean} dryRun
  * @param {string[]} removed @param {string[]} skipped @param {Set<string>} removedSet
+ * @param {string} appRoot the app root `paths.core/app`
  */
-function reverseVendoredTree(entry, dryRun, removed, skipped, removedSet) {
+function reverseVendoredTree(entry, dryRun, removed, skipped, removedSet, appRoot) {
   if (!isDir(entry.path)) { skipped.push(entry.path); return; }
+  if (!sameResolvedDir(entry.path, appRoot)) {
+    process.stderr.write(`wienerdog: refusing to remove ${entry.path} — not the Wienerdog app tree\n`);
+    skipped.push(entry.path);
+    return;
+  }
   if (!dryRun) fs.rmSync(entry.path, { recursive: true, force: true });
   removedSet.add(entry.path);
   removed.push(entry.path);
@@ -267,14 +288,51 @@ function reverseVendoredTree(entry, dryRun, removed, skipped, removedSet) {
 
 /**
  * Reverse a 'copied-skill' entry: recursively remove the copied skill folder
- * (entirely Wienerdog-authored, regenerable by `sync`). Adds the path to
- * removedSet so the enclosing skills dir still counts as empty.
+ * ONLY when ALL of (a) its PARENT resolves equal to a harness skills root (a
+ * strict child — not merely a descendant), (b) its basename is `wienerdog-*`,
+ * (c) the path is itself a REAL directory (an `lstat`, which does NOT follow
+ * symlinks — a symlink at this path is definitionally not the directory we
+ * copied, even if it points at an identical tree), and (d) the on-disk tree
+ * still fingerprints (via the shared `hashDir`) to the `hash` recorded at copy
+ * time. A hash-less (legacy) entry, a fingerprint mismatch (user edited/replaced
+ * our copy), an unreadable tree (`hashDir` → null, which can never === a recorded
+ * string), or a symlink-at-the-path is PRESERVED with a notice, never deleted.
+ * Adds the path to removedSet so the enclosing skills dir still counts as empty.
  * @param {ManifestEntry} entry
  * @param {boolean} dryRun
  * @param {string[]} removed @param {string[]} skipped @param {Set<string>} removedSet
+ * @param {string[]} skillsRoots the harness skills roots
  */
-function reverseCopiedSkill(entry, dryRun, removed, skipped, removedSet) {
+function reverseCopiedSkill(entry, dryRun, removed, skipped, removedSet, skillsRoots) {
   if (!isDir(entry.path)) { skipped.push(entry.path); return; }
+  const base = path.basename(entry.path);
+  const parentIsRoot = skillsRoots.some((root) => sameResolvedDir(path.dirname(entry.path), root));
+  if (!base.startsWith('wienerdog-') || !parentIsRoot) {
+    process.stderr.write(`wienerdog: refusing to remove ${entry.path} — not a Wienerdog skill directly under a harness skills dir\n`);
+    skipped.push(entry.path);
+    return;
+  }
+  // Tighten the ownership proof: the root must be a REAL directory. isDir() above
+  // FOLLOWS symlinks, so a user who moved our copied skill elsewhere and left a
+  // SYMLINK to an identical tree at this path would otherwise pass the fingerprint
+  // check (hashDir follows the link to the matching target) and have their symlink
+  // deleted. lstat does NOT follow the link — a symlink here is not our directory.
+  let isRealDir = false;
+  try {
+    isRealDir = fs.lstatSync(entry.path).isDirectory();
+  } catch {
+    isRealDir = false;
+  }
+  if (!isRealDir) {
+    process.stderr.write(`wienerdog: keeping ${entry.path} — not the Wienerdog skill we recorded (modified, replaced, or unverifiable)\n`);
+    skipped.push(entry.path);
+    return;
+  }
+  if (typeof entry.hash !== 'string' || hashDir(entry.path) !== entry.hash) {
+    process.stderr.write(`wienerdog: keeping ${entry.path} — not the Wienerdog skill we recorded (modified, replaced, or unverifiable)\n`);
+    skipped.push(entry.path);
+    return;
+  }
   if (!dryRun) fs.rmSync(entry.path, { recursive: true, force: true });
   removedSet.add(entry.path);
   removed.push(entry.path);
@@ -322,42 +380,113 @@ function save(paths, manifest) {
 
 /**
  * Reverse the manifest: remove files we created (kind 'file'), then dirs (kind
- * 'dir', only if empty), in reverse order. Files that changed since install are
- * still ours to remove EXCEPT config.yaml, which is kept with a notice when it
- * was modified after install (recorded hash mismatch). Unknown kinds are
- * skipped with a warning (forward compat for later WPs). The manifest file
- * itself is removed as bookkeeping.
+ * 'dir', only if empty), in reverse order. A `kind:'file'` entry that carries a
+ * recorded `hash` which no longer matches on-disk content is kept with a notice
+ * (prove-before-delete); hash-less entries keep the plain delete behavior.
+ * Unknown kinds are skipped with a warning (forward compat for later WPs).
+ *
+ * The three deferred-deletion-set members — the manifest, the canonical core dir,
+ * and config.yaml — are NEVER deleted/damaged here, enforced by a SINGLE GLOBAL
+ * GUARD at the top of the entry loop, BEFORE the kind dispatch, so no reverser of
+ * ANY kind can touch them via `entry.path` (realpath-aware, so a symlinked or
+ * normalized alias is caught too). The manifest and core are deferred to
+ * uninstall.js; an UNMODIFIED config.yaml is returned in `deferredConfig` (deleted
+ * LAST by uninstall.js, after the manifest); a CUSTOMIZED config is kept forever
+ * (ADR-0019). A crash at any point therefore leaves a replayable recovery ledger
+ * AND the config.yaml `vault:` source a retry needs to protect a nested vault.
+ *
+ * `deferredConfigHash` carries the recorded hash forward so uninstall.js can
+ * RE-VERIFY it immediately before the deferred delete (prove-before-delete at the
+ * delete site): config was proven unmodified HERE, but is deleted much later —
+ * after the mechanics sweep — so a user edit during that window must abort the
+ * delete. Both are null when there is no deferred (unmodified) config.
  * @param {import('./paths').WienerdogPaths} paths
  * @param {Manifest} manifest
  * @param {{dryRun?: boolean}} [opts]
- * @returns {{removed: string[], skipped: string[], preserved: string[]}}
+ * @returns {{removed: string[], skipped: string[], preserved: string[], deferredConfig: string|null, deferredConfigHash: string|null}}
  */
 function reverse(paths, manifest, { dryRun = false } = {}) {
   /** @type {string[]} */ const removed = [];
   /** @type {string[]} */ const skipped = [];
   /** @type {string[]} */ const preserved = [];
-  // The manifest file is our own bookkeeping: treat it as (virtually) removed
-  // so the core dir counts as empty, and delete it for real on a live run.
+  /** @type {string|null} */ let deferredConfig = null; // unmodified config.yaml → deleted last by uninstall.js
+  /** @type {string|null} */ let deferredConfigHash = null; // its recorded hash → re-verified before that delete
+  // Seed with the manifest path so the core dir still counts as (virtually)
+  // empty. The manifest FILE is NOT touched here — uninstall.js deletes it only
+  // after the whole uninstall (reversal loop + mechanics sweep) has succeeded,
+  // so a crash at any point leaves a replayable ledger (uninstall refuses
+  // without it).
   const removedSet = new Set([paths.manifest]);
-  if (!dryRun) {
-    try {
-      fs.rmSync(paths.manifest, { force: true });
-    } catch {
-      /* ignore — already gone */
-    }
-  }
+  // Containment anchors for the recursive-tree removers, computed inline from
+  // `paths` (no vendor.js/adapter import — wrong dependency direction).
+  const appRoot = path.join(paths.core, 'app');
+  const skillsRoots = [path.join(paths.claudeDir, 'skills'), path.join(paths.codexDir, 'skills')];
+  // Realpath-aware equality (string fallback when a side is unresolvable): true
+  // iff `p` is `target` or resolves to it. Applies to files and dirs
+  // (`sameResolvedDir` is just realpath equality). Catches symlinked/normalized
+  // aliases of any deferred member.
+  const resolvesTo = (p, target) => p === target || sameResolvedDir(p, target);
 
   for (const entry of [...manifest.entries].reverse()) {
+    // ── GLOBAL DEFERRED-MEMBER GUARD (before kind dispatch) ──────────────────
+    // reverse() must NEVER delete/damage the three deferred members — the
+    // manifest, the core dir, and config.yaml — regardless of entry KIND or path
+    // normalization. A malformed/hand-edited/adversarial manifest can point ANY
+    // kind at a deferred member (e.g. {kind:'scheduler-entry', path: manifest}
+    // deletes the ledger; a {kind:'file', path:'<core>/./config.yaml'} normalized
+    // alias bypasses an exact-string config check; a symlink/managed-block/
+    // settings-entry can unlink/rewrite one). This single guard blocks every
+    // PATH-based route for every kind at once. (It does NOT police INDIRECT side
+    // effects — e.g. a scheduler-entry's executable `unload` argv — which is an
+    // out-of-scope, pre-existing residual; see the WP-088 spec Non-goals.)
+    if (resolvesTo(entry.path, paths.manifest) || resolvesTo(entry.path, paths.core)) {
+      // Manifest → retry ledger (uninstall.js deletes it LAST via the
+      // rmSync-outcome gate); core → deferred to disposeCoreMechanics. Never
+      // touched here by any kind. (removedSet already holds paths.manifest; a
+      // normal manifest's sole core entry is {kind:'dir', path: paths.core} —
+      // this is where it is skipped.)
+      skipped.push(entry.path);
+      continue;
+    }
+    if (resolvesTo(entry.path, paths.config)) {
+      // config.yaml is deferred/kept here for EVERY kind — its `vault:` line is
+      // what disposeCoreMechanics reads on every retry to protect a nested vault;
+      // reverse() never deletes it. Decide defer-vs-keep from the recorded hash of
+      // the LEGITIMATE file entry (Wienerdog records config only as
+      // {kind:'file', path, hash}):
+      if (entry.kind === 'file' && isFile(entry.path) && entry.hash) {
+        if (sha256File(entry.path) === entry.hash) {
+          // UNMODIFIED → deferred: uninstall.js deletes it LAST (after the sweep,
+          // after the manifest). Store the CANONICAL path (not a normalized
+          // alias); add to removedSet so the core still counts as empty. Carry the
+          // recorded hash forward so uninstall.js can re-prove it unmodified at the
+          // (much later) delete site — a user edit during the sweep aborts the delete.
+          deferredConfig = paths.config;
+          deferredConfigHash = entry.hash;
+          removedSet.add(paths.config);
+          continue; // the deferred member — not in removed/skipped
+        }
+        // CUSTOMIZED (hash mismatch) → kept forever (ADR-0019). Keeps the core alive.
+        process.stderr.write(`wienerdog: keeping ${entry.path} — modified since install\n`);
+      }
+      // Customized config, OR any non-file/hash-less/adversarial entry targeting
+      // config → PROTECT it: never delete/rewrite. (deferredConfig is set only by
+      // the legitimate unmodified file entry above; if the manifest is too corrupt
+      // to have one, config simply stays — safe, uninstall.js keeps the core.)
+      skipped.push(entry.path);
+      continue;
+    }
+    // ── end global guard ─────────────────────────────────────────────────────
     if (entry.kind === 'file') {
+      // (manifest/config already handled by the global guard above.)
       if (!isFile(entry.path)) {
         skipped.push(entry.path);
         continue;
       }
-      if (
-        entry.path === paths.config &&
-        entry.hash &&
-        sha256File(entry.path) !== entry.hash
-      ) {
+      if (entry.hash && sha256File(entry.path) !== entry.hash) {
+        // We recorded this file's content at write time; it differs now → the
+        // user (or another writer) changed it. Prove-before-delete: keep it,
+        // don't destroy an edit.
         process.stderr.write(`wienerdog: keeping ${entry.path} — modified since install\n`);
         skipped.push(entry.path);
         continue;
@@ -366,6 +495,7 @@ function reverse(paths, manifest, { dryRun = false } = {}) {
       removedSet.add(entry.path);
       removed.push(entry.path);
     } else if (entry.kind === 'dir') {
+      // (The core is handled by the global guard above and never reaches here.)
       if (!isDir(entry.path)) {
         skipped.push(entry.path);
         continue;
@@ -390,9 +520,9 @@ function reverse(paths, manifest, { dryRun = false } = {}) {
     } else if (entry.kind === 'scheduler-entry') {
       reverseSchedulerEntry(entry, dryRun, removed, skipped, removedSet);
     } else if (entry.kind === 'vendored-tree') {
-      reverseVendoredTree(entry, dryRun, removed, skipped, removedSet);
+      reverseVendoredTree(entry, dryRun, removed, skipped, removedSet, appRoot);
     } else if (entry.kind === 'copied-skill') {
-      reverseCopiedSkill(entry, dryRun, removed, skipped, removedSet);
+      reverseCopiedSkill(entry, dryRun, removed, skipped, removedSet, skillsRoots);
     } else if (entry.kind === 'vault-file' || entry.kind === 'vault-dir') {
       // The vault is the user's treasure — always preserved (ADR-0010, ADR-0019).
       // No filesystem action; NOT added to removedSet (it lives outside the core).
@@ -407,7 +537,7 @@ function reverse(paths, manifest, { dryRun = false } = {}) {
     }
   }
 
-  return { removed, skipped, preserved };
+  return { removed, skipped, preserved, deferredConfig, deferredConfigHash };
 }
 
 /**
@@ -494,4 +624,4 @@ function disposeCoreMechanics(paths, { dryRun = false, vaultPath = null } = {}) 
   return { removed, skippedForVault };
 }
 
-module.exports = { load, record, save, reverse, disposeCoreMechanics, reverseSchedulerEntry, reverseVendoredTree, reverseCopiedSkill, hashDir };
+module.exports = { load, record, save, reverse, disposeCoreMechanics, reverseSchedulerEntry, reverseVendoredTree, reverseCopiedSkill, hashDir, sha256File };

--- a/tests/unit/gws-grant.test.js
+++ b/tests/unit/gws-grant.test.js
@@ -159,11 +159,16 @@ test('saveGrant upserts by routine and re-syncs the manifest hash (uninstall sta
   assert.equal(grant.parseGrants(cfg).length, 2);
 
   // The manifest hash was re-synced, so uninstall removes config.yaml cleanly.
+  // WP-088: config.yaml is now a deferred-deletion-set member — reverse() defers
+  // it (returns it in deferredConfig) rather than deleting it inline; uninstall.js
+  // deletes it LAST. A re-synced hash means it is recognized as our own unmodified
+  // file (deferred), NOT kept as a customized edit.
   const manifest = manifestLib.load(paths);
   const entry = manifest.entries.find((e) => e.kind === 'file' && e.path === paths.config);
   assert.equal(entry.hash, sha256(cfg));
-  manifestLib.reverse(paths, manifest);
-  assert.equal(fs.existsSync(paths.config), false);
+  const { deferredConfig } = manifestLib.reverse(paths, manifest);
+  assert.equal(deferredConfig, paths.config, 'unmodified config is deferred for clean removal, not kept as a user edit');
+  assert.ok(fs.existsSync(paths.config), 'reverse() defers config.yaml; uninstall.js removes it last');
 });
 
 // --- CLI confirmation gating -------------------------------------------------

--- a/tests/unit/manifest.test.js
+++ b/tests/unit/manifest.test.js
@@ -27,6 +27,11 @@ function makeInstall(paths) {
   fs.mkdirSync(paths.state);
   fs.mkdirSync(paths.secrets, { mode: 0o700 });
   fs.mkdirSync(paths.logs);
+  // Mirror a real install: `sync` (which init runs) leaves an untracked runtime
+  // artifact in state/, so the core is never physically empty when reverse()
+  // runs. reverse() therefore never rmdirs the core — it leaves the manifest
+  // ledger behind, and disposeCoreMechanics (in uninstall.js) finishes the job.
+  fs.writeFileSync(path.join(paths.state, 'scheduler-status.json'), '{}\n');
   const content = 'version: 1\n';
   fs.writeFileSync(paths.config, content);
   const hash = crypto.createHash('sha256').update(content).digest('hex');
@@ -180,37 +185,255 @@ test('load throws on a corrupted manifest', () => {
   assert.throws(() => manifestLib.load(paths));
 });
 
-test('reverse removes all files and empty dirs, leaving nothing', () => {
+test('reverse does NOT delete the install manifest (recovery ledger survives for uninstall.js)', () => {
   const paths = tempPaths();
   const manifest = makeInstall(paths);
-  const { removed, skipped } = manifestLib.reverse(paths, manifest, {});
-  assert.equal(fs.existsSync(paths.core), false);
-  assert.ok(removed.includes(paths.config));
-  assert.ok(removed.includes(paths.core));
-  assert.equal(skipped.length, 0);
+  assert.equal(fs.existsSync(paths.manifest), true);
+  manifestLib.reverse(paths, manifest, {});
+  assert.equal(fs.existsSync(paths.manifest), true, 'the manifest file remains after reverse() returns');
 });
 
-test('reverse dry-run removes nothing but reports would-be removals', () => {
+test('reverse removes tracked files and empty dirs but defers config + leaves the manifest ledger and core', () => {
   const paths = tempPaths();
   const manifest = makeInstall(paths);
-  const { removed } = manifestLib.reverse(paths, manifest, { dryRun: true });
+  const { removed, skipped, deferredConfig } = manifestLib.reverse(paths, manifest, {});
+  // The recovery ledger and the core survive reverse() — the manifest still sits
+  // in the (physically non-empty) core, which uninstall.js removes later.
+  assert.equal(fs.existsSync(paths.manifest), true, 'reverse() does NOT delete the manifest');
+  assert.equal(fs.existsSync(paths.core), true, 'core kept alive (the manifest still sits in it)');
+  // config.yaml (unmodified) is now DEFERRED, not deleted by reverse() — it is
+  // returned in deferredConfig and deleted LAST by uninstall.js.
+  assert.equal(deferredConfig, paths.config, 'the unmodified config is deferred, not removed');
+  assert.ok(!removed.includes(paths.config), 'reverse() does not delete config.yaml');
+  assert.equal(fs.existsSync(paths.config), true, 'config.yaml survives reverse() for the vault-path source');
+  assert.ok(removed.includes(paths.logs) && removed.includes(paths.secrets), 'empty tracked dirs removed');
+  // state holds an untracked artifact (as after a real sync) → kept; core kept.
+  assert.ok(skipped.includes(paths.state));
+  assert.ok(skipped.includes(paths.core));
+});
+
+test('reverse never rmdirs the core even when it is virtually empty (retry-after-partial-sweep wedge guard)', () => {
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  // Simulate a RETRY after a partial uninstall: the first attempt already reversed
+  // the tracked files, and the mechanics sweep already removed state/, but crashed
+  // before deleting the manifest. On disk only the manifest remains in the core.
+  fs.rmSync(paths.config, { force: true });
+  fs.rmSync(paths.state, { recursive: true, force: true });
+  fs.rmSync(paths.secrets, { recursive: true, force: true });
+  fs.rmSync(paths.logs, { recursive: true, force: true });
+  assert.equal(fs.existsSync(paths.manifest), true, 'the ledger is still physically present');
+  // Pre-fix this threw ENOTEMPTY (core virtually empty + manifest still on disk),
+  // wedging every retry before manifest deletion. It must NOT throw or rmdir core.
+  let result;
+  assert.doesNotThrow(() => {
+    result = manifestLib.reverse(paths, manifest, {});
+  });
+  assert.equal(fs.existsSync(paths.core), true, 'reverse() leaves the core for uninstall.js disposal');
+  assert.equal(fs.existsSync(paths.manifest), true, 'the ledger survives — the retry can proceed');
+  assert.ok(result.skipped.includes(paths.core), 'the core is reported skipped, never removed');
+  assert.ok(!result.removed.includes(paths.core));
+});
+
+test('reverse dry-run removes nothing but reports would-be removals (config deferred either way)', () => {
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  const { removed, deferredConfig } = manifestLib.reverse(paths, manifest, { dryRun: true });
   assert.equal(fs.existsSync(paths.core), true);
   assert.equal(fs.existsSync(paths.config), true);
   assert.equal(fs.existsSync(paths.manifest), true);
-  assert.ok(removed.includes(paths.config));
-  assert.ok(removed.includes(paths.core));
+  // config.yaml is deferred under dryRun too (reverse never deletes it either way);
+  // it moved out of `removed` into `deferredConfig`.
+  assert.ok(!removed.includes(paths.config));
+  assert.equal(deferredConfig, paths.config, 'dry-run still reports the deferred config');
+  assert.ok(removed.includes(paths.logs), 'other tracked items still listed as would-be removed');
 });
 
-test('reverse keeps config.yaml when it was modified since install', () => {
+test('reverse keeps config.yaml when it was modified since install (deferredConfig null)', () => {
   const paths = tempPaths();
   const manifest = makeInstall(paths);
   fs.writeFileSync(paths.config, 'user edited this\n');
-  const { removed, skipped } = manifestLib.reverse(paths, manifest, {});
+  const { removed, skipped, deferredConfig } = manifestLib.reverse(paths, manifest, {});
   assert.ok(skipped.includes(paths.config));
   assert.ok(!removed.includes(paths.config));
+  assert.equal(deferredConfig, null, 'a customized config is NOT deferred for deletion (kept forever)');
   assert.equal(fs.existsSync(paths.config), true);
   // Core dir must remain because config still lives in it.
   assert.equal(fs.existsSync(paths.core), true);
+});
+
+// ── Global deferred-member guard: cross-kind regression (REAL manifest JSON,
+//    loaded via manifestLib.load, reverse() on the REAL filesystem, NO fs stubs).
+//    Each asserts the targeted deferred member survives on disk and is NOT in
+//    `removed` — proving the single guard before the kind dispatch closes every
+//    DIRECT path-based route regardless of entry kind or path normalization. ──
+
+const MB_BEGIN = '<!-- wienerdog:begin -->';
+const MB_END = '<!-- wienerdog:end -->';
+
+test('global guard (i): a self-referential {kind:file, path: manifest} entry never deletes the ledger', () => {
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  manifestLib.record(manifest, { kind: 'file', path: paths.manifest });
+  manifestLib.save(paths, manifest);
+  const reloaded = manifestLib.load(paths);
+  const { removed, skipped } = manifestLib.reverse(paths, reloaded, {});
+  assert.equal(fs.existsSync(paths.manifest), true, 'the real ledger is intact on disk');
+  assert.ok(!removed.includes(paths.manifest), 'manifest not in removed');
+  assert.ok(skipped.includes(paths.manifest));
+});
+
+test('global guard (ii): a {kind:scheduler-entry, path: manifest} entry never rmSyncs the ledger', () => {
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  manifestLib.record(manifest, { kind: 'scheduler-entry', path: paths.manifest }); // no unload
+  manifestLib.save(paths, manifest);
+  const reloaded = manifestLib.load(paths);
+  const { removed } = manifestLib.reverse(paths, reloaded, {});
+  assert.equal(fs.existsSync(paths.manifest), true, 'scheduler-entry did not delete the ledger');
+  assert.ok(!removed.includes(paths.manifest));
+});
+
+test('global guard (iii): a {kind:symlink} whose path resolves to a deferred member is never unlinked', () => {
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  // A symlink (inside the core) pointing at the manifest ledger. Without the
+  // realpath-aware guard, reverseSymlink would unlink it.
+  const link = path.join(paths.core, 'ledger-link');
+  fs.symlinkSync(paths.manifest, link);
+  manifestLib.record(manifest, { kind: 'symlink', path: link });
+  manifestLib.save(paths, manifest);
+  const reloaded = manifestLib.load(paths);
+  const { removed, skipped } = manifestLib.reverse(paths, reloaded, {});
+  assert.equal(fs.existsSync(paths.manifest), true, 'the ledger survives');
+  assert.equal(fs.lstatSync(link).isSymbolicLink(), true, 'the symlink to a deferred member is not unlinked');
+  assert.ok(!removed.includes(link));
+  assert.ok(skipped.includes(link));
+});
+
+test('global guard (iv): a {kind:settings-entry, path: config} never rewrites/deletes config (mutation branch)', () => {
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  // Craft config so that WITHOUT the guard reverseSettingsEntry would delete it:
+  // valid JSON with empty hooks + createdFile:true prunes to {} → rmSync.
+  const cfg = '{"hooks":{}}';
+  fs.writeFileSync(paths.config, cfg);
+  manifestLib.record(manifest, { kind: 'settings-entry', path: paths.config, createdFile: true, commands: [] });
+  manifestLib.save(paths, manifest);
+  const reloaded = manifestLib.load(paths);
+  const { removed } = manifestLib.reverse(paths, reloaded, {});
+  assert.equal(fs.existsSync(paths.config), true, 'config not deleted by the settings-entry');
+  assert.equal(fs.readFileSync(paths.config, 'utf8'), cfg, 'config content not rewritten');
+  assert.ok(!removed.includes(paths.config));
+});
+
+test('global guard (iv-b): a {kind:managed-block, path: config} never rewrites/deletes config (mutation branch)', () => {
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  // Craft config as a Wienerdog-created managed-block-only file so that WITHOUT
+  // the guard reverseManagedBlock (createdFile:true, remaining empty) would rmSync it.
+  const cfg = `${MB_BEGIN}\nblock body\n${MB_END}\n`;
+  fs.writeFileSync(paths.config, cfg);
+  manifestLib.record(manifest, { kind: 'managed-block', path: paths.config, createdFile: true });
+  manifestLib.save(paths, manifest);
+  const reloaded = manifestLib.load(paths);
+  const { removed } = manifestLib.reverse(paths, reloaded, {});
+  assert.equal(fs.existsSync(paths.config), true, 'config not deleted by the managed-block entry');
+  assert.equal(fs.readFileSync(paths.config, 'utf8'), cfg, 'config content not rewritten');
+  assert.ok(!removed.includes(paths.config));
+});
+
+test('global guard (v): a normalized {kind:file, path: <core>/./config.yaml} alias defers config to the CANONICAL path', () => {
+  const paths = tempPaths();
+  const manifest = makeInstall(paths); // records the canonical config file entry (matching hash)
+  const alias = `${paths.core}/./config.yaml`; // un-normalized alias string (path.join would collapse it)
+  assert.notEqual(alias, paths.config, 'the alias is a distinct string from the canonical path');
+  const hash = crypto.createHash('sha256').update(fs.readFileSync(paths.config)).digest('hex');
+  manifestLib.record(manifest, { kind: 'file', path: alias, hash });
+  manifestLib.save(paths, manifest);
+  const reloaded = manifestLib.load(paths);
+  const { removed, deferredConfig } = manifestLib.reverse(paths, reloaded, {});
+  assert.equal(fs.existsSync(paths.config), true, 'the normalized alias did not reach the generic rmSync');
+  assert.equal(deferredConfig, paths.config, 'deferredConfig is the CANONICAL path, not the alias');
+  assert.ok(!removed.includes(alias) && !removed.includes(paths.config));
+});
+
+test('global guard (vi): a {kind:scheduler-entry, path: config} leaves config intact', () => {
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  manifestLib.record(manifest, { kind: 'scheduler-entry', path: paths.config }); // no unload
+  manifestLib.save(paths, manifest);
+  const reloaded = manifestLib.load(paths);
+  const { removed } = manifestLib.reverse(paths, reloaded, {});
+  assert.equal(fs.existsSync(paths.config), true, 'scheduler-entry did not delete config');
+  assert.ok(!removed.includes(paths.config));
+});
+
+test('global guard (vii) DOCUMENTED RESIDUAL: a scheduler-entry `unload` argv IS invoked as designed (guard screens entry.path, NOT unload)', () => {
+  // The global guard screens entry.path only. A scheduler-entry with a
+  // NON-deferred path but an `unload` argv that would touch a deferred member
+  // still runs its unload — an explicit, ACCEPTED out-of-scope residual (WP-088
+  // Non-goals / round 6). This test PINS that behavior + scoping; it is NOT a
+  // "guard blocks it" assertion. Forging `unload` requires write access to the
+  // core, which already grants arbitrary code execution.
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  const schedFile = path.join(paths.core, 'schedules', 'wienerdog-dream.plist');
+  fs.mkdirSync(path.dirname(schedFile), { recursive: true });
+  fs.writeFileSync(schedFile, '<plist/>\n');
+  const unload = ['launchctl', 'bootout', `would-touch:${paths.manifest}`];
+  manifestLib.record(manifest, { kind: 'scheduler-entry', path: schedFile, unload });
+  manifestLib.save(paths, manifest);
+  const reloaded = manifestLib.load(paths);
+
+  // Spy on the single scheduler mutation chokepoint (reverse() re-requires the
+  // module, so mutating its export is observed).
+  const spawnMod = require('../../src/scheduler/spawn');
+  const origSpawn = spawnMod.schedulerSpawn;
+  /** @type {string[][]} */ const calls = [];
+  spawnMod.schedulerSpawn = (argv) => { calls.push(argv); return { status: 0 }; };
+  try {
+    manifestLib.reverse(paths, reloaded, {});
+  } finally {
+    spawnMod.schedulerSpawn = origSpawn;
+  }
+  assert.equal(calls.length, 1, 'the unload argv is invoked as designed (accepted residual)');
+  assert.deepEqual(calls[0], unload, 'the exact unload argv reached the chokepoint — the guard did NOT block it');
+  // And this indirect route is NOT a WP-088 regression: the ledger is untouched
+  // (the unload was a marker, not a real delete).
+  assert.equal(fs.existsSync(paths.manifest), true);
+});
+
+test('reverse preserves ANY kind:file entry whose recorded hash no longer matches (generalized guard)', () => {
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  // A hashed file that is NOT config.yaml — the generalized prove-before-delete.
+  const extra = path.join(paths.core, 'notes.md');
+  const content = '# notes\n';
+  fs.writeFileSync(extra, content);
+  const hash = crypto.createHash('sha256').update(content).digest('hex');
+  manifestLib.record(manifest, { kind: 'file', path: extra, hash });
+  manifestLib.save(paths, manifest);
+  // The user edits it after install.
+  fs.writeFileSync(extra, '# edited by the user\n');
+  const { removed, skipped } = manifestLib.reverse(paths, manifest, {});
+  assert.ok(skipped.includes(extra), 'a modified hashed file is kept, not deleted');
+  assert.ok(!removed.includes(extra));
+  assert.equal(fs.existsSync(extra), true);
+});
+
+test('reverse removes a kind:file entry whose recorded hash still matches', () => {
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  const extra = path.join(paths.core, 'notes.md');
+  const content = '# notes\n';
+  fs.writeFileSync(extra, content);
+  const hash = crypto.createHash('sha256').update(content).digest('hex');
+  manifestLib.record(manifest, { kind: 'file', path: extra, hash });
+  manifestLib.save(paths, manifest);
+  const { removed } = manifestLib.reverse(paths, manifest, {});
+  assert.ok(removed.includes(extra));
+  assert.equal(fs.existsSync(extra), false);
 });
 
 test('reverse reports already-gone entries as skipped', () => {
@@ -219,14 +442,17 @@ test('reverse reports already-gone entries as skipped', () => {
   fs.rmSync(paths.config);
   const { skipped } = manifestLib.reverse(paths, manifest, {});
   assert.ok(skipped.includes(paths.config));
-  // Everything else still cleaned up.
-  assert.equal(fs.existsSync(paths.core), false);
+  // The empty tracked subdirs are still cleaned up; the core + ledger remain
+  // for uninstall.js to finish.
+  assert.equal(fs.existsSync(paths.logs), false);
+  assert.equal(fs.existsSync(paths.secrets), false);
+  assert.equal(fs.existsSync(paths.core), true);
 });
 
-test('reverse removes a vendored-tree recursively and empties the enclosing core', () => {
+test('reverse removes a vendored-tree at the app root recursively (core kept for the sweep)', () => {
   const paths = tempPaths();
   const manifest = makeInstall(paths);
-  // Build a realistic vendored app tree: app/<version>/{bin,...} + a current symlink.
+  // A realistic vendored app tree at the app root: app/<version>/{bin,...} + symlink.
   const app = path.join(paths.core, 'app');
   const versionDir = path.join(app, '0.2.1');
   fs.mkdirSync(path.join(versionDir, 'bin'), { recursive: true });
@@ -235,13 +461,39 @@ test('reverse removes a vendored-tree recursively and empties the enclosing core
   manifestLib.record(manifest, { kind: 'vendored-tree', path: app });
   manifestLib.save(paths, manifest);
 
-  const { removed, skipped } = manifestLib.reverse(paths, manifest, {});
+  const { removed } = manifestLib.reverse(paths, manifest, {});
   assert.equal(fs.existsSync(app), false, 'the vendored app tree is removed recursively');
   assert.ok(removed.includes(app));
-  // Empties the core so the enclosing core dir is still removed.
-  assert.equal(fs.existsSync(paths.core), false);
-  assert.ok(removed.includes(paths.core));
-  assert.equal(skipped.length, 0);
+  // reverse() leaves the core + ledger; uninstall.js completes the removal.
+  assert.equal(fs.existsSync(paths.core), true);
+  assert.equal(fs.existsSync(paths.manifest), true);
+});
+
+test('reverse refuses a vendored-tree entry EQUAL to the core (P0 core-deletion) — never recursive-deletes it', () => {
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  manifestLib.record(manifest, { kind: 'vendored-tree', path: paths.core });
+  manifestLib.save(paths, manifest);
+  const { removed, skipped } = manifestLib.reverse(paths, manifest, {});
+  assert.ok(!removed.includes(paths.core), 'the core is never recursively removed via a vendored-tree entry');
+  assert.ok(skipped.includes(paths.core));
+  assert.equal(fs.existsSync(paths.core), true);
+  assert.equal(fs.existsSync(paths.manifest), true, 'core contents (the ledger) survive the refusal');
+});
+
+test('reverse refuses a vendored-tree entry that is a descendant of (not equal to) the app root', () => {
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  const app = path.join(paths.core, 'app');
+  const nested = path.join(app, 'nested');
+  fs.mkdirSync(nested, { recursive: true });
+  fs.writeFileSync(path.join(nested, 'x'), 'x\n');
+  manifestLib.record(manifest, { kind: 'vendored-tree', path: nested });
+  manifestLib.save(paths, manifest);
+  const { removed, skipped } = manifestLib.reverse(paths, manifest, {});
+  assert.ok(!removed.includes(nested));
+  assert.ok(skipped.includes(nested));
+  assert.equal(fs.existsSync(nested), true, 'a descendant of the app root is preserved, not removed');
 });
 
 test('reverse skips a vendored-tree entry that is already gone', () => {
@@ -252,40 +504,154 @@ test('reverse skips a vendored-tree entry that is already gone', () => {
   manifestLib.save(paths, manifest);
   const { skipped } = manifestLib.reverse(paths, manifest, {});
   assert.ok(skipped.includes(app), 'a missing vendored tree is skipped, not an error');
-  assert.equal(fs.existsSync(paths.core), false);
+  assert.equal(fs.existsSync(paths.core), true);
 });
 
-test('reverse removes a copied-skill recursively and empties the enclosing skills dir', () => {
+test('reverse removes a legitimate copied-skill (parent is a harness skills root, wienerdog-*, fingerprint matches)', () => {
   const paths = tempPaths();
   const manifest = makeInstall(paths);
-  // Build a realistic copied skill: <claude>/skills/wienerdog-setup/{SKILL.md,sub/ref.md}.
-  const skillsDir = path.join(paths.core, 'harness-skills');
-  const copied = path.join(skillsDir, 'wienerdog-setup');
+  // A realistic copied skill: <claudeDir>/skills/wienerdog-setup/{SKILL.md,sub/ref.md}.
+  const skillsRoot = path.join(paths.claudeDir, 'skills');
+  const copied = path.join(skillsRoot, 'wienerdog-setup');
   fs.mkdirSync(path.join(copied, 'sub'), { recursive: true });
   fs.writeFileSync(path.join(copied, 'SKILL.md'), '# skill\n');
   fs.writeFileSync(path.join(copied, 'sub', 'ref.md'), 'ref\n');
-  manifestLib.record(manifest, { kind: 'dir', path: skillsDir });
-  manifestLib.record(manifest, { kind: 'copied-skill', path: copied });
+  const hash = manifestLib.hashDir(copied);
+  manifestLib.record(manifest, { kind: 'copied-skill', path: copied, hash });
   manifestLib.save(paths, manifest);
 
   const { removed, skipped } = manifestLib.reverse(paths, manifest, {});
-  assert.equal(fs.existsSync(copied), false, 'the copied skill folder is removed recursively');
+  assert.equal(fs.existsSync(copied), false, 'a fingerprint-matching Wienerdog skill is removed recursively');
   assert.ok(removed.includes(copied));
-  // The now-empty skills dir is removed too (copied path in removedSet).
-  assert.equal(fs.existsSync(skillsDir), false);
-  assert.ok(removed.includes(skillsDir));
-  assert.equal(skipped.length, 0);
+  assert.ok(!skipped.includes(copied));
+});
+
+test('reverse preserves a copied-skill whose on-disk tree no longer fingerprints to the recorded hash', () => {
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  const skillsRoot = path.join(paths.claudeDir, 'skills');
+  const copied = path.join(skillsRoot, 'wienerdog-setup');
+  fs.mkdirSync(copied, { recursive: true });
+  fs.writeFileSync(path.join(copied, 'SKILL.md'), '# skill\n');
+  const hash = manifestLib.hashDir(copied);
+  // The user edits/replaces Wienerdog's copy AFTER install → fingerprint drifts.
+  fs.writeFileSync(path.join(copied, 'SKILL.md'), '# user edited\n');
+  manifestLib.record(manifest, { kind: 'copied-skill', path: copied, hash });
+  manifestLib.save(paths, manifest);
+
+  const { removed, skipped } = manifestLib.reverse(paths, manifest, {});
+  assert.ok(!removed.includes(copied));
+  assert.ok(skipped.includes(copied));
+  assert.equal(fs.existsSync(copied), true, 'an edited copy is preserved, never deleted');
+});
+
+test('reverse preserves a copied-skill path that is a SYMLINK to an identical tree (lstat ownership gate, not deleted)', (t) => {
+  if (!isPosix) return t.skip('symlink creation may be unavailable');
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  // The user moved our fallback-copied skill to their OWN location and left a
+  // symlink at the copied-skill path pointing at an identical-content tree.
+  const realTree = path.join(path.dirname(paths.core), 'my-skills', 'wienerdog-setup');
+  fs.mkdirSync(path.join(realTree, 'sub'), { recursive: true });
+  fs.writeFileSync(path.join(realTree, 'SKILL.md'), '# skill\n');
+  fs.writeFileSync(path.join(realTree, 'sub', 'ref.md'), 'ref\n');
+  const skillsRoot = path.join(paths.claudeDir, 'skills');
+  const linkPath = path.join(skillsRoot, 'wienerdog-setup');
+  fs.mkdirSync(skillsRoot, { recursive: true });
+  fs.symlinkSync(realTree, linkPath);
+  // The recorded hash MATCHES (hashDir follows the symlink to the identical tree),
+  // so ONLY the lstat real-directory gate prevents the delete.
+  const hash = manifestLib.hashDir(linkPath);
+  assert.equal(hash, manifestLib.hashDir(realTree), 'the symlink fingerprints to the identical target tree');
+  manifestLib.record(manifest, { kind: 'copied-skill', path: linkPath, hash });
+  manifestLib.save(paths, manifest);
+
+  const { removed, skipped } = manifestLib.reverse(paths, manifest, {});
+  assert.ok(!removed.includes(linkPath), 'a symlink at the copied-skill path is never deleted');
+  assert.ok(skipped.includes(linkPath));
+  assert.equal(fs.lstatSync(linkPath).isSymbolicLink(), true, 'the user-created symlink survives (lstat gate)');
+  assert.equal(fs.existsSync(path.join(realTree, 'SKILL.md')), true, 'the symlink target tree is untouched');
+});
+
+test('reverse preserves a legacy hash-less copied-skill entry (no fingerprint to verify)', () => {
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  const skillsRoot = path.join(paths.claudeDir, 'skills');
+  const copied = path.join(skillsRoot, 'wienerdog-setup');
+  fs.mkdirSync(copied, { recursive: true });
+  fs.writeFileSync(path.join(copied, 'SKILL.md'), '# skill\n');
+  manifestLib.record(manifest, { kind: 'copied-skill', path: copied }); // no hash
+  manifestLib.save(paths, manifest);
+
+  const { removed, skipped } = manifestLib.reverse(paths, manifest, {});
+  assert.ok(!removed.includes(copied));
+  assert.ok(skipped.includes(copied));
+  assert.equal(fs.existsSync(copied), true, 'a hash-less legacy entry is preserved, never deleted');
+});
+
+test('reverse preserves a copied-skill whose tree is unreadable (hashDir → null, never deleted)', (t) => {
+  if (!isPosix || isRoot) return t.skip('needs POSIX permission enforcement (non-root)');
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  const skillsRoot = path.join(paths.claudeDir, 'skills');
+  const copied = path.join(skillsRoot, 'wienerdog-setup');
+  const locked = path.join(copied, 'locked');
+  fs.mkdirSync(locked, { recursive: true });
+  fs.writeFileSync(path.join(locked, 'secret'), 'x\n');
+  manifestLib.record(manifest, { kind: 'copied-skill', path: copied, hash: 'a'.repeat(64) });
+  manifestLib.save(paths, manifest);
+  fs.chmodSync(locked, 0o000);
+  try {
+    const { removed, skipped } = manifestLib.reverse(paths, manifest, {});
+    assert.ok(!removed.includes(copied));
+    assert.ok(skipped.includes(copied));
+    assert.equal(fs.existsSync(copied), true, 'an unreadable copy is never deleted');
+  } finally {
+    fs.chmodSync(locked, 0o700); // restore so tmp cleanup can proceed
+  }
+});
+
+test('reverse refuses a copied-skill whose parent is NOT a harness skills root (deeper descendant)', () => {
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  const skillsRoot = path.join(paths.claudeDir, 'skills');
+  const copied = path.join(skillsRoot, 'user-content', 'wienerdog-x');
+  fs.mkdirSync(copied, { recursive: true });
+  fs.writeFileSync(path.join(copied, 'SKILL.md'), '# skill\n');
+  const hash = manifestLib.hashDir(copied);
+  manifestLib.record(manifest, { kind: 'copied-skill', path: copied, hash });
+  manifestLib.save(paths, manifest);
+  const { removed, skipped } = manifestLib.reverse(paths, manifest, {});
+  assert.ok(!removed.includes(copied));
+  assert.ok(skipped.includes(copied));
+  assert.equal(fs.existsSync(copied), true, 'a deeper descendant is refused even with a matching fingerprint');
+});
+
+test('reverse refuses a copied-skill whose basename is outside the wienerdog-* namespace', () => {
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  const skillsRoot = path.join(paths.claudeDir, 'skills');
+  const copied = path.join(skillsRoot, 'some-other-skill');
+  fs.mkdirSync(copied, { recursive: true });
+  fs.writeFileSync(path.join(copied, 'SKILL.md'), '# skill\n');
+  const hash = manifestLib.hashDir(copied);
+  manifestLib.record(manifest, { kind: 'copied-skill', path: copied, hash });
+  manifestLib.save(paths, manifest);
+  const { removed, skipped } = manifestLib.reverse(paths, manifest, {});
+  assert.ok(!removed.includes(copied));
+  assert.ok(skipped.includes(copied));
+  assert.equal(fs.existsSync(copied), true, 'a non-wienerdog-* name is refused even directly under a skills root');
 });
 
 test('reverse skips a copied-skill entry that is already gone', () => {
   const paths = tempPaths();
   const manifest = makeInstall(paths);
-  const copied = path.join(paths.core, 'harness-skills', 'wienerdog-setup');
-  manifestLib.record(manifest, { kind: 'copied-skill', path: copied });
+  const copied = path.join(paths.claudeDir, 'skills', 'wienerdog-setup');
+  manifestLib.record(manifest, { kind: 'copied-skill', path: copied, hash: 'a'.repeat(64) });
   manifestLib.save(paths, manifest);
   const { skipped } = manifestLib.reverse(paths, manifest, {});
   assert.ok(skipped.includes(copied), 'a missing copied skill is skipped, not an error');
-  assert.equal(fs.existsSync(paths.core), false);
+  assert.equal(fs.existsSync(paths.core), true);
 });
 
 test('reverse skips unknown entry kinds (forward compat)', () => {

--- a/tests/unit/scheduler-schedule.test.js
+++ b/tests/unit/scheduler-schedule.test.js
@@ -313,7 +313,7 @@ test('scheduler-schedule: a second identical add is idempotent (no OS call)', { 
   assert.equal(calls2.length, 0, 'no loader calls on an unchanged re-add');
 });
 
-test('scheduler-schedule: add then manifest.reverse still removes config.yaml (hash re-synced)', { skip: !SCHED_SUPPORTED }, async () => {
+test('scheduler-schedule: add then manifest.reverse DEFERS config.yaml (hash re-synced, not mistaken for a user edit) (WP-088)', { skip: !SCHED_SUPPORTED }, async () => {
   const { env, paths } = setup();
   await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], () => ({ status: 0 }));
   assert.ok(fs.existsSync(paths.config));
@@ -323,8 +323,13 @@ test('scheduler-schedule: add then manifest.reverse still removes config.yaml (h
     if (e.kind === 'scheduler-entry') e.unload = [process.execPath, '-e', '0'];
   }
   manifestLib.save(paths, manifest);
-  manifestLib.reverse(paths, manifestLib.load(paths));
-  assert.ok(!fs.existsSync(paths.config), 'config.yaml removed — not mistaken for a user edit');
+  // WP-088: config.yaml is a deferred-deletion-set member — reverse() NO LONGER
+  // deletes it. A re-synced (unmodified) hash means it is recognized as our own
+  // file and returned in deferredConfig (uninstall.js deletes it LAST), NOT kept
+  // as a customized edit.
+  const { deferredConfig } = manifestLib.reverse(paths, manifestLib.load(paths));
+  assert.equal(deferredConfig, paths.config, 'unmodified config is deferred (recognized), not mistaken for a user edit');
+  assert.ok(fs.existsSync(paths.config), 'reverse() defers config.yaml; uninstall.js deletes it last');
 });
 
 test('scheduler-schedule: remove runs the unload, deletes files, drops entries and the job', { skip: !SCHED_SUPPORTED }, async () => {

--- a/tests/unit/uninstall.test.js
+++ b/tests/unit/uninstall.test.js
@@ -227,6 +227,256 @@ test('uninstall never deletes a vault nested inside state/ — survives with the
   assert.doesNotMatch(r.stdout, /fully removed/);
 });
 
+test('a clean uninstall deletes the manifest last, then the unmodified config, and removes the empty core', () => {
+  const { core, env } = tempEnv();
+  run(['init', '--yes'], env);
+  assert.ok(fs.existsSync(path.join(core, 'install-manifest.json')), 'init wrote the manifest');
+  assert.ok(fs.existsSync(path.join(core, 'config.yaml')), 'init wrote config.yaml');
+  const r = run(['uninstall', '--yes'], env);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /fully removed/);
+  // Manifest + the unmodified config gone WITH the emptied core (deleted last,
+  // then the core swept).
+  assert.equal(fs.existsSync(path.join(core, 'config.yaml')), false, 'the unmodified config is deleted');
+  assert.equal(fs.existsSync(core), false, 'the empty core is removed');
+});
+
+test('a clean uninstall summary does not list the swept core/state under "Skipped" (consistent with "fully removed")', () => {
+  const { core, env } = tempEnv();
+  run(['init', '--yes'], env);
+  const r = run(['uninstall', '--yes'], env);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /fully removed/);
+  // The core and its state dir were swept — they must NOT be reported as skipped,
+  // which would contradict "fully removed".
+  const skippedSection = r.stdout.includes('Skipped') ? r.stdout.slice(r.stdout.indexOf('Skipped')) : '';
+  assert.doesNotMatch(skippedSection, new RegExp(`${core}(\\s|$)`), 'the swept core is not listed under Skipped');
+  assert.doesNotMatch(skippedSection, new RegExp(path.join(core, 'state')), 'the swept state dir is not listed under Skipped');
+  // On a fully-clean uninstall nothing is preserved, so no Skipped section at all.
+  assert.doesNotMatch(r.stdout, /Skipped \d+ item/);
+});
+
+test('uninstall keeps the manifest when disposeCoreMechanics throws mid-sweep (recovery ledger intact)', async () => {
+  const { core, env } = tempEnv();
+  // Build a real install via the CLI (subprocess), then drive run() IN-PROCESS so
+  // we can inject a throwing disposeCoreMechanics between reverse() and the
+  // manifest deletion — proving a crash there leaves a replayable ledger.
+  run(['init', '--yes'], env);
+  const manifestPath = path.join(core, 'install-manifest.json');
+  assert.ok(fs.existsSync(manifestPath));
+
+  const manifestLib = require('../../src/core/manifest');
+  const { run: runUninstall } = require('../../src/cli/uninstall');
+  const origDispose = manifestLib.disposeCoreMechanics;
+  const savedEnv = { ...process.env };
+  Object.assign(process.env, env); // getPaths() reads env at call time
+  manifestLib.disposeCoreMechanics = () => {
+    throw new Error('boom mid-sweep');
+  };
+  let threw = false;
+  try {
+    await runUninstall(['--yes']);
+  } catch {
+    threw = true;
+  } finally {
+    manifestLib.disposeCoreMechanics = origDispose;
+    for (const k of Object.keys(env)) delete process.env[k];
+    Object.assign(process.env, savedEnv);
+  }
+  assert.ok(threw, 'the injected dispose throw propagates out of run()');
+  assert.equal(
+    fs.existsSync(manifestPath),
+    true,
+    'the manifest ledger survives a crash during the mechanics sweep — uninstall can be re-run'
+  );
+  assert.equal(
+    fs.existsSync(path.join(core, 'config.yaml')),
+    true,
+    'config.yaml also survives the crash — its vault: line is the retry vault-path source'
+  );
+});
+
+/**
+ * Nest a vault INSIDE the core's state/ dir, point config.yaml at it, re-sync the
+ * manifest hash (so the rewrite is not mistaken for a user edit), and record a
+ * vault-file entry. Mirrors the legacy/hand-edited install the regression guards.
+ * @param {string} core @returns {{nestedVault:string, precious:string}}
+ */
+function nestVaultInState(core) {
+  const crypto = require('node:crypto');
+  const nestedVault = path.join(core, 'state', 'mynotes');
+  fs.mkdirSync(nestedVault, { recursive: true });
+  const precious = path.join(nestedVault, 'precious-note.md');
+  fs.writeFileSync(precious, '# precious\n');
+  const configPath = path.join(core, 'config.yaml');
+  const cfg = fs.readFileSync(configPath, 'utf8').replace(/^vault:.*$/m, `vault: ${nestedVault}`);
+  fs.writeFileSync(configPath, cfg);
+  const manifestPath = path.join(core, 'install-manifest.json');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const cfgEntry = manifest.entries.find((e) => e.kind === 'file' && e.path === configPath);
+  cfgEntry.hash = crypto.createHash('sha256').update(cfg).digest('hex');
+  manifest.entries.push({ kind: 'vault-file', path: precious });
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+  return { nestedVault, precious };
+}
+
+test('crashed-then-retried uninstall with a NESTED vault: retry re-reads config.yaml and the nested vault survives (config-deferral regression)', async () => {
+  const { core, env } = tempEnv();
+  run(['init', '--yes'], env);
+  const { precious } = nestVaultInState(core);
+  const manifestPath = path.join(core, 'install-manifest.json');
+  const configPath = path.join(core, 'config.yaml');
+
+  const manifestLib = require('../../src/core/manifest');
+  const { run: runUninstall } = require('../../src/cli/uninstall');
+  const origDispose = manifestLib.disposeCoreMechanics;
+  const savedEnv = { ...process.env };
+  Object.assign(process.env, env); // getPaths() reads env at call time
+  try {
+    // ── Attempt 1: crash INSIDE disposeCoreMechanics (before it sweeps). ──
+    manifestLib.disposeCoreMechanics = () => {
+      throw new Error('boom mid-sweep');
+    };
+    let threw = false;
+    try {
+      await runUninstall(['--yes']);
+    } catch {
+      threw = true;
+    }
+    manifestLib.disposeCoreMechanics = origDispose; // real dispose for the retry
+    assert.ok(threw, 'attempt 1 crashes in the sweep');
+    // The deferred set + the nested vault all survive the crash → a retry is safe.
+    assert.equal(fs.existsSync(manifestPath), true, 'ledger survives the crash');
+    assert.equal(fs.existsSync(configPath), true, 'config.yaml (vault-path source) survives the crash');
+    assert.equal(fs.readFileSync(precious, 'utf8'), '# precious\n', 'nested vault untouched after the crash');
+
+    // ── Attempt 2: a REAL retry re-reads the surviving config.yaml. ──
+    const logs = [];
+    const origLog = console.log;
+    console.log = (...a) => logs.push(a.join(' '));
+    try {
+      await runUninstall(['--yes']);
+    } finally {
+      console.log = origLog;
+    }
+    const out = logs.join('\n');
+    // The nested vault SURVIVES the crashed-then-retried uninstall (skippedForVault).
+    assert.equal(
+      fs.readFileSync(precious, 'utf8'),
+      '# precious\n',
+      'the nested vault survives the crashed-then-retried uninstall'
+    );
+    assert.match(out, /left in place|still lives inside it/, 'the retry reports the vault was protected (skippedForVault)');
+    assert.equal(fs.existsSync(core), true, 'core kept — it still holds the nested vault');
+  } finally {
+    manifestLib.disposeCoreMechanics = origDispose;
+    for (const k of Object.keys(env)) delete process.env[k];
+    Object.assign(process.env, savedEnv);
+  }
+});
+
+test('manifest-delete FAILURE injection: run() aborts with WienerdogError, config NOT deleted, and a real retry keeps a nested vault', async () => {
+  const { core, env } = tempEnv();
+  run(['init', '--yes'], env);
+  const { precious } = nestVaultInState(core);
+  const manifestPath = path.join(core, 'install-manifest.json');
+  const configPath = path.join(core, 'config.yaml');
+  const configContent = fs.readFileSync(configPath, 'utf8');
+
+  const { run: runUninstall } = require('../../src/cli/uninstall');
+  const { WienerdogError } = require('../../src/core/errors');
+  const savedEnv = { ...process.env };
+  Object.assign(process.env, env);
+  const origRmSync = fs.rmSync;
+  try {
+    // ── Stub ONLY the manifest deletion to throw (real err.code), delegate every
+    //    other rmSync to the real filesystem (no verification is stubbed — the
+    //    gate is rmSync's own outcome). ──
+    fs.rmSync = (target, opts) => {
+      if (target === manifestPath) {
+        const err = new Error('permission denied');
+        err.code = 'EACCES';
+        throw err;
+      }
+      return origRmSync(target, opts);
+    };
+    let caught = null;
+    try {
+      await runUninstall(['--yes']);
+    } catch (e) {
+      caught = e;
+    }
+    fs.rmSync = origRmSync; // lift the stub before observing / retrying
+
+    assert.ok(caught instanceof WienerdogError, 'run() rejects with WienerdogError on a manifest-delete failure');
+    assert.match(caught.message, /could not remove the install manifest \(EACCES\)/);
+    // The manifest is still present (delete threw) and config was NOT deleted →
+    // manifest-present + config-present, so a retry stays vault-safe.
+    assert.equal(fs.existsSync(manifestPath), true, 'the ledger remains after the failed delete');
+    assert.equal(fs.existsSync(configPath), true, 'config.yaml was NOT deleted after the manifest-delete failure');
+    assert.equal(fs.readFileSync(configPath, 'utf8'), configContent, 'config.yaml is untouched on disk');
+    assert.equal(fs.readFileSync(precious, 'utf8'), '# precious\n', 'nested vault intact on the delete-failure path');
+
+    // ── A subsequent REAL retry (stub lifted) completes and keeps the nested vault. ──
+    await runUninstall(['--yes']);
+    assert.equal(
+      fs.readFileSync(precious, 'utf8'),
+      '# precious\n',
+      'the nested vault survives the retry after the delete-failure abort'
+    );
+    assert.equal(fs.existsSync(core), true, 'core kept — it still holds the nested vault');
+  } finally {
+    fs.rmSync = origRmSync;
+    for (const k of Object.keys(env)) delete process.env[k];
+    Object.assign(process.env, savedEnv);
+  }
+});
+
+test('deferred config re-verify (TOCTOU): a config.yaml edited DURING the sweep is PRESERVED, not deleted', async () => {
+  const { core, env } = tempEnv();
+  run(['init', '--yes'], env);
+  const configPath = path.join(core, 'config.yaml');
+
+  const manifestLib = require('../../src/core/manifest');
+  const { run: runUninstall } = require('../../src/cli/uninstall');
+  const origDispose = manifestLib.disposeCoreMechanics;
+  const savedEnv = { ...process.env };
+  Object.assign(process.env, env);
+  // Capture the keep-notice emitted at the delete site.
+  const origErrWrite = process.stderr.write.bind(process.stderr);
+  let errOut = '';
+  const editedContent = 'user edited config DURING uninstall\n';
+  let calls = 0;
+  // reverse() proves config unmodified and defers it. The FIRST disposeCoreMechanics
+  // runs BETWEEN reverse() and the deferred config delete — the exact TOCTOU window.
+  // Mutate config there to simulate the user editing it mid-uninstall, then delegate
+  // to the real sweep.
+  manifestLib.disposeCoreMechanics = (p, opts) => {
+    calls += 1;
+    if (calls === 1) fs.writeFileSync(configPath, editedContent);
+    return origDispose(p, opts);
+  };
+  process.stderr.write = (chunk) => {
+    errOut += chunk;
+    return true;
+  };
+  try {
+    await runUninstall(['--yes']);
+  } finally {
+    manifestLib.disposeCoreMechanics = origDispose;
+    process.stderr.write = origErrWrite;
+    for (const k of Object.keys(env)) delete process.env[k];
+    Object.assign(process.env, savedEnv);
+  }
+  // The re-verify at the delete site sees the mismatched hash → PRESERVE. The user's
+  // mid-uninstall edit survives byte-identical; it is NOT deleted.
+  assert.equal(fs.existsSync(configPath), true, 'the edited config is preserved, not deleted');
+  assert.equal(fs.readFileSync(configPath, 'utf8'), editedContent, 'the user edit survives byte-identical');
+  assert.match(errOut, /keeping .*config\.yaml — modified since install/, 'a keep-notice is emitted at the delete site');
+  // A now-customized config keeps the core alive (core non-empty).
+  assert.equal(fs.existsSync(core), true, 'core kept — the edited config remains in it');
+});
+
 test('uninstall --yes with a symlinked core exits 0 and unlinks the link (target dir kept)', () => {
   const { root, env } = tempEnv();
   // The core path is a symlink to a real dir the user made themselves.


### PR DESCRIPTION
Spec: docs/specs/WP-088-manifest-reverse-crash-safety.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

Changed files: `src/core/manifest.js`, `src/cli/uninstall.js`, `tests/unit/manifest.test.js`, `tests/unit/uninstall.test.js` (+ the spec itself).

## What this does

- **Crash-safety (delete manifest last):** `reverse()` no longer deletes `install-manifest.json`. `uninstall.js` deletes it only after both `reverse()` and `disposeCoreMechanics()` succeed, then sweeps the emptied core via a second idempotent `disposeCoreMechanics()`. A crash during the mechanics sweep leaves a replayable recovery ledger.
- **reverse() never rmdirs the core:** core disposal belongs entirely to `uninstall.js`'s post-manifest step (delete manifest → `disposeCoreMechanics`). The `dir` reverser skips the entry that resolves to `paths.core`, so a deferred manifest can never trigger `ENOTEMPTY` — on the happy path or on a retry-after-partial-sweep.
- **Generalized hash-guard:** the config-only `sha256File` mismatch-preservation now applies to every `kind:'file'` entry that carries a `hash`; un-hashed shims/hook scripts unchanged.
- **Contained recursive-tree removals:** `reverseVendoredTree` deletes only a target resolving EQUAL to `paths.core/app`; `reverseCopiedSkill` deletes only a strict child of a harness skills root (`sameResolvedDir(parent, root)`), `wienerdog-*` named, whose on-disk tree still fingerprints (WP-089 `hashDir`) to `entry.hash` — else preserved.
- One local `sameResolvedDir` helper; **no new import** to `manifest.js` (preserves the WP-091 assumption); `hashDir` reused, not redefined.

## Verification output

```
$ npm test -- --test-name-pattern "manifest|uninstall"
ℹ tests 75   ℹ pass 75   ℹ fail 0   ℹ skipped 0

$ npm test
ℹ tests 691   ℹ pass 690   ℹ fail 0   ℹ skipped 1   ℹ todo 0   (~37s)

$ npm run lint
--- markdownlint --- Summary: 0 error(s)
--- shellcheck ---
--- PSScriptAnalyzer ---
--- frontmatter check --- passed: 15 spec(s), 4 agent(s)
lint passed
```
(The single skip is a platform-gated POSIX raw-byte/FIFO hashDir test, unrelated.) Also drove the real CLI end-to-end: `init --yes` → `uninstall --yes` prints "Wienerdog is fully removed", core gone.

## Decisions made

- **reverse() must never `rmdirSync(paths.core)` (Codex P1 fix, spec amended 2026-07-13).** With the manifest deferred, `removedSet`'s seed makes the core look virtually empty once its other entries are reversed, so the `dir` branch would `rmdirSync(paths.core)` while the ledger is still physically present → `ENOTEMPTY`. On a **retry after a partial mechanics sweep** (`state/` already gone, tracked files already gone) the core is genuinely virtually-empty and the throw happens *before* manifest deletion/disposal — wedging every retry permanently. Fix: the `dir` reverser skips the entry resolving to `paths.core` (`entry.path === paths.core || sameResolvedDir(...)`), leaving core disposal entirely to `uninstall.js`. The spec's "do not touch the dir reverser" constraint was lifted for exactly this case (orchestrator-authorized) and the Exact Contract now specifies it. New regression test: `reverse never rmdirs the core even when it is virtually empty (retry-after-partial-sweep wedge guard)`. `--dry-run` still lists the core (printed by `uninstall.js`, not from `reverse()`).
- **Skipped-summary fix (earlier review):** `reverse()`'s `skipped` array carries `<core>`/`<core>/state`; the CLI now filters the *printed* skipped set to items still existing after the final sweep, so a clean uninstall never contradicts "fully removed". `reverse()`'s `skipped` RETURN value is unchanged.
- **Test helper `makeInstall` plants an untracked `state/scheduler-status.json`** (mirroring real init/sync). Pre-existing assertions that "reverse() alone removes the core" were updated to "reverse() leaves the manifest + core", with full removal asserted in the uninstall integration tests.
- Copied-skill/vendored-tree "already gone" fixtures re-anchored to real harness skills roots / the app root.

## Discovered issues (out of scope, not fixed)

- None outstanding. (The retry-wedge previously flagged here as a latent follow-up was traced by Codex to a permanent wedge and is now fixed in this PR, per above.)

---
Generated-by: claude-opus-4-8
