### PR TITLE
fix(adapters): full-line managed-block anchoring, fail-closed on ambiguity (WP-091)

### DIFF
--- a/docs/specs/WP-091-managed-block-line-anchoring.md
+++ b/docs/specs/WP-091-managed-block-line-anchoring.md
@@ -1,7 +1,7 @@
 ---
 id: WP-091
 title: Anchor managed-block sentinels to full lines and fail closed on ambiguous markers
-status: Draft
+status: In-Review
 model: opus
 size: M
 depends_on: [WP-088, WP-090]

--- a/src/adapters/shared.js
+++ b/src/adapters/shared.js
@@ -3,9 +3,40 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { hashDir } = require('../core/manifest');
+const { WienerdogError } = require('../core/errors');
 
 const BEGIN = '<!-- wienerdog:begin -->';
 const END = '<!-- wienerdog:end -->';
+
+/** Locate the SINGLE managed block by FULL-LINE sentinel match (a line whose
+ *  trimmed content equals the sentinel). Returns {begin, end} character offsets
+ *  where `begin` = start of the BEGIN line and `end` = position just past the END
+ *  sentinel text on its line (matching the historical slice offsets), OR null when
+ *  no sentinel line exists. Throws WienerdogError when the markers are AMBIGUOUS:
+ *  more than one BEGIN or END line, or an END line before the BEGIN line, or exactly
+ *  one of the two present — refuse to edit rather than guess and swallow user text.
+ *  @param {string} content @param {string} what  file path, for the error message
+ *  @returns {{begin:number, end:number}|null} */
+function locateManagedBlock(content, what) {
+  const lines = content.split('\n');
+  const starts = []; let off = 0;
+  for (const l of lines) { starts.push(off); off += l.length + 1; }
+  const begins = []; const ends = [];
+  for (let i = 0; i < lines.length; i++) {
+    const t = lines[i].trim();
+    if (t === BEGIN) begins.push(i);
+    else if (t === END) ends.push(i);
+  }
+  if (begins.length === 0 && ends.length === 0) return null;
+  if (begins.length !== 1 || ends.length !== 1 || ends[0] < begins[0]) {
+    throw new WienerdogError(`ambiguous wienerdog managed-block markers in ${what} — refusing to edit (resolve by hand)`);
+  }
+  const b = begins[0], e = ends[0];
+  // `end` = right after the END sentinel text on its line (excludes trailing \n),
+  // matching the historical `indexOf(END) + END.length` for a clean written block.
+  const end = starts[e] + lines[e].indexOf(END) + END.length;
+  return { begin: starts[b], end };
+}
 
 /**
  * Record a manifest entry only if one with the same kind+path is not already
@@ -40,12 +71,27 @@ function recordCopiedSkill(manifest, linkPath, hash) {
 }
 
 /**
- * Build the sentinel-delimited managed block from a digest string.
+ * Build the sentinel-delimited managed block from a digest string. Neutralize any
+ * digest LINE that trims exactly to a sentinel so the emitted block always has
+ * exactly ONE begin/end pair — otherwise a self-wedge: the next sync/uninstall
+ * would see two markers, hit the single-pair invariant, and fail closed on
+ * Wienerdog's own output. Only a full-line sentinel is touched (colon → space);
+ * inline mentions are already safe under full-line matching, and a normal digest
+ * is unchanged (golden output stays byte-identical).
  * @param {string} digest
- * @returns {string} begin sentinel + digest.trimEnd() + end sentinel, no trailing newline.
+ * @returns {string} begin sentinel + neutralized digest.trimEnd() + end sentinel, no trailing newline.
  */
 function buildBlock(digest) {
-  return `${BEGIN}\n${digest.trimEnd()}\n${END}`;
+  const safeDigest = digest
+    .split('\n')
+    .map((line) => {
+      const t = line.trim();
+      if (t === BEGIN) return line.replace(BEGIN, '<!-- wienerdog begin -->'); // colon → space: no longer a sentinel
+      if (t === END) return line.replace(END, '<!-- wienerdog end -->');
+      return line;
+    })
+    .join('\n');
+  return `${BEGIN}\n${safeDigest.trimEnd()}\n${END}`;
 }
 
 /**
@@ -78,12 +124,11 @@ function applyManagedBlock(mdPath, digest, dryRun, manifest, out) {
     return;
   }
 
-  const begin = current.indexOf(BEGIN);
-  const end = current.indexOf(END);
-  if (begin !== -1 && end !== -1 && end > begin) {
+  const span = locateManagedBlock(current, mdPath); // may throw on ambiguous markers
+  if (span) {
     // Replace everything from begin sentinel through end sentinel (inclusive).
-    const before = current.slice(0, begin);
-    const after = current.slice(end + END.length);
+    const before = current.slice(0, span.begin);
+    const after = current.slice(span.end);
     const next = `${before}${block}${after}`;
     if (next === current) {
       out.unchanged.push(mdPath);

--- a/src/core/manifest.js
+++ b/src/core/manifest.js
@@ -3,6 +3,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const crypto = require('node:crypto');
+const { WienerdogError } = require('./errors');
 
 /**
  * install-manifest.json shape:
@@ -41,6 +42,38 @@ const crypto = require('node:crypto');
 
 const BEGIN_SENTINEL = '<!-- wienerdog:begin -->';
 const END_SENTINEL = '<!-- wienerdog:end -->';
+
+/** Locate the SINGLE managed block by FULL-LINE sentinel match (a line whose
+ *  trimmed content equals the sentinel). Returns {begin, end} character offsets
+ *  where `begin` = start of the BEGIN line and `end` = position just past the END
+ *  sentinel text on its line (matching the historical slice offsets), OR null when
+ *  no sentinel line exists. Throws WienerdogError when the markers are AMBIGUOUS:
+ *  more than one BEGIN or END line, or an END line before the BEGIN line, or exactly
+ *  one of the two present — refuse to edit rather than guess and swallow user text.
+ *  Deliberately duplicated in src/adapters/shared.js — the two modules must not
+ *  cross-depend (manifest.js is core; adapters/ sits above it).
+ *  @param {string} content @param {string} what  file path, for the error message
+ *  @returns {{begin:number, end:number}|null} */
+function locateManagedBlock(content, what) {
+  const lines = content.split('\n');
+  const starts = []; let off = 0;
+  for (const l of lines) { starts.push(off); off += l.length + 1; }
+  const begins = []; const ends = [];
+  for (let i = 0; i < lines.length; i++) {
+    const t = lines[i].trim();
+    if (t === BEGIN_SENTINEL) begins.push(i);
+    else if (t === END_SENTINEL) ends.push(i);
+  }
+  if (begins.length === 0 && ends.length === 0) return null;
+  if (begins.length !== 1 || ends.length !== 1 || ends[0] < begins[0]) {
+    throw new WienerdogError(`ambiguous wienerdog managed-block markers in ${what} — refusing to edit (resolve by hand)`);
+  }
+  const b = begins[0], e = ends[0];
+  // `end` = right after the END sentinel text on its line (excludes trailing \n),
+  // matching the historical `indexOf(END) + END.length` for a clean written block.
+  const end = starts[e] + lines[e].indexOf(END_SENTINEL) + END_SENTINEL.length;
+  return { begin: starts[b], end };
+}
 
 /** @param {string} p @returns {boolean} */
 function isFile(p) {
@@ -145,15 +178,23 @@ function reverseManagedBlock(entry, dryRun, removed, skipped, removedSet) {
     skipped.push(entry.path);
     return;
   }
-  const begin = content.indexOf(BEGIN_SENTINEL);
-  const end = content.indexOf(END_SENTINEL);
-  if (begin === -1 || end === -1 || end < begin) {
+  let span;
+  try {
+    span = locateManagedBlock(content, entry.path); // may throw on ambiguity
+  } catch (err) {
+    // Ambiguous markers → do NOT guess and delete user text; skip this entry and
+    // keep the uninstall going (the reverse loop has no try/catch of its own).
+    process.stderr.write(`wienerdog: ${err.message}; leaving ${entry.path} in place\n`);
+    skipped.push(entry.path);
+    return;
+  }
+  if (span === null) {
     // User removed the block themselves — nothing to reverse.
     skipped.push(entry.path);
     return;
   }
-  let before = content.slice(0, begin);
-  let after = content.slice(end + END_SENTINEL.length);
+  let before = content.slice(0, span.begin);
+  let after = content.slice(span.end);
   // The forward step wrote '\n' + block + '\n' after the prior content's own
   // trailing newline: one newline forming the blank-line separator, one
   // terminating the end sentinel. Remove exactly those two characters along

--- a/tests/unit/claude-adapter.test.js
+++ b/tests/unit/claude-adapter.test.js
@@ -360,6 +360,97 @@ test('a user-relocated mid-file block uninstalls to exactly one blank line', () 
   );
 });
 
