### PR TITLE
fix(alerts): bound + sanitize alerts.jsonl (byte/count budgets, TOCTOU-safe read) (WP-096)

### DIFF
--- a/docs/specs/WP-096-alerts-bounded-schema-capped.md
+++ b/docs/specs/WP-096-alerts-bounded-schema-capped.md
@@ -1,7 +1,7 @@
 ---
 id: WP-096
 title: Bound alerts.jsonl growth and cap alert field sizes so the durable-failure log can't grow or corrupt unboundedly
-status: Draft
+status: In-Review
 model: sonnet
 size: S
 depends_on: []
@@ -299,6 +299,16 @@ npm run lint
   heavier than warranted; in practice the dream lock serializes the dream and each
   job clears only its own alerts. Note it as an accepted residual under "Decisions
   made".
+- **Compaction concurrent-writer residual (accepted):** the compaction step's
+  read-rewrite-rename shares the accepted concurrent-writer residual — a compaction
+  rewrite by one `run-job` can drop a record a DIFFERENT `run-job` appended in the
+  same window (once `MAX_ALERTS`/`MAX_FILE_BYTES` is reached, every append takes this
+  path). Full cross-process locking is deliberately OUT OF SCOPE for a files-only /
+  no-daemon product (ADR-0004), and `run-job` overlap is rare. Mitigation: each writer
+  appends its OWN record ATOMICALLY (`fs.appendFileSync`, O_APPEND — atomic for a
+  single small line) BEFORE the compaction rewrite, so the appending process never
+  loses its own fail-loud alert; only a concurrently-appended OTHER record can be lost.
+  This matches the wd-reviewer's note that concurrency is spec-accepted.
 - Changing the digest alert renderer (a different module) or the alert record shape
   produced by `run-job.js`.
 

--- a/src/core/alerts.js
+++ b/src/core/alerts.js
@@ -10,34 +10,160 @@ const path = require('node:path');
 
 const ALERTS_FILE = 'alerts.jsonl';
 
+const MAX_ALERTS = 200; // keep only the most-recent N records
+const MAX_FIELD_CHARS = 2000; // cap each string field (control-plane text, not prose)
+const MAX_FILE_BYTES = 512 * 1024; // hard byte bound on the log file / the read
+
 /** @param {import('./paths').WienerdogPaths} paths @returns {string} */
 function alertsPath(paths) {
   return path.join(paths.state, ALERTS_FILE);
 }
 
