### PR TITLE
fix(scheduler): fail loud on missing/failed secondary calls, truthful remove() (WP-098)

### DIFF
--- a/docs/specs/WP-098-scheduler-secondary-call-fail-loud.md
+++ b/docs/specs/WP-098-scheduler-secondary-call-fail-loud.md
@@ -1,7 +1,7 @@
 ---
 id: WP-098
 title: Surface failures of best-effort systemd calls and report schedule-removal truthfully
-status: Draft
+status: In-Review
 model: sonnet
 size: S
 depends_on: []

--- a/src/cli/schedule.js
+++ b/src/cli/schedule.js
@@ -192,11 +192,26 @@ function registerPlatform(paths, manifest, o, loader, platform = process.platfor
     let loaded = true;
     if (changed) {
       // Best-effort daemon-reload/linger are not gated; only `enable --now` counts.
-      loader(['systemctl', '--user', 'daemon-reload']);
+      const reload = loader(['systemctl', '--user', 'daemon-reload']);
+      // Treat a MISSING result (undefined result OR a nullish status) as a failure too —
+      // absence of a result is not success. `!= null` catches both undefined and null, so
+      // a `{status:null}` result warns and prints 'no result', never 'null'.
+      if (!reload || reload.status == null || reload.status !== 0) {
+        const s = reload && reload.status != null ? reload.status : 'no result';
+        process.stderr.write(`wienerdog: warning — 'systemctl --user daemon-reload' returned ${s}; the timer may load from stale units. Run 'wienerdog doctor'.\n`);
+      }
       loaded = loader(['systemctl', '--user', 'enable', '--now', `${unitBase}.timer`]).status === 0;
       // Best-effort: let timers fire when the user is logged out.
       const user = process.env.USER || process.env.LOGNAME || '';
-      if (user) loader(['loginctl', 'enable-linger', user]);
+      if (user) {
+        const linger = loader(['loginctl', 'enable-linger', user]);
+        // Same nullish handling as daemon-reload: a `{status:null}` result warns and
+        // prints 'no result', never 'null'.
+        if (!linger || linger.status == null || linger.status !== 0) {
+          const s = linger && linger.status != null ? linger.status : 'no result';
+          process.stderr.write(`wienerdog: warning — 'loginctl enable-linger ${user}' returned ${s}; scheduled jobs may not run while you are logged out.\n`);
+        }
+      }
     }
     return { platform: 'systemd', changed, loaded };
   }