+// ── WP-091: full-line sentinel anchoring + single-block invariant (forward) ──
+
+test('WP-091 forward: an inline sentinel in prose is NOT a marker; only the real full-line block is edited', () => {
+  const { applyManagedBlock } = require('../../src/adapters/shared');
+  const paths = setup();
+  const mdPath = path.join(paths.claudeDir, 'CLAUDE.md');
+  const prose = 'Docs mention <!-- wienerdog:begin --> inline as an example.';
+  const original = `# Notes\n${prose}\n\n<!-- wienerdog:begin -->\nold body\n<!-- wienerdog:end -->\n`;
+  fs.writeFileSync(mdPath, original);
+  const out = { changed: [], unchanged: [], notices: [] };
+
+  applyManagedBlock(mdPath, 'new body', false, freshManifest(), out);
+  const content = fs.readFileSync(mdPath, 'utf8');
+  assert.ok(content.includes(prose), 'the inline mention is preserved verbatim');
+  assert.ok(content.includes('new body'), 'the real full-line block was updated');
+  assert.ok(!content.includes('old body'), 'the old block body was replaced');
+  assert.equal((content.match(/^<!-- wienerdog:begin -->$/gm) || []).length, 1, 'exactly one full-line begin');
+});
+
+test('WP-091 forward: duplicate/half-written/reversed markers FAIL CLOSED (WienerdogError, no write)', () => {
+  const { applyManagedBlock } = require('../../src/adapters/shared');
+  const { WienerdogError } = require('../../src/core/errors');
+  const paths = setup();
+  const mdPath = path.join(paths.claudeDir, 'CLAUDE.md');
+  const cases = {
+    'two begins': `<!-- wienerdog:begin -->\na\n<!-- wienerdog:end -->\n\n<!-- wienerdog:begin -->\nb\n<!-- wienerdog:end -->\n`,
+    'end before begin': `<!-- wienerdog:end -->\nx\n<!-- wienerdog:begin -->\n`,
+    'only a begin': `# notes\n<!-- wienerdog:begin -->\nhalf-written\n`,
+    'only an end': `# notes\n<!-- wienerdog:end -->\n`,
+  };
+  for (const [label, original] of Object.entries(cases)) {
+    fs.writeFileSync(mdPath, original);
+    const out = { changed: [], unchanged: [], notices: [] };
+    assert.throws(
+      () => applyManagedBlock(mdPath, 'new body', false, freshManifest(), out),
+      (err) => err instanceof WienerdogError && !(err instanceof ReferenceError),
+      `${label} must throw a WienerdogError (proves the ../core/errors import), not a ReferenceError`
+    );
+    assert.equal(fs.readFileSync(mdPath, 'utf8'), original, `${label}: the ambiguous file is left byte-identical`);
+  }
+});
+
+test('WP-091 forward: a user-authored line equal to a sentinel with no matching pair fails closed, never swallows content', () => {
+  const { applyManagedBlock } = require('../../src/adapters/shared');
+  const { WienerdogError } = require('../../src/core/errors');
+  const paths = setup();
+  const mdPath = path.join(paths.claudeDir, 'CLAUDE.md');
+  // The user happened to write a bare begin sentinel line in their own prose.
+  const original = `# My notes\n\n<!-- wienerdog:begin -->\n\nmore user text\n`;
+  fs.writeFileSync(mdPath, original);
+  const out = { changed: [], unchanged: [], notices: [] };
+  assert.throws(
+    () => applyManagedBlock(mdPath, 'digest', false, freshManifest(), out),
+    WienerdogError
+  );
+  assert.equal(fs.readFileSync(mdPath, 'utf8'), original, 'the user file is untouched');
+});
+
+test('WP-091 buildBlock neutralizes a digest line that trims exactly to a sentinel (single pair only)', () => {
+  const { buildBlock } = require('../../src/adapters/shared');
+  const digest = ['intro', '<!-- wienerdog:begin -->', 'middle', '   <!-- wienerdog:end -->  ', 'tail'].join('\n');
+  const block = buildBlock(digest);
+  const lines = block.split('\n');
+  assert.equal(lines.filter((l) => l.trim() === '<!-- wienerdog:begin -->').length, 1, 'only the wrapper begin remains');
+  assert.equal(lines.filter((l) => l.trim() === '<!-- wienerdog:end -->').length, 1, 'only the wrapper end remains');
+  assert.ok(block.includes('<!-- wienerdog begin -->'), 'the embedded begin was neutralized (colon → space)');
+  assert.ok(block.includes('<!-- wienerdog end -->'), 'the embedded end was neutralized (colon → space)');
+  // A normal digest (no full-line sentinel) is unchanged → golden output stays byte-identical.
+  assert.equal(buildBlock('a\nb\n'), '<!-- wienerdog:begin -->\na\nb\n<!-- wienerdog:end -->');
+});
+
+test('WP-091: a digest containing a full-line sentinel round-trips — the written block locates without hitting fail-closed', () => {
+  const { applyManagedBlock } = require('../../src/adapters/shared');
+  const paths = setup();
+  const mdPath = path.join(paths.claudeDir, 'CLAUDE.md');
+  const digest = ['line one', '<!-- wienerdog:begin -->', 'line two'].join('\n');
+  const manifest = freshManifest();
+  const out1 = { changed: [], unchanged: [], notices: [] };
+
+  applyManagedBlock(mdPath, digest, false, manifest, out1);
+  const written = fs.readFileSync(mdPath, 'utf8');
+  assert.equal((written.match(/^<!-- wienerdog:begin -->$/gm) || []).length, 1, 'exactly one begin line in the written file');
+  assert.equal((written.match(/^<!-- wienerdog:end -->$/gm) || []).length, 1, 'exactly one end line in the written file');
+
+  // A second apply must NOT throw (no self-wedge) and must be a no-op — proving
+  // locateManagedBlock found the single block in Wienerdog's own output.
+  const out2 = { changed: [], unchanged: [], notices: [] };
+  assert.doesNotThrow(() => applyManagedBlock(mdPath, digest, false, manifest, out2));
+  assert.ok(out2.unchanged.includes(mdPath), 'the second apply is unchanged (single-pair invariant self-consistent)');
+});
+
 test('uninstall reverses everything, keeping unrelated hooks and user content', () => {
   const paths = setup();
   const coreSkill = path.join(paths.core, 'skills', 'wienerdog-setup');

--- a/tests/unit/manifest.test.js
+++ b/tests/unit/manifest.test.js
@@ -826,6 +826,70 @@ test('disposeCoreMechanics on a symlinked core unlinks the link, keeps the targe
   assert.equal(fs.existsSync(linkCore), false, 'the symlink was unlinked, not rmdir-crashed');
 });
 
+// ── WP-091: reverse-side full-line anchoring + fail-closed (caught internally) ──
+
+test('WP-091 reverse: an inline sentinel in prose is NOT a marker; a real full-line block round-trips byte-identically', () => {
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  const md = path.join(paths.claudeDir, 'CLAUDE.md');
+  fs.mkdirSync(paths.claudeDir, { recursive: true });
+  const prose = 'See <!-- wienerdog:begin --> mentioned inline as an example.';
+  // The pre-existing user file (what a byte-identical round-trip must restore).
+  const original = `# notes\n${prose}\n\ntail\n`;
+  // The forward step appends exactly '\n\n' + block + '\n' after trimming trailing newlines.
+  const block = `${MB_BEGIN}\nbody\n${MB_END}`;
+  const withBlock = `${original.replace(/\n+$/, '')}\n\n${block}\n`;
+  fs.writeFileSync(md, withBlock);
+  manifestLib.record(manifest, { kind: 'managed-block', path: md, createdFile: false });
+  manifestLib.save(paths, manifest);
+  const reloaded = manifestLib.load(paths);
+
+  const { removed } = manifestLib.reverse(paths, reloaded, {});
+  assert.ok(removed.includes(md));
+  assert.equal(
+    fs.readFileSync(md, 'utf8'),
+    original,
+    'reverse strips ONLY the real full-line block; the inline mention is preserved byte-identically'
+  );
+});
+
+test('WP-091 reverse: an ambiguous managed-block entry is caught+skipped (WienerdogError, not ReferenceError) and uninstall CONTINUES', () => {
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  fs.mkdirSync(paths.claudeDir, { recursive: true });
+  // A user-owned file with TWO full-line begin markers → ambiguous.
+  const md = path.join(paths.claudeDir, 'CLAUDE.md');
+  const ambiguous = `# notes\n\n${MB_BEGIN}\na\n${MB_END}\n\n${MB_BEGIN}\nb\n${MB_END}\n`;
+  fs.writeFileSync(md, ambiguous);
+  manifestLib.record(manifest, { kind: 'managed-block', path: md, createdFile: false });
+  // Another removable entry recorded AFTER the block → reversed BEFORE it, so the
+  // ambiguity throw must not abort the loop before OR after it either way.
+  const extra = path.join(paths.core, 'notes.md');
+  fs.writeFileSync(extra, '# x\n');
+  manifestLib.record(manifest, { kind: 'file', path: extra });
+  manifestLib.save(paths, manifest);
+  const reloaded = manifestLib.load(paths);
+
+  // Capture stderr to prove the CAUGHT WienerdogError message was reported. A
+  // missing import would instead surface "WienerdogError is not defined" here.
+  const origWrite = process.stderr.write.bind(process.stderr);
+  let err = '';
+  process.stderr.write = (chunk) => { err += chunk; return true; };
+  let result;
+  try {
+    assert.doesNotThrow(() => { result = manifestLib.reverse(paths, reloaded, {}); },
+      'an ambiguous managed-block must NOT abort the whole uninstall');
+  } finally {
+    process.stderr.write = origWrite;
+  }
+  assert.match(err, /ambiguous wienerdog managed-block markers/, 'the caught WienerdogError message was written (not a ReferenceError)');
+  assert.doesNotMatch(err, /is not defined/, 'no ReferenceError leaked — WienerdogError is imported');
+  assert.ok(result.skipped.includes(md), 'the ambiguous file is skipped');
+  assert.equal(fs.readFileSync(md, 'utf8'), ambiguous, 'the ambiguous file is left byte-identical (no user content swallowed)');
+  assert.ok(result.removed.includes(extra), 'the OTHER removable entry is still reversed — the loop continued');
+  assert.equal(fs.existsSync(extra), false, 'uninstall did not abort');
+});
+
 test('disposeCoreMechanics dry-run changes nothing on disk', () => {
   const paths = tempPaths();
   fs.mkdirSync(paths.core, { recursive: true });


### PR DESCRIPTION
Spec: docs/specs/WP-091-managed-block-line-anchoring.md

Hardens the managed-block invariant (Threat T5 — never corrupt/swallow user content outside Wienerdog's markers). Previously `applyManagedBlock`/`reverseManagedBlock` paired the first `BEGIN`/`END` found *anywhere* via `indexOf`, so a sentinel-looking substring in user prose, or duplicated/half-written markers, could swallow user content. Now markers are matched on **full lines** with a **single-block invariant** that **fails closed** on ambiguity (duplicate, end-before-begin, half-written) in both the forward and reverse paths. `reverseManagedBlock` catches the ambiguity `WienerdogError` **internally** (skip + stderr notice + continue) so a malformed entry never aborts uninstall (the reverse loop has no per-entry try/catch). `buildBlock` neutralizes any digest line that trims exactly to a sentinel, so Wienerdog's own output can't self-wedge the invariant.

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table (`src/adapters/shared.js`, `src/core/manifest.js`, `tests/unit/claude-adapter.test.js`, `tests/unit/manifest.test.js`)
- [x] Spec status flipped to In-Review

## Verification output

```
npm test -- --test-name-pattern "managed|adapter|manifest|uninstall" : 85 pass / 0 fail
npm test                                                             : 709 pass / 0 fail / 1 skip (pre-existing POSIX-gated)
npm run lint                                                         : clean
node scripts/boundary-check.js                                       : exit 0
```

## Decisions made

- `locateManagedBlock` is duplicated in `shared.js` and `manifest.js` (not exported/shared) — deliberate, to avoid a cross-module dependency; each uses its own local sentinels.
- Reverse-ambiguity test asserts via the captured stderr message (the internal catch means the `WienerdogError` can't be asserted directly): matches the ambiguity message AND asserts absence of `is not defined`, together proving it's the caught `WienerdogError`, not a `ReferenceError`.

## Discovered issues (out of scope, not fixed)

- none. No collateral test breakage (the existing round-trip / relocated-block / global-guard managed-block tests all pass unchanged — byte-identical offsets confirmed).

---
Generated-by: claude-opus (implement) + claude-fable-5 (orchestrate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uxThuapovGTPsbyn86BAf