+/** Coerce a record to the known string fields, each length-capped. Requires a
+ *  non-null, non-array OBJECT — any other value (null, number, string, array) is
+ *  treated as an empty object, so a valid-JSON primitive can't crash the deref.
+ *  Drops unknown keys; missing fields become ''.
+ *  @param {*} r @returns {{job:string, at:string, reason:string, log_hint:string}} */
+function sanitizeAlert(r) {
+  const o = r && typeof r === 'object' && !Array.isArray(r) ? r : {};
+  const cap = (v) => String(v == null ? '' : v).slice(0, MAX_FIELD_CHARS);
+  return { job: cap(o.job), at: cap(o.at), reason: cap(o.reason), log_hint: cap(o.log_hint) };
+}
+
 /** Append one unresolved failure alert (atomic append; creates state/ if needed).
+ *  Compacts to `MAX_ALERTS` records / `MAX_FILE_BYTES` bytes when either bound
+ *  is exceeded after the append.
  *  @param {import('./paths').WienerdogPaths} paths
  *  @param {{job:string, at:string, reason:string, log_hint:string}} record */
 function appendAlert(paths, record) {
   fs.mkdirSync(paths.state, { recursive: true });
-  fs.appendFileSync(alertsPath(paths), `${JSON.stringify(record)}\n`);
+  const file = alertsPath(paths);
+  // Separator guard: if the existing file does NOT end in a newline (e.g. a
+  // truncated/oversized malformed tail with no terminator), a bare append would FUSE
+  // the new record onto that malformed line. The oversized-tail reader then drops
+  // through the first newline — which would be the one appended AFTER the new record —
+  // discarding the newest fail-loud alert. Prefix a '\n' so the new record is always
+  // its own complete line and survives the tail read + compaction.
+  let sep = '';
+  try {
+    const st = fs.statSync(file);
+    if (st.size > 0) {
+      const fd = fs.openSync(file, 'r');
+      try {
+        const last = Buffer.alloc(1);
+        const n = fs.readSync(fd, last, 0, 1, st.size - 1);
+        if (n === 1 && last[0] !== 0x0a) sep = '\n'; // 0x0A = '\n'
+      } finally {
+        fs.closeSync(fd);
+      }
+    }
+  } catch {
+    /* no existing file (or unreadable) → no separator needed */
+  }
+  // Concurrency mitigation (see spec Residuals): append the new record ATOMICALLY
+  // (O_APPEND, atomic for a single small line) BEFORE the read-rewrite-rename
+  // compaction below. This guarantees THIS process's own alert is durably on disk
+  // even if a concurrent run-job's compaction rewrites the file in the same window —
+  // the appending writer never loses its own fail-loud record. (A compaction by one
+  // run-job can still drop a record a DIFFERENT run-job appended in the same window;
+  // that residual is accepted — full cross-process locking is out of scope per ADR-0004.)
+  fs.appendFileSync(file, `${sep}${JSON.stringify(sanitizeAlert(record))}\n`);
+  let size = 0;
+  try {
+    size = fs.statSync(file).size;
+  } catch {
+    size = 0;
+  }
+  const all = readAlerts(paths); // sanitized, byte-bounded read
+  // Empty-read guard: we JUST appended a valid record atomically, so a correct read
+  // back can never be empty. `all.length === 0` therefore means the read FAILED
+  // (readAlerts now returns [] on any fstat/read error — e.g. an appendable-but-
+  // unreadable mode-0200 file, or a transient I/O error). Rewriting the file from an
+  // empty snapshot would serialize "\n" and rename it over the log, SILENTLY DELETING
+  // the alert we just appended (and any prior ones). Skip compaction and leave the
+  // atomically-appended file intact — fail-loud durability is preserved.
+  if (all.length === 0) return;
+  if (all.length > MAX_ALERTS || size > MAX_FILE_BYTES) {
+    // Count budget first, then byte budget: drop the oldest until BOTH hold.
+    let kept = all.slice(Math.max(0, all.length - MAX_ALERTS)); // newest N (append order = chronological)
+    const serialize = (rows) => rows.map((a) => JSON.stringify(a)).join('\n') + '\n';
+    let text = serialize(kept);
+    // Keep at least the just-appended newest record; one sanitized record is always
+    // well under MAX_FILE_BYTES (4 fields × MAX_FIELD_CHARS ≈ 8 KiB + JSON overhead).
+    while (kept.length > 1 && Buffer.byteLength(text) > MAX_FILE_BYTES) {
+      kept = kept.slice(1); // drop oldest
+      text = serialize(kept);
+    }
+    const tmp = `${file}.${process.pid}.tmp`;
+    fs.writeFileSync(tmp, text);
+    fs.renameSync(tmp, file); // atomic replace (mirrors clearAlerts)
+  }
 }
 
 /** All unresolved alerts, oldest first. Missing file → []; malformed lines skipped.
+ *  Byte-bounds its read (tail window of `MAX_FILE_BYTES` for oversized files) and
+ *  sanitizes every parsed line so no unbounded/primitive record reaches callers.
  *  @param {import('./paths').WienerdogPaths} paths
  *  @returns {Array<{job:string, at:string, reason:string, log_hint:string}>} */
 function readAlerts(paths) {
-  let text;
+  const file = alertsPath(paths);
+  let fd;
   try {
-    text = fs.readFileSync(alertsPath(paths), 'utf8');
+    fd = fs.openSync(file, 'r');
   } catch {
     return [];
+  }
+  let text;
+  try {
+    // fstat/read can still fail AFTER a successful open (e.g. alerts.jsonl is a
+    // directory → EISDIR on read, or a transient I/O error). Treat any such failure
+    // like a missing/unreadable file: return [] rather than crash digest generation.
+    const st = fs.fstatSync(fd); // stat the OPEN fd — no stat→read TOCTOU
+    if (st.size > MAX_FILE_BYTES) {
+      // Read the trailing MAX_FILE_BYTES (newest records) PLUS one preceding byte, so
+      // we can tell whether the window began exactly on a line boundary. Bounds memory
+      // even for a pathologically oversized file (fixed buffer).
+      const readStart = st.size - MAX_FILE_BYTES - 1; // >= 0 since st.size > MAX_FILE_BYTES
+      const len = st.size - readStart;
+      const buf = Buffer.alloc(len);
+      let off = 0;
+      while (off < len) {
+        const n = fs.readSync(fd, buf, off, len - off, readStart + off);
+        if (n === 0) break;
+        off += n;
+      }
+      // Compare the RAW preceding byte (0x0A = '\n'); '\n' never appears inside a
+      // multi-byte UTF-8 sequence, so a byte compare is safe even if the window split
+      // a character. If the preceding byte is a newline, the window starts on a line
+      // boundary → the first line is COMPLETE, keep it. Otherwise it is a partial →
+      // drop through the first newline.
+      const precedingIsNewline = buf[0] === 0x0a;
+      let raw = buf.subarray(1, off).toString('utf8'); // decode from after the preceding byte
+      if (!precedingIsNewline) {
+        const nl = raw.indexOf('\n');
+        raw = nl === -1 ? '' : raw.slice(nl + 1);
+      }
+      text = raw;
+    } else {
+      const buf = Buffer.alloc(st.size);
+      let off = 0;
+      while (off < st.size) {
+        const n = fs.readSync(fd, buf, off, st.size - off, off);
+        if (n === 0) break;
+        off += n;
+      }
+      text = buf.subarray(0, off).toString('utf8');
+    }
+  } catch {
+    return []; // fstat/read error after open → resilient empty result (finally still closes fd)
+  } finally {
+    fs.closeSync(fd);
   }
   const out = [];
   for (const line of text.split('\n')) {
     if (line.trim() === '') continue;
     try {
-      out.push(JSON.parse(line));
+      out.push(sanitizeAlert(JSON.parse(line)));
     } catch {
       /* skip malformed */
     }
@@ -60,4 +186,12 @@ function clearAlerts(paths, job) {
   fs.renameSync(tmp, file);
 }
 
-module.exports = { appendAlert, readAlerts, clearAlerts, ALERTS_FILE };
+module.exports = {
+  appendAlert,
+  readAlerts,
+  clearAlerts,
+  ALERTS_FILE,
+  MAX_ALERTS,
+  MAX_FIELD_CHARS,
+  MAX_FILE_BYTES,
+};

--- a/tests/unit/alerts.test.js
+++ b/tests/unit/alerts.test.js
@@ -7,7 +7,15 @@ const os = require('node:os');
 const path = require('node:path');
 
 const { getPaths } = require('../../src/core/paths');
-const { appendAlert, readAlerts, clearAlerts, ALERTS_FILE } = require('../../src/core/alerts');
+const {
+  appendAlert,
+  readAlerts,
+  clearAlerts,
+  ALERTS_FILE,
+  MAX_ALERTS,
+  MAX_FIELD_CHARS,
+  MAX_FILE_BYTES,
+} = require('../../src/core/alerts');
 const { renderDigest } = require('../../src/core/digest');
 
 /** Isolated temp core; state/ is created lazily by appendAlert. */
@@ -87,6 +95,221 @@ test('alerts: clearAlerts removes only that job and deletes the file when empty'
 
   // Clearing a job with no alerts / a missing file is a no-op that never throws.
   assert.doesNotThrow(() => clearAlerts(paths, 'ghost'));
+});
+
+// -------------------------------------------------------------------------
+// bound + schema-cap (WP-096)
+// -------------------------------------------------------------------------
+
+test('alerts: appending past MAX_ALERTS keeps only the newest N, in chronological order', () => {
+  const { paths } = setup();
+  const total = MAX_ALERTS + 5;
+  for (let i = 0; i < total; i += 1) {
+    appendAlert(paths, rec('dream', `2026-01-01T00:00:${String(i).padStart(4, '0')}Z`, `failure ${i}`));
+  }
+  const got = readAlerts(paths);
+  assert.equal(got.length, MAX_ALERTS, 'exactly MAX_ALERTS retained');
+  assert.equal(got[0].reason, 'failure 5', 'oldest surviving record is the 6th appended (0-indexed 5)');
+  assert.equal(got[got.length - 1].reason, `failure ${total - 1}`, 'newest record retained');
+  const ats = got.map((a) => a.at);
+  const sorted = [...ats].sort();
+  assert.deepEqual(ats, sorted, 'chronological order preserved');
+});
+
+test('alerts: a field longer than MAX_FIELD_CHARS is stored/returned truncated', () => {
+  const { paths } = setup();
+  const longReason = 'r'.repeat(MAX_FIELD_CHARS + 500);
+  appendAlert(paths, rec('dream', '2026-07-04T01:00:00.000Z', longReason));
+  const got = readAlerts(paths);
+  assert.equal(got.length, 1);
+  assert.equal(got[0].reason.length, MAX_FIELD_CHARS);
+  assert.equal(got[0].reason, longReason.slice(0, MAX_FIELD_CHARS));
+});
+
+test('alerts: unknown keys are dropped and missing fields read back as empty string', () => {
+  const { paths } = setup();
+  fs.mkdirSync(paths.state, { recursive: true });
+  const file = path.join(paths.state, ALERTS_FILE);
+  fs.writeFileSync(file, `${JSON.stringify({ job: 'dream', extra: 'nope' })}\n`);
+  const got = readAlerts(paths);
+  assert.equal(got.length, 1);
+  assert.deepEqual(got[0], { job: 'dream', at: '', reason: '', log_hint: '' });
+});
+
+test('alerts: a valid-JSON primitive line does not crash and reads back as an empty-fields record', () => {
+  const { paths } = setup();
+  fs.mkdirSync(paths.state, { recursive: true });
+  const file = path.join(paths.state, ALERTS_FILE);
+  fs.writeFileSync(file, ['null', '42', '"x"', '[]'].join('\n') + '\n');
+  const got = readAlerts(paths);
+  assert.equal(got.length, 4, 'all four primitive lines parse without throwing');
+  for (const a of got) {
+    assert.deepEqual(a, { job: '', at: '', reason: '', log_hint: '' });
+  }
+});
+
+test('alerts: a huge malformed line is compacted away on the next append (byte bound)', () => {
+  const { paths } = setup();
+  fs.mkdirSync(paths.state, { recursive: true });
+  const file = path.join(paths.state, ALERTS_FILE);
+  const garbage = 'x'.repeat(MAX_FILE_BYTES + 1000); // not valid JSON, terminated
+  fs.writeFileSync(file, `${garbage}\n`);
+  assert.ok(fs.statSync(file).size > MAX_FILE_BYTES, 'precondition: file already over the byte bound');
+
+  appendAlert(paths, rec('dream', '2026-07-04T01:00:00.000Z', 'fresh failure'));
+
+  const size = fs.statSync(file).size;
+  assert.ok(size <= MAX_FILE_BYTES, 'file compacted back under the byte bound');
+  const got = readAlerts(paths);
+  assert.equal(got.length, 1, 'the malformed line is gone; only the just-appended record remains');
+  assert.equal(got[0].reason, 'fresh failure');
+});
+
+test('alerts: appending onto an oversized malformed UNTERMINATED tail survives and is the single retained record', () => {
+  const { paths } = setup();
+  fs.mkdirSync(paths.state, { recursive: true });
+  const file = path.join(paths.state, ALERTS_FILE);
+  const garbage = 'x'.repeat(MAX_FILE_BYTES + 1000); // no trailing newline
+  fs.writeFileSync(file, garbage);
+  assert.ok(fs.statSync(file).size > MAX_FILE_BYTES, 'precondition: file already over the byte bound');
+  assert.notEqual(fs.readFileSync(file, 'utf8').slice(-1), '\n', 'precondition: unterminated');
+
+  appendAlert(paths, rec('dream', '2026-07-04T02:00:00.000Z', 'newest survives'));
+
+  const got = readAlerts(paths);
+  assert.equal(got.length, 1, 'the just-appended alert is the single retained record');
+  assert.equal(got[0].reason, 'newest survives');
+  assert.ok(fs.statSync(file).size <= MAX_FILE_BYTES);
+});
+
+test('alerts: large-field records drive bytes over MAX_FILE_BYTES; compaction keeps fewer than MAX_ALERTS and stays within MAX_FILE_BYTES', () => {
+  const { paths } = setup();
+  const bigField = 'y'.repeat(MAX_FIELD_CHARS - 20);
+  const count = 100; // 100 * ~6KB records (job/reason/log_hint all near MAX_FIELD_CHARS) ≈ 600KB, over the 512KB bound, well under MAX_ALERTS
+  for (let i = 0; i < count; i += 1) {
+    appendAlert(paths, {
+      job: bigField,
+      at: `2026-07-04T${String(i).padStart(3, '0')}:00:00.000Z`,
+      reason: bigField,
+      log_hint: bigField,
+    });
+  }
+  const file = path.join(paths.state, ALERTS_FILE);
+  const size = fs.statSync(file).size;
+  assert.ok(size <= MAX_FILE_BYTES, 'rewritten file never exceeds MAX_FILE_BYTES');
+  const got = readAlerts(paths);
+  assert.ok(got.length < count, 'some older large-field records were dropped');
+  assert.ok(got.length < MAX_ALERTS, 'byte budget bites well before the count budget');
+  assert.equal(got[got.length - 1].at, `2026-07-04T${String(count - 1).padStart(3, '0')}:00:00.000Z`, 'newest record retained');
+});
+
+test('alerts: readAlerts tail window beginning exactly on a line boundary keeps the first complete record', () => {
+  const { paths } = setup();
+  fs.mkdirSync(paths.state, { recursive: true });
+  const file = path.join(paths.state, ALERTS_FILE);
+
+  // Build N fixed-length lines (each exactly LINE_LEN bytes including its trailing
+  // newline) such that LINE_LEN divides MAX_FILE_BYTES. Then any file made of these
+  // lines whose total size exceeds MAX_FILE_BYTES puts the tail-read boundary exactly
+  // on a newline — precedingIsNewline is true, and the first line inside the window
+  // is a complete record that must be kept.
+  const LINE_LEN = 1024;
+  assert.equal(MAX_FILE_BYTES % LINE_LEN, 0, 'LINE_LEN must divide MAX_FILE_BYTES for this construction');
+  const base = JSON.stringify({ job: 'j', at: '000', reason: '', log_hint: 'h' });
+  const padLen = LINE_LEN - 1 - base.length; // -1 for the trailing '\n'
+  const lineFor = (i) =>
+    JSON.stringify({ job: 'j', at: String(i).padStart(3, '0'), reason: 'x'.repeat(padLen), log_hint: 'h' }) + '\n';
+
+  const windowLines = MAX_FILE_BYTES / LINE_LEN; // 512
+  const total = windowLines + 1; // 513: guarantees size > MAX_FILE_BYTES and boundary alignment
+  let content = '';
+  for (let i = 0; i < total; i += 1) {
+    const line = lineFor(i);
+    assert.equal(Buffer.byteLength(line), LINE_LEN, 'sanity: every line is exactly LINE_LEN bytes');
+    content += line;
+  }
+  fs.writeFileSync(file, content);
+  assert.ok(fs.statSync(file).size > MAX_FILE_BYTES, 'precondition: oversized file');
+
+  const got = readAlerts(paths);
+  assert.equal(got.length, windowLines, 'the whole aligned window of complete records is kept');
+  assert.equal(got[0].at, '001', 'first complete record in the window (line index 1) is kept, not dropped');
+  assert.equal(got[got.length - 1].at, String(total - 1).padStart(3, '0'), 'last line kept');
+});
+
+test('alerts: readAlerts returns [] and does not throw when alerts.jsonl is a directory (fstat/read error after open)', () => {
+  const { paths } = setup();
+  fs.mkdirSync(paths.state, { recursive: true });
+  // Create alerts.jsonl AS A DIRECTORY: openSync('r') succeeds on a dir, but the
+  // subsequent fstat-driven readSync throws EISDIR. The read logic must catch that
+  // and return [] (resilient), not crash digest generation.
+  fs.mkdirSync(path.join(paths.state, ALERTS_FILE), { recursive: true });
+  let got;
+  assert.doesNotThrow(() => {
+    got = readAlerts(paths);
+  }, 'a read error after a successful open must not escape');
+  assert.deepEqual(got, [], 'unreadable path → []');
+});
+
+test('alerts: atomic-append ordering keeps the appending process\'s own record after compaction (concurrency mitigation)', () => {
+  const { paths } = setup();
+  // Fill to the count bound so the NEXT append takes the compaction (read-rewrite-rename)
+  // path. Because the record is appended atomically BEFORE the compaction rewrite, the
+  // just-appended record must be present (and newest) after append-then-compact.
+  for (let i = 0; i < MAX_ALERTS; i += 1) {
+    appendAlert(paths, rec('dream', `2026-01-01T00:00:${String(i).padStart(4, '0')}Z`, `old ${i}`));
+  }
+  appendAlert(paths, rec('digest', '2026-02-02T00:00:00.000Z', 'the newest failure'));
+  const got = readAlerts(paths);
+  assert.equal(got.length, MAX_ALERTS, 'compaction ran (still capped at MAX_ALERTS)');
+  const newest = got[got.length - 1];
+  assert.equal(newest.job, 'digest', "the appending process's own record survives compaction");
+  assert.equal(newest.reason, 'the newest failure');
+  assert.ok(
+    got.some((a) => a.job === 'digest' && a.reason === 'the newest failure'),
+    'newest record present in the rewritten file'
+  );
+});
+
+test('alerts: appendAlert does NOT empty the log when the post-append read-back fails (empty-read guard)', () => {
+  const { paths } = setup();
+  fs.mkdirSync(paths.state, { recursive: true });
+  const file = path.join(paths.state, ALERTS_FILE);
+
+  // Pre-fill with an OVERSIZED but valid log so that, were compaction to run, the
+  // `size > MAX_FILE_BYTES` branch would fire. Without the guard, a failed read-back
+  // (readAlerts → []) would serialize the empty set to "\n" and rename it over the log,
+  // silently deleting every alert. The guard must leave the atomically-appended file
+  // intact instead.
+  const priorLine = JSON.stringify(rec('dream', '2026-07-04T01:00:00.000Z', 'y'.repeat(MAX_FIELD_CHARS - 20))) + '\n';
+  let prior = '';
+  while (Buffer.byteLength(prior) <= MAX_FILE_BYTES) prior += priorLine;
+  fs.writeFileSync(file, prior);
+  assert.ok(fs.statSync(file).size > MAX_FILE_BYTES, 'precondition: oversized file (compaction branch would fire)');
+
+  // Simulate an appendable-but-unreadable file: fstatSync (called ONLY by readAlerts,
+  // on its open fd) throws, so the post-append read-back returns []. append/statSync/
+  // writeFileSync are untouched. Deterministic and portable (no root/chmod dependence).
+  const realFstatSync = fs.fstatSync;
+  fs.fstatSync = () => {
+    throw Object.assign(new Error('simulated I/O error'), { code: 'EIO' });
+  };
+  try {
+    appendAlert(paths, rec('digest', '2026-07-04T07:00:00.000Z', 'newest fail-loud alert'));
+  } finally {
+    fs.fstatSync = realFstatSync;
+  }
+
+  const raw = fs.readFileSync(file, 'utf8');
+  assert.notEqual(raw.trim(), '', 'log must NOT be emptied by a failed read-back');
+  assert.ok(raw.includes('newest fail-loud alert'), 'the just-appended alert survived on disk');
+  assert.ok(raw.includes('2026-07-04T01:00:00.000Z'), 'prior alerts were not clobbered');
+  // With the read restored, the file reads back and contains the newest alert.
+  const got = readAlerts(paths);
+  assert.ok(
+    got.some((a) => a.job === 'digest' && a.reason === 'newest fail-loud alert'),
+    'newest alert readable after the transient read failure clears'
+  );
 });
 
 // -------------------------------------------------------------------------


### PR DESCRIPTION
Spec: docs/specs/WP-096-alerts-bounded-schema-capped.md

Bounds and hardens `alerts.jsonl` (Threat T6). `sanitizeAlert` coerces non-object/null/array to `{}` (valid-JSON primitives no longer crash on `.job`) and caps each field; compaction is gated on BOTH a record-count and a serialized-byte budget (`MAX_FILE_BYTES`); `readAlerts` opens once + `fstat` + fixed-buffer read (no stat→read TOCTOU) and drops the first partial tail line only when the preceding byte isn't a newline; `appendAlert` writes a leading `\n` separator when the file doesn't end in a newline so a new record can't fuse onto an oversized unterminated malformed tail and be lost.

## Deliverables checklist
- [x] Changed files in the Deliverables table (`src/core/alerts.js`, `tests/unit/alerts.test.js`)
- [x] Spec status flipped to In-Review

## Verification output
```
npm test : 717 pass / 0 fail / 1 skip (pre-existing)
npm run lint : clean
node scripts/boundary-check.js : exit 0
```
## Decisions made
- Exported `MAX_ALERTS`/`MAX_FIELD_CHARS`/`MAX_FILE_BYTES` so tests reference real bounds instead of duplicating literals.
## Discovered issues (out of scope, not fixed)
- none.

---
Generated-by: claude-sonnet (implement) + claude-fable-5 (orchestrate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uxThuapovGTPsbyn86BAf
