### PR TITLE
fix(scheduler): XML-escape plist + quote/escape systemd ExecStart paths (WP-097)

### DIFF
--- a/docs/specs/WP-097-scheduler-generator-path-escaping.md
+++ b/docs/specs/WP-097-scheduler-generator-path-escaping.md
@@ -1,7 +1,7 @@
 ---
 id: WP-097
 title: XML-escape launchd plist values and quote systemd ExecStart paths so a special-character install path can't break registration
-status: Draft
+status: In-Review
 model: sonnet
 size: S
 depends_on: []

--- a/src/scheduler/generators.js
+++ b/src/scheduler/generators.js
@@ -85,6 +85,15 @@ function parseAt(at) {
   return { hour: Number(h), minute: Number(m) };
 }
 
+/** Escape a value for insertion into XML character data (plist <string>). Order
+ *  matters: & first. @param {string} s @returns {string} */
+function xmlEscape(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
 /**
  * Render a per-job launchd plist. All paths ABSOLUTE (no $HOME/~).
  * @param {{name:string, hour:number, minute:number, node:string, bin:string,
@@ -100,8 +109,8 @@ function launchdPlist(o) {
   <string>${launchdLabel(o.name)}</string>
   <key>ProgramArguments</key>
   <array>
-    <string>${o.node}</string>
-    <string>${o.bin}</string>
+    <string>${xmlEscape(o.node)}</string>
+    <string>${xmlEscape(o.bin)}</string>
     <string>run-job</string>
     <string>${o.name}</string>
   </array>
@@ -113,9 +122,9 @@ function launchdPlist(o) {
     <integer>${o.minute}</integer>
   </dict>
   <key>StandardOutPath</key>
-  <string>${path.join(o.logDir, 'launchd.out.log')}</string>
+  <string>${xmlEscape(path.join(o.logDir, 'launchd.out.log'))}</string>
   <key>StandardErrorPath</key>
-  <string>${path.join(o.logDir, 'launchd.err.log')}</string>
+  <string>${xmlEscape(path.join(o.logDir, 'launchd.err.log'))}</string>
   <key>ProcessType</key>
   <string>Background</string>
 </dict>
@@ -138,8 +147,8 @@ function catchupPlist(o) {
   <string>ai.wienerdog.catchup</string>
   <key>ProgramArguments</key>
   <array>
-    <string>${o.node}</string>
-    <string>${o.bin}</string>
+    <string>${xmlEscape(o.node)}</string>
+    <string>${xmlEscape(o.bin)}</string>
     <string>run-job</string>
     <string>--catch-up</string>
   </array>
@@ -151,9 +160,9 @@ function catchupPlist(o) {
     <integer>0</integer>
   </dict>
   <key>StandardOutPath</key>
-  <string>${path.join(o.logDir, 'launchd.out.log')}</string>
+  <string>${xmlEscape(path.join(o.logDir, 'launchd.out.log'))}</string>
   <key>StandardErrorPath</key>
-  <string>${path.join(o.logDir, 'launchd.err.log')}</string>
+  <string>${xmlEscape(path.join(o.logDir, 'launchd.err.log'))}</string>
   <key>ProcessType</key>
   <string>Background</string>
 </dict>
@@ -187,6 +196,14 @@ WantedBy=timers.target
 `;
 }
 
+/** Quote a path as a single systemd ExecStart argument: escape the systemd
+ *  specifier char (% → %%) so a literal % is not expanded, then double-quote,
+ *  escaping \ and ". Order: \ first (so added \" is not re-escaped), then %, then ".
+ *  @param {string} s @returns {string} */
+function systemdQuote(s) {
+  return `"${String(s).replace(/\\/g, '\\\\').replace(/%/g, '%%').replace(/"/g, '\\"')}"`;
+}
+
 /**
  * Render a systemd oneshot .service unit. All paths ABSOLUTE.
  * @param {{name:string, node:string, bin:string}} o
@@ -198,7 +215,7 @@ Description=Wienerdog job: ${o.name}
 
 [Service]
 Type=oneshot
-ExecStart=${o.node} ${o.bin} run-job ${o.name}
+ExecStart=${systemdQuote(o.node)} ${systemdQuote(o.bin)} run-job ${o.name}
 `;
 }
 
@@ -446,10 +463,12 @@ module.exports = {
   launchdLabel,
   systemdUnitBase,
   parseAt,
+  xmlEscape,
   launchdPlist,
   catchupPlist,
   systemdTimer,
   systemdService,
+  systemdQuote,
   windowsTaskName,
   windowsTasksDir,
   windowsTaskFileName,

--- a/tests/unit/scheduler-generators.test.js
+++ b/tests/unit/scheduler-generators.test.js
@@ -82,7 +82,7 @@ Description=Wienerdog job: daily-digest
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/node /opt/wienerdog/bin/wienerdog.js run-job daily-digest
+ExecStart="/usr/bin/node" "/opt/wienerdog/bin/wienerdog.js" run-job daily-digest
 `;
 
 const EXPECTED_DREAM = `<?xml version="1.0" encoding="UTF-16"?>
@@ -194,6 +194,89 @@ test('scheduler-generators: systemdTimer matches the golden byte-for-byte', () =
 });
 
 test('scheduler-generators: systemdService matches the golden byte-for-byte', () => {
+  assert.equal(
+    gen.systemdService({
+      name: 'daily-digest',
+      node: '/usr/bin/node',
+      bin: '/opt/wienerdog/bin/wienerdog.js',
+    }),
+    EXPECTED_SERVICE
+  );
+});
+
+test('scheduler-generators: xmlEscape escapes & < > in that order', () => {
+  assert.equal(gen.xmlEscape('a & b < c > d'), 'a &amp; b &lt; c &gt; d');
+  // a bare & must become &amp; and not be re-mangled by the later </> passes.
+  assert.equal(gen.xmlEscape('&<>'), '&amp;&lt;&gt;');
+});
+
+test('scheduler-generators: launchdPlist XML-escapes node/bin/logDir path values', () => {
+  const out = gen.launchdPlist({
+    name: 'daily-digest',
+    hour: 7,
+    minute: 0,
+    node: '/opt/a&b/node',
+    bin: '/opt/<wienerdog>/wienerdog.js',
+    logDir: '/var/log/a&b<c>d',
+  });
+  assert.match(out, /<string>\/opt\/a&amp;b\/node<\/string>/);
+  assert.match(out, /<string>\/opt\/&lt;wienerdog&gt;\/wienerdog\.js<\/string>/);
+  assert.match(out, /<string>\/var\/log\/a&amp;b&lt;c&gt;d\/launchd\.out\.log<\/string>/);
+  assert.match(out, /<string>\/var\/log\/a&amp;b&lt;c&gt;d\/launchd\.err\.log<\/string>/);
+  // well-formed: every & is part of a recognized entity, and no bare < or > remain
+  // outside of the plist's own tags (the interpolated values contain none).
+  assert.doesNotMatch(out, /&(?!amp;|lt;|gt;)/);
+});
+
+test('scheduler-generators: catchupPlist XML-escapes node/bin/logDir path values', () => {
+  const out = gen.catchupPlist({
+    node: '/opt/a&b/node',
+    bin: '/opt/<wienerdog>/wienerdog.js',
+    logDir: '/var/log/a&b<c>d',
+  });
+  assert.match(out, /<string>\/opt\/a&amp;b\/node<\/string>/);
+  assert.match(out, /<string>\/opt\/&lt;wienerdog&gt;\/wienerdog\.js<\/string>/);
+  assert.match(out, /<string>\/var\/log\/a&amp;b&lt;c&gt;d\/launchd\.out\.log<\/string>/);
+  assert.match(out, /<string>\/var\/log\/a&amp;b&lt;c&gt;d\/launchd\.err\.log<\/string>/);
+  assert.doesNotMatch(out, /&(?!amp;|lt;|gt;)/);
+});
+
+test('scheduler-generators: launchdPlist is byte-identical to the golden for a normal path (no special chars)', () => {
+  const out = gen.launchdPlist({
+    name: 'daily-digest',
+    hour: 7,
+    minute: 0,
+    node: '/usr/local/bin/node',
+    bin: '/opt/wienerdog/bin/wienerdog.js',
+    logDir: '/Users/ada/.wienerdog/logs/daily-digest',
+  });
+  assert.equal(out, EXPECTED_PLIST);
+});
+
+test('scheduler-generators: systemdQuote double-quotes and escapes \\, %, and " (order: \\ before ")', () => {
+  assert.equal(gen.systemdQuote('/opt/wienerdog/bin/wienerdog.js'), '"/opt/wienerdog/bin/wienerdog.js"');
+  assert.equal(gen.systemdQuote('/opt/with space/node'), '"/opt/with space/node"');
+  assert.equal(gen.systemdQuote('/opt/100%dir/node'), '"/opt/100%%dir/node"');
+  assert.equal(gen.systemdQuote('C:\\path\\node.exe'), '"C:\\\\path\\\\node.exe"');
+  assert.equal(gen.systemdQuote('/opt/"quoted"/node'), '"/opt/\\"quoted\\"/node"');
+  // kitchen sink: space + % + backslash + " all in one path.
+  const rawPath = '/opt/wien er/100%\\path"quote';
+  const expectedQuoted = '"/opt/wien er/100%%\\\\path\\"quote"';
+  assert.equal(gen.systemdQuote(rawPath), expectedQuoted);
+});
+
+test('scheduler-generators: systemdService quotes ExecStart paths and escapes %, \\, ", and spaces', () => {
+  const node = '/opt/with space/100%node\\path"x';
+  const bin = '/opt/wienerdog/bin/wienerdog.js';
+  const out = gen.systemdService({ name: 'daily-digest', node, bin });
+  const expectedExecStart = `ExecStart=${gen.systemdQuote(node)} ${gen.systemdQuote(bin)} run-job daily-digest`;
+  assert.ok(out.includes(expectedExecStart), out);
+  // the literal % must render doubled (%%), never a bare specifier-expandable %.
+  assert.match(out, /100%%node/);
+  assert.doesNotMatch(out, /100%node/);
+});
+
+test('scheduler-generators: systemdService ExecStart matches the golden (quoted form) for a normal path', () => {
   assert.equal(
     gen.systemdService({
       name: 'daily-digest',


### PR DESCRIPTION
Spec: docs/specs/WP-097-scheduler-generator-path-escaping.md

Scheduler generators interpolated node/bin/log paths into launchd plist XML and systemd `ExecStart` without escaping, so an install path containing `&`/`<`/`>` broke the plist and a path with a space or a systemd `%` specifier corrupted `ExecStart`. Adds `xmlEscape` (launchd/catchup plist values) and `systemdQuote` (escapes `\`→`\\`, `%`→`%%`, `"`→`\"` in order, then wraps in quotes) so `%` specifier expansion can't alter a `%`-bearing path even inside quoted `ExecStart`.

## Deliverables checklist
- [x] Every changed file is listed in the spec's Deliverables table (`src/scheduler/generators.js`, `tests/unit/scheduler-generators.test.js`)
- [x] Spec status flipped to In-Review

## Verification output
```
npm test : 716 pass / 0 fail / 1 skip (pre-existing)
npm run lint : clean
node scripts/boundary-check.js : exit 0
```

## Decisions made
- XML well-formedness asserted via regex (`&(?!amp;|lt;|gt;)`) rather than adding an XML parser (zero-dep policy).

## Discovered issues (out of scope, not fixed)
- none.

---
Generated-by: claude-sonnet (implement) + claude-fable-5 (orchestrate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uxThuapovGTPsbyn86BAf
