### PR TITLE
fix(install-ps1): validate Git-for-Windows asset + final-redirect URL (WP-099)

### DIFF
--- a/docs/specs/WP-099-install-ps1-git-url-validation.md
+++ b/docs/specs/WP-099-install-ps1-git-url-validation.md
@@ -1,7 +1,7 @@
 ---
 id: WP-099
 title: Validate the Git-for-Windows asset URL is HTTPS on a GitHub host before download
-status: Draft
+status: In-Review
 model: sonnet
 size: S
 depends_on: []

--- a/install.ps1
+++ b/install.ps1
@@ -283,17 +283,75 @@ function Get-MsiexecArgs {
 
 # --- Git-for-Windows discovery (PURE - Pester-tested with fixtures) ---------
 
+# Official Git-for-Windows release-asset origin: HTTPS on github.com under the
+# canonical repository release-download path. Host alone is insufficient - a
+# github.com URL under any OTHER repo path is not the official project.
+$script:GitForWindowsAssetPathPrefix = '/git-for-windows/git/releases/download/'
+
+# HTTPS + host github.com + the official Git-for-Windows release path. PURE.
+function Test-GitHubAssetUrl {
+    param([Parameter(Mandatory)][string]$Url)
+    try { $u = [System.Uri]$Url } catch { return $false }
+    if ($u.Scheme -ne 'https') { return $false }
+    if ($u.Host -ne 'github.com') { return $false }
+    return $u.AbsolutePath.StartsWith($script:GitForWindowsAssetPathPrefix, [System.StringComparison]::Ordinal)
+}
+
 # From a PARSED GitHub releases 'latest' object, return the download URL of the
 # standard $Arch-bit Git-for-Windows installer .exe (e.g. Git-2.55.0-64-bit.exe),
-# or '' if none. PURE. The '^Git-' anchor skips PortableGit/MinGit assets.
+# or '' if none. PURE. The '^Git-' anchor skips PortableGit/MinGit assets; a
+# matching name whose URL fails Test-GitHubAssetUrl (wrong scheme/host/repo
+# path) is skipped rather than trusted on filename alone. A matching name with a
+# missing/empty browser_download_url is skipped here (guarded BEFORE the call) -
+# an empty string cannot bind Test-GitHubAssetUrl's Mandatory param, and letting
+# that throw would abort the bootstrap even though Git is optional.
 function Get-GitForWindowsAssetUrl {
     param([Parameter(Mandatory)]$Release, [string]$Arch = '64')
     foreach ($asset in $Release.assets) {
         if (([string]$asset.name) -match "^Git-.*-$Arch-bit\.exe$") {
-            return [string]$asset.browser_download_url
+            $url = [string]$asset.browser_download_url
+            if ($url -and (Test-GitHubAssetUrl $url)) { return $url }
         }
     }
     return ''
+}
+
+# Hosts allowed as the FINAL download URI after redirects: github.com and its
+# release-asset CDN (objects.githubusercontent.com etc.). HTTPS required. PURE.
+function Test-GitHubDownloadUri {
+    param([Parameter(Mandatory)][System.Uri]$Uri)
+    if ($Uri.Scheme -ne 'https') { return $false }
+    return ($Uri.Host -eq 'github.com' -or $Uri.Host.EndsWith('.githubusercontent.com', [System.StringComparison]::Ordinal))
+}
+
+# PINNED cross-edition accessor for the FINAL (post-redirect) request URI of an
+# Invoke-WebRequest -PassThru response. PowerShell 7+ (HttpClient) exposes it as
+# BaseResponse.RequestMessage.RequestUri; Windows PowerShell 5.1 (HttpWebRequest) as
+# BaseResponse.ResponseUri. PREFER the 7+ shape when present (it is the actual final
+# URI on modern runtimes). Returns $null when neither is available - the caller then
+# REFUSES. PURE: takes an object, does no network, so Pester drives it with mocks.
+function Get-ResponseFinalUri {
+    param([Parameter(Mandatory)]$Response)
+    $base = $Response.BaseResponse
+    if ($null -eq $base) { return $null }
+    if ($base.PSObject.Properties['RequestMessage'] -and $base.RequestMessage -and $base.RequestMessage.RequestUri) {
+        return [System.Uri]$base.RequestMessage.RequestUri     # PowerShell 7+
+    }
+    if ($base.PSObject.Properties['ResponseUri'] -and $base.ResponseUri) {
+        return [System.Uri]$base.ResponseUri                   # Windows PowerShell 5.1
+    }
+    return $null
+}
+
+# Whole redirect decision as one PURE predicate over a response object: is the FINAL
+# URI a GitHub-owned HTTPS host? $false when the final URI is absent (neither accessor
+# present) or off-host. Composing the two helpers here makes the redirect-validation
+# decision unit-testable with a mocked response, independent of a live network.
+function Test-GitHubResponseFinalUri {
+    param([Parameter(Mandatory)]$Response)
+    $final = Get-ResponseFinalUri $Response
+    if ($null -eq $final) { return $false }
+    return Test-GitHubDownloadUri $final
 }
 
 # The documented Git-for-Windows (Inno Setup) silent-install arg list. PURE.
@@ -350,16 +408,26 @@ function Install-GitViaWinget {
     return ($LASTEXITCODE -eq 0)
 }
 
-# Official signed Git-for-Windows .exe path: download $Url and run it with the
-# documented silent flags (invoking the .exe directly, not `winget --silent`,
-# which maps to /SILENT not /VERYSILENT). Returns $true on a completed install.
+# Official signed Git-for-Windows .exe path: validate the origin URL's provenance,
+# download $Url, then validate the FINAL redirected URI before running the .exe with
+# the documented silent flags (invoking it directly, not `winget --silent`, which
+# maps to /SILENT not /VERYSILENT). Returns $true on a completed install; refuses
+# (deletes the file, returns $false, never runs it) on a failed origin/redirect check.
 function Install-GitViaExe {
     param([Parameter(Mandatory)][string]$Url)
+    if (-not (Test-GitHubAssetUrl $Url)) { Write-Host 'Refusing: Git asset URL failed provenance validation.'; return $false }
     $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("wd-git-" + [System.Guid]::NewGuid().ToString('N'))
     New-Item -ItemType Directory -Path $tmp -Force | Out-Null
     try {
         $exe = Join-Path $tmp 'git-for-windows.exe'
-        Invoke-WebRequest -Uri $Url -OutFile $exe -UseBasicParsing
+        # -PassThru returns the response so we can inspect the FINAL URI after redirects.
+        $resp = Invoke-WebRequest -Uri $Url -OutFile $exe -UseBasicParsing -PassThru
+        if (-not (Test-GitHubResponseFinalUri $resp)) {
+            Remove-Item -Force $exe -ErrorAction SilentlyContinue
+            $shown = Get-ResponseFinalUri $resp
+            Write-Host "Refusing: Git download redirected to an untrusted or unknown URL ($shown)."
+            return $false
+        }
         $p = Start-Process $exe -ArgumentList (Get-GitSilentArgs) -Wait -PassThru
         return ($p.ExitCode -eq 0)
     }

--- a/tests/ps/install-ps1.Tests.ps1
+++ b/tests/ps/install-ps1.Tests.ps1
@@ -278,22 +278,227 @@ Describe 'Install-NodeViaMsi (security branches)' {
     }
 }
 
-Describe 'Get-GitForWindowsAssetUrl' {
-    BeforeAll {
-        $script:Release = [pscustomobject]@{ assets = @(
-                [pscustomobject]@{ name = 'Git-2.55.0-32-bit.exe'; browser_download_url = 'https://example/32.exe' }
-                [pscustomobject]@{ name = 'Git-2.55.0-64-bit.exe'; browser_download_url = 'https://example/64.exe' }
-                [pscustomobject]@{ name = 'PortableGit-2.55.0-64-bit.7z.exe'; browser_download_url = 'https://example/portable' }
-            ) }
+Describe 'Test-GitHubAssetUrl' {
+    It 'accepts the canonical git-for-windows release-download URL' {
+        Test-GitHubAssetUrl 'https://github.com/git-for-windows/git/releases/download/v2.55.0.windows.1/Git-2.55.0-64-bit.exe' |
+            Should -BeTrue
     }
 
-    It 'returns the standard 64-bit installer .exe URL by default' {
-        Get-GitForWindowsAssetUrl -Release $script:Release | Should -Be 'https://example/64.exe'
+    It 'rejects a non-HTTPS URL' {
+        Test-GitHubAssetUrl 'http://github.com/git-for-windows/git/releases/download/v2.55.0/Git-2.55.0-64-bit.exe' |
+            Should -BeFalse
+    }
+
+    It 'rejects a non-github.com host' {
+        Test-GitHubAssetUrl 'https://evil.example.com/Git-2.55.0-64-bit.exe' | Should -BeFalse
+    }
+
+    It 'rejects a github.com URL under a different repository path' {
+        Test-GitHubAssetUrl 'https://github.com/attacker/repo/releases/download/v1/Git-2.55.0-64-bit.exe' |
+            Should -BeFalse
+    }
+
+    It 'rejects an unparseable URL' {
+        Test-GitHubAssetUrl 'not a url' | Should -BeFalse
+    }
+}
+
+Describe 'Get-GitForWindowsAssetUrl' {
+    BeforeAll {
+        $script:GoodUrl = 'https://github.com/git-for-windows/git/releases/download/v2.55.0.windows.1/Git-2.55.0-64-bit.exe'
+    }
+
+    It 'returns the standard 64-bit installer .exe URL when it passes provenance validation' {
+        $release = [pscustomobject]@{ assets = @(
+                [pscustomobject]@{ name = 'Git-2.55.0-32-bit.exe'; browser_download_url = 'https://example/32.exe' }
+                [pscustomobject]@{ name = 'Git-2.55.0-64-bit.exe'; browser_download_url = $script:GoodUrl }
+                [pscustomobject]@{ name = 'PortableGit-2.55.0-64-bit.7z.exe'; browser_download_url = 'https://example/portable' }
+            ) }
+        Get-GitForWindowsAssetUrl -Release $release | Should -Be $script:GoodUrl
     }
 
     It "returns '' when no matching asset exists" {
         $r = [pscustomobject]@{ assets = @([pscustomobject]@{ name = 'notes.txt'; browser_download_url = 'x' }) }
         Get-GitForWindowsAssetUrl -Release $r | Should -Be ''
+    }
+
+    It "returns '' when the matching-name asset's URL is http (non-HTTPS)" {
+        $r = [pscustomobject]@{ assets = @(
+                [pscustomobject]@{ name = 'Git-2.55.0-64-bit.exe'; browser_download_url = 'http://github.com/git-for-windows/git/releases/download/v1/Git-2.55.0-64-bit.exe' }
+            ) }
+        Get-GitForWindowsAssetUrl -Release $r | Should -Be ''
+    }
+
+    It "returns '' when the matching-name asset's URL is a non-github.com host" {
+        $r = [pscustomobject]@{ assets = @(
+                [pscustomobject]@{ name = 'Git-2.55.0-64-bit.exe'; browser_download_url = 'https://evil.example.com/Git-2.55.0-64-bit.exe' }
+            ) }
+        Get-GitForWindowsAssetUrl -Release $r | Should -Be ''
+    }
+
+    It "returns '' when the matching-name asset's URL is a wrong-repo github.com path" {
+        $r = [pscustomobject]@{ assets = @(
+                [pscustomobject]@{ name = 'Git-2.55.0-64-bit.exe'; browser_download_url = 'https://github.com/attacker/repo/releases/download/v1/Git-2.55.0-64-bit.exe' }
+            ) }
+        Get-GitForWindowsAssetUrl -Release $r | Should -Be ''
+    }
+
+    It "returns '' without throwing when a matching asset has an empty browser_download_url" {
+        $r = [pscustomobject]@{ assets = @(
+                [pscustomobject]@{ name = 'Git-2.55.0-64-bit.exe'; browser_download_url = '' }
+            ) }
+        { Get-GitForWindowsAssetUrl -Release $r } | Should -Not -Throw
+        Get-GitForWindowsAssetUrl -Release $r | Should -Be ''
+    }
+
+    It "returns '' without throwing when a matching asset omits browser_download_url (null)" {
+        $r = [pscustomobject]@{ assets = @(
+                [pscustomobject]@{ name = 'Git-2.55.0-64-bit.exe' }   # no browser_download_url property -> null
+            ) }
+        { Get-GitForWindowsAssetUrl -Release $r } | Should -Not -Throw
+        Get-GitForWindowsAssetUrl -Release $r | Should -Be ''
+    }
+}
+
+Describe 'Test-GitHubDownloadUri' {
+    It 'accepts https github.com' {
+        Test-GitHubDownloadUri ([System.Uri]'https://github.com/x/y') | Should -BeTrue
+    }
+    It 'accepts https *.githubusercontent.com' {
+        Test-GitHubDownloadUri ([System.Uri]'https://objects.githubusercontent.com/x/y') | Should -BeTrue
+    }
+    It 'rejects http' {
+        Test-GitHubDownloadUri ([System.Uri]'http://github.com/x/y') | Should -BeFalse
+    }
+    It 'rejects a non-GitHub host' {
+        Test-GitHubDownloadUri ([System.Uri]'https://evil.example.com/x/y') | Should -BeFalse
+    }
+}
+
+Describe 'Get-ResponseFinalUri' {
+    It 'returns the URI from a 5.1-shaped response (BaseResponse.ResponseUri, no RequestMessage)' {
+        $resp = [pscustomobject]@{
+            BaseResponse = [pscustomobject]@{ ResponseUri = [System.Uri]'https://objects.githubusercontent.com/a/b' }
+        }
+        Get-ResponseFinalUri $resp | Should -Be ([System.Uri]'https://objects.githubusercontent.com/a/b')
+    }
+
+    It 'returns the URI from a 7+-shaped response (BaseResponse.RequestMessage.RequestUri)' {
+        $resp = [pscustomobject]@{
+            BaseResponse = [pscustomobject]@{
+                RequestMessage = [pscustomobject]@{ RequestUri = [System.Uri]'https://github.com/a/b' }
+            }
+        }
+        Get-ResponseFinalUri $resp | Should -Be ([System.Uri]'https://github.com/a/b')
+    }
+
+    It 'prefers the 7+ shape when both accessors are present' {
+        $resp = [pscustomobject]@{
+            BaseResponse = [pscustomobject]@{
+                RequestMessage = [pscustomobject]@{ RequestUri = [System.Uri]'https://github.com/seven' }
+                ResponseUri    = [System.Uri]'https://github.com/five-one'
+            }
+        }
+        Get-ResponseFinalUri $resp | Should -Be ([System.Uri]'https://github.com/seven')
+    }
+
+    It 'returns $null when neither accessor is present' {
+        $resp = [pscustomobject]@{ BaseResponse = [pscustomobject]@{} }
+        Get-ResponseFinalUri $resp | Should -BeNullOrEmpty
+    }
+
+    It 'returns $null when BaseResponse itself is absent' {
+        $resp = [pscustomobject]@{ BaseResponse = $null }
+        Get-ResponseFinalUri $resp | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Test-GitHubResponseFinalUri' {
+    It 'accepts a mock whose final URI is https objects.githubusercontent.com' {
+        $resp = [pscustomobject]@{
+            BaseResponse = [pscustomobject]@{ ResponseUri = [System.Uri]'https://objects.githubusercontent.com/a/b' }
+        }
+        Test-GitHubResponseFinalUri $resp | Should -BeTrue
+    }
+
+    It 'rejects a mock whose final URI is http' {
+        $resp = [pscustomobject]@{
+            BaseResponse = [pscustomobject]@{ ResponseUri = [System.Uri]'http://objects.githubusercontent.com/a/b' }
+        }
+        Test-GitHubResponseFinalUri $resp | Should -BeFalse
+    }
+
+    It 'rejects a mock whose final URI is an off-host https URL' {
+        $resp = [pscustomobject]@{
+            BaseResponse = [pscustomobject]@{ ResponseUri = [System.Uri]'https://evil.example.com/a/b' }
+        }
+        Test-GitHubResponseFinalUri $resp | Should -BeFalse
+    }
+
+    It 'rejects a mock with neither accessor present (refuse fail-closed)' {
+        $resp = [pscustomobject]@{ BaseResponse = [pscustomobject]@{} }
+        Test-GitHubResponseFinalUri $resp | Should -BeFalse
+    }
+}
+
+Describe 'Install-GitViaExe' {
+    BeforeAll {
+        $script:GoodOrigin = 'https://github.com/git-for-windows/git/releases/download/v2.55.0.windows.1/Git-2.55.0-64-bit.exe'
+    }
+
+    It 'refuses an off-host origin URL without downloading' {
+        Mock Invoke-WebRequest { throw 'Invoke-WebRequest must not be called for a bad origin URL' }
+        Mock Start-Process { throw 'Start-Process must not run when the origin is refused' }
+        Install-GitViaExe -Url 'https://evil.example.com/Git-2.55.0-64-bit.exe' | Should -BeFalse
+        Should -Invoke Invoke-WebRequest -Times 0
+        Should -Invoke Start-Process -Times 0
+    }
+
+    It 'refuses, deletes the file, and never runs Start-Process on an off-host FINAL (redirected) URI' {
+        Mock Invoke-WebRequest {
+            [System.IO.File]::WriteAllBytes($OutFile, [byte[]](1, 2, 3))
+            [pscustomobject]@{
+                BaseResponse = [pscustomobject]@{ ResponseUri = [System.Uri]'https://evil.example.com/redirected.exe' }
+            }
+        }
+        Mock Start-Process { throw 'Start-Process must not run on an off-host final URI' }
+
+        Install-GitViaExe -Url $script:GoodOrigin | Should -BeFalse
+        Should -Invoke Start-Process -Times 0
+    }
+
+    It 'downloads and runs when the origin and final URI both validate' {
+        Mock Invoke-WebRequest {
+            [System.IO.File]::WriteAllBytes($OutFile, [byte[]](1, 2, 3))
+            [pscustomobject]@{
+                BaseResponse = [pscustomobject]@{ ResponseUri = [System.Uri]'https://objects.githubusercontent.com/redirected.exe' }
+            }
+        }
+        Mock Start-Process { [pscustomobject]@{ ExitCode = 0 } }
+
+        Install-GitViaExe -Url $script:GoodOrigin | Should -BeTrue
+        Should -Invoke Start-Process -Times 1
+    }
+}
+
+Describe 'Ensure-Git (optional-Git fallback)' {
+    It 'continues without throwing or running Start-Process when the release asset URL is empty/missing' {
+        # git absent (so it proceeds), winget absent (so it hits the release path).
+        Mock Get-Command { $null } -ParameterFilter { $Name -eq 'git' }
+        Mock Get-Command { $null } -ParameterFilter { $Name -eq 'winget' }
+        # Compromised/malformed response: matching asset NAME but empty download URL.
+        Mock Invoke-RestMethod {
+            [pscustomobject]@{ assets = @(
+                    [pscustomobject]@{ name = 'Git-2.55.0-64-bit.exe'; browser_download_url = '' }
+                ) }
+        }
+        Mock Confirm-Step { throw 'Confirm-Step must not be reached when there is no valid asset URL' }
+        Mock Install-GitViaExe { throw 'Install-GitViaExe must not run without a valid asset URL' }
+        Mock Start-Process { throw 'Start-Process must not run' }
+
+        { Ensure-Git } | Should -Not -Throw
+        Should -Invoke Install-GitViaExe -Times 0
+        Should -Invoke Start-Process -Times 0
     }
 }
 


### PR DESCRIPTION
Spec: docs/specs/WP-099-install-ps1-git-url-validation.md

install.ps1's Git-for-Windows fallback ran a GitHub-API-supplied download URL with only a name-regex check. Now `Test-GitHubAssetUrl` requires HTTPS + host `github.com` + the canonical `/git-for-windows/git/releases/download/` path prefix, and `Install-GitViaExe` validates the FINAL redirected URI (HTTPS on github.com / *.githubusercontent.com) via the pinned `Get-ResponseFinalUri` (7+ `RequestMessage.RequestUri` → 5.1 `ResponseUri` → `$null`→refuse), deleting the file and returning `$false` (never `Start-Process`) on an off-host/downgrade redirect.

## Deliverables checklist
- [x] Changed files in the Deliverables table (`install.ps1`, `tests/ps/install-ps1.Tests.ps1`)
- [x] Spec status flipped to In-Review

## Verification output
```
Invoke-Pester tests/ps/install-ps1.Tests.ps1 : 70/70 pass
Invoke-ScriptAnalyzer install.ps1            : clean
npm test : 709 pass / 0 fail / 1 skip ; npm run lint : clean ; boundary-check : exit 0
```
## Decisions made
- Ran PSScriptAnalyzer against the real settings path (`./PSScriptAnalyzerSettings.psd1`, repo root) — the spec's verification line referenced a `tests/ps/` path that doesn't exist (minor spec inaccuracy, flagged).
## Discovered issues (out of scope, not fixed)
- Spec verification-command path for PSScriptAnalyzerSettings is wrong (repo-root, not tests/ps/); cosmetic.

---
Generated-by: claude-sonnet (implement) + claude-fable-5 (orchestrate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uxThuapovGTPsbyn86BAf