@@ -403,7 +418,21 @@ function remove(argv, loader) {
   manifestLib.save(paths, manifest);
   jobsLib.removeJob(paths, name);
 
-  process.stdout.write(`wienerdog: removed "${name}" (unloaded and deleted its schedule entry).\n`);
+  if (removed.length === 0) {
+    // No schedule FILE was present to delete (already removed, or never registered).
+    // But reverseSchedulerEntry runs any recorded `unload` argv BEFORE checking the
+    // file (manifest.js:193 — unload, then the isFile() guard), so a best-effort
+    // OS-unregister command may still have RUN even with zero file deletions. Report
+    // the count (0) AND the same best-effort qualifier as the non-empty branch; do NOT
+    // assert the OS entry was "already gone" — that is not known here.
+    process.stdout.write(`wienerdog: removed "${name}" from Wienerdog's schedule — deleted 0 schedule files and ran any recorded OS-unregister command(s) best-effort (no schedule file was present to delete).\n`);
+  } else {
+    const fileWord = removed.length === 1 ? 'file' : 'files';
+    const absentTail = skipped.length > 0
+      ? `; ${skipped.length} file${skipped.length === 1 ? ' was' : 's were'} already absent`
+      : '';
+    process.stdout.write(`wienerdog: removed "${name}" from Wienerdog's schedule — deleted ${removed.length} schedule ${fileWord} and ran any recorded OS-unregister command(s) best-effort${absentTail}.\n`);
+  }
 }
 
 /**

--- a/tests/unit/scheduler-schedule.test.js
+++ b/tests/unit/scheduler-schedule.test.js
@@ -101,6 +101,14 @@ const SCHED_SUPPORTED =
   (process.platform === 'linux' &&
     (fs.existsSync('/run/systemd/system') || !spawnSync('systemctl', ['--version']).error));
 
+// Mirrors schedule.js's internal (unexported) hasSystemd() probe: registerPlatform's
+// Linux branch throws on a host without systemd regardless of the injected `platform`
+// param, so the WP-098 secondary-call-warning tests (which force platform:'linux' to
+// exercise that branch directly) only run where the real host actually has systemd.
+const LINUX_SYSTEMD =
+  process.platform === 'linux' &&
+  (fs.existsSync('/run/systemd/system') || !spawnSync('systemctl', ['--version']).error);
+
 // -------------------------------------------------------------------------
 // jobs.js: parseJobs / renderConfigWithJobs round-trip + coexistence
 // -------------------------------------------------------------------------
@@ -370,6 +378,167 @@ test('scheduler-schedule: remove runs the unload, deletes files, drops entries a
 test('scheduler-schedule: remove of an unknown job is a no-op notice', async () => {
   const { env } = setup();
   await runSchedule(env, ['remove', 'nope'], () => ({ status: 0 })); // must not throw
+});
+
+// -------------------------------------------------------------------------
+// WP-098: secondary systemd calls (daemon-reload / enable-linger) warn to
+// stderr on a nonzero OR missing result, without affecting `loaded` (still
+// gated only on `enable --now`).
+// -------------------------------------------------------------------------
+
+/**
+ * Capture process.stderr.write during `fn`, restoring it afterwards.
+ * @template T @param {() => T} fn @returns {{result:T, stderr:string}}
+ */
+function captureStderr(fn) {
+  let out = '';
+  const orig = process.stderr.write.bind(process.stderr);
+  process.stderr.write = (s) => ((out += s), true);
+  try {
+    return { result: fn(), stderr: out };
+  } finally {
+    process.stderr.write = orig;
+  }
+}
+
+test('scheduler-schedule: registerPlatform warns on a NONZERO daemon-reload and a MISSING (undefined) enable-linger result', { skip: !LINUX_SYSTEMD }, () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const savedUser = process.env.USER;
+  process.env.USER = 'ada';
+  try {
+    const loader = (argv) => {
+      if (argv[0] === 'systemctl' && argv.includes('daemon-reload')) return { status: 1 }; // nonzero
+      if (argv[0] === 'systemctl' && argv.includes('enable')) return { status: 0 }; // primary succeeds
+      if (argv[0] === 'loginctl') return undefined; // MISSING result
+      return { status: 0 };
+    };
+    const { result: res, stderr } = captureStderr(() =>
+      schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'linux')
+    );
+    assert.equal(res.loaded, true, '`loaded` stays gated only on `enable --now`, which returned status 0');
+    assert.match(stderr, /'systemctl --user daemon-reload' returned 1/, 'nonzero daemon-reload warns with its status');
+    assert.match(stderr, /'loginctl enable-linger ada' returned no result/, 'a MISSING (undefined) result warns as "no result", not silence');
+  } finally {
+    if (savedUser === undefined) delete process.env.USER;
+    else process.env.USER = savedUser;
+  }
+});
+
+test('scheduler-schedule: registerPlatform warns on a MISSING ({status:null}) daemon-reload and a NONZERO enable-linger result', { skip: !LINUX_SYSTEMD }, () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const savedUser = process.env.USER;
+  process.env.USER = 'ada';
+  try {
+    const loader = (argv) => {
+      if (argv[0] === 'systemctl' && argv.includes('daemon-reload')) return { status: null }; // MISSING (null status)
+      if (argv[0] === 'systemctl' && argv.includes('enable')) return { status: 0 }; // primary succeeds
+      if (argv[0] === 'loginctl') return { status: 2 }; // nonzero
+      return { status: 0 };
+    };
+    const { result: res, stderr } = captureStderr(() =>
+      schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'linux')
+    );
+    assert.equal(res.loaded, true, '`loaded` stays gated only on `enable --now`, which returned status 0');
+    assert.match(stderr, /'systemctl --user daemon-reload' returned no result/, 'a {status:null} result warns as "no result", not success');
+    assert.match(stderr, /'loginctl enable-linger ada' returned 2/, 'nonzero enable-linger warns with its status');
+  } finally {
+    if (savedUser === undefined) delete process.env.USER;
+    else process.env.USER = savedUser;
+  }
+});
+
+test('scheduler-schedule: registerPlatform emits no secondary-call warnings when daemon-reload and enable-linger both succeed', { skip: !LINUX_SYSTEMD }, () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const savedUser = process.env.USER;
+  process.env.USER = 'ada';
+  try {
+    const { stderr } = captureStderr(() =>
+      schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, () => ({ status: 0 }), 'linux')
+    );
+    assert.equal(stderr, '', 'no warnings when every secondary call reports status 0');
+  } finally {
+    if (savedUser === undefined) delete process.env.USER;
+    else process.env.USER = savedUser;
+  }
+});
+
+// -------------------------------------------------------------------------
+// WP-098: `remove()` reports the truthful outcome — removed.length in every
+// branch, and a qualified "ran any recorded OS-unregister command(s)
+// best-effort" statement, never "unloaded" / "already gone".
+// -------------------------------------------------------------------------
+
+test('scheduler-schedule: remove reports the zero-removal wording (count + best-effort unregister, no "unloaded"/"already gone") when the schedule file is already gone', async () => {
+  const { env, paths, root } = setup();
+  const manifest = manifestLib.load(paths);
+  // A recorded scheduler-entry whose FILE was never written (or already removed) —
+  // reverseSchedulerEntry still runs its `unload` argv best-effort before checking
+  // the file, so removed.length stays 0 while a command may still have run.
+  const file = path.join(root, `${gen.launchdLabel('ghost-job')}.plist`);
+  const marker = path.join(root, 'zero-removal-unload-ran');
+  manifestLib.record(manifest, {
+    kind: 'scheduler-entry',
+    path: file,
+    unload: [process.execPath, '-e', `require('fs').writeFileSync(${JSON.stringify(marker)}, 'ran')`],
+  });
+  manifestLib.save(paths, manifest);
+  jobsLib.saveJob(paths, { name: 'ghost-job', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+
+  let out = '';
+  const origOut = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (s) => ((out += s), true);
+  try {
+    await withUnloadSpawnAllowed(() => runSchedule(env, ['remove', 'ghost-job'], () => ({ status: 0 })));
+  } finally {
+    process.stdout.write = origOut;
+  }
+
+  assert.ok(fs.existsSync(marker), 'the recorded unload argv ran best-effort even though the file was absent');
+  assert.match(
+    out,
+    /deleted 0 schedule files and ran any recorded OS-unregister command\(s\) best-effort \(no schedule file was present to delete\)/
+  );
+  assert.ok(!/unloaded/.test(out), 'never claims "unloaded"');
+  assert.ok(!/already gone/i.test(out), 'never claims the OS entry was "already gone"');
+  assert.equal(jobsLib.findJob(paths, 'ghost-job'), null, 'job definition still dropped');
+});
+
+test('scheduler-schedule: a normal removal reports removed.length (N=2), not the singular "its schedule file"', async () => {
+  const { env, paths, root } = setup();
+  const manifest = manifestLib.load(paths);
+  // Two scheduler-entries (mirrors the Linux timer+service pair) whose files
+  // actually exist on disk, portable regardless of the real host platform.
+  const timerPath = path.join(root, `${gen.systemdUnitBase('two-files')}.timer`);
+  const servicePath = path.join(root, `${gen.systemdUnitBase('two-files')}.service`);
+  fs.writeFileSync(timerPath, '[Timer]\n');
+  fs.writeFileSync(servicePath, '[Service]\n');
+  const marker = path.join(root, 'two-files-unload-ran');
+  manifestLib.record(manifest, {
+    kind: 'scheduler-entry',
+    path: timerPath,
+    unload: [process.execPath, '-e', `require('fs').writeFileSync(${JSON.stringify(marker)}, 'ran')`],
+  });
+  manifestLib.record(manifest, { kind: 'scheduler-entry', path: servicePath, unload: null });
+  manifestLib.save(paths, manifest);
+  jobsLib.saveJob(paths, { name: 'two-files', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+
+  let out = '';
+  const origOut = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (s) => ((out += s), true);
+  try {
+    await withUnloadSpawnAllowed(() => runSchedule(env, ['remove', 'two-files'], () => ({ status: 0 })));
+  } finally {
+    process.stdout.write = origOut;
+  }
+
+  assert.ok(fs.existsSync(marker), 'the recorded unload argv ran');
+  assert.ok(!fs.existsSync(timerPath) && !fs.existsSync(servicePath), 'both files deleted');
+  assert.match(out, /deleted 2 schedule files and ran any recorded OS-unregister command\(s\) best-effort/);
+  assert.ok(!/its schedule file/.test(out), 'does not misreport with the singular "its schedule file"');
+  assert.ok(!/unloaded/.test(out), 'never claims "unloaded"');
 });
 
 // -------------------------------------------------------------------------


### PR DESCRIPTION
Spec: docs/specs/WP-098-scheduler-secondary-call-fail-loud.md

Closes fail-loud gaps in the scheduler's secondary calls (Threat T6). The Linux `daemon-reload`/`enable-linger` results are now captured and WARN on a MISSING (`undefined`/`null`) result as well as nonzero (absence of a result is not success); `remove()` reports the truthful outcome — the numeric `removed.length` in every branch (including zero-removal) and a qualified "ran any recorded OS-unregister command(s) best-effort" statement, never a false "unloaded"/"already gone".

## Deliverables checklist
- [x] Changed files in the Deliverables table (`src/cli/schedule.js`, `tests/unit/scheduler-schedule.test.js`)
- [x] Spec status flipped to In-Review

## Verification output
```
npm test : 711 pass / 0 fail / 4 skip (3 Linux-systemd-gated new tests + 1 pre-existing)
npm run lint : clean
node scripts/boundary-check.js : exit 0
```
The 3 new registerPlatform-warning tests are gated on a Linux+systemd host (this dev box is macOS) — they run on CI's ubuntu runner; the truthful-`remove()` tests are host-portable and run everywhere.

## Decisions made
- Followed the spec's Exact Contracts as source of truth: it scopes the missing-result warning to the Linux `registerPlatform` `daemon-reload`/`enable-linger` calls and leaves `remove()`'s unload-status surfacing as an out-of-scope follow-up. Did not touch `ensureCatchup` (flagged in Discovered).

## Discovered issues (out of scope, not fixed)
- The orchestration brief mentioned an `ensureCatchup` bootstrap-result warning, but the spec's contracts/acceptance don't include it (they scope to registerPlatform + remove() wording); followed the spec. Worth a spec touch-up if the `ensureCatchup` warning is wanted.

---
Generated-by: claude-sonnet (implement) + claude-fable-5 (orchestrate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uxThuapovGTPsbyn86BAf
