### PR TITLE
docs: WP-100/101 specs + post-audit THREAT-MODEL and spec cleanup

### DIFF
--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -65,6 +65,8 @@ As of ADR-0020, dream-created skills can also be **revised** automatically from 
 
 **Mitigations (ADR-0007)**: sending executes only under a **send grant** scoped to `(routine, recipient allowlist)`; grants live in `~/.wienerdog/config.yaml` (mechanics — no model-writable surface) and are created only by the interactive CLI with a typed confirmation naming routine and recipients — no skill, hook, dream, or headless job can create or widen one; ungranted sends degrade to draft + notice (fail-safe, fail-visible); third-party-recipient grants carry an extra plain-language warning; the dream job has no `gws` access at all; `_alert` remains a fixed-template self-send.
 
+**Residual (accepted, v1)**: the CLI typed-confirmation defends only against *model/headless* grant creation — any local process able to write `config.yaml` directly (or to load the project modules and call the exported `saveGrant`) can forge a send grant, since a grant is an unauthenticated YAML fact with no provenance or signature marker. This is the same OS-user file-permission boundary that guards the OAuth tokens (T4); a provenance/signature marker on grants is deliberately **not** built in v1 (it would not raise the boundary above file permissions an already-local attacker has cleared). Accepted; revisit if grants ever move outside a single-user-machine trust model.
+
 ## T5a — curl|bash entry point
 
 **Hazard**: the default install is `curl … | bash` (ADR-0006), a pattern users are right to be wary of.
@@ -86,6 +88,8 @@ As of ADR-0020, dream-created skills can also be **revised** automatically from 
 - **No root self-run.** The script still refuses `EUID 0`; installs go through per-action `sudo`, not a root-run script.
 
 **Residual risk (accepted)**: a compromised upstream package index or nested script could serve a malicious package that a consenting user installs as root — the same trust a user places in their OS package manager every day. Wienerdog adds no signature verification beyond what the OS package manager, the signed `.pkg`, and TLS already provide; it minimizes exposure by preferring signed sources and showing every command, but does not eliminate the inherent trust in installing software. This is the explicit cost of a one-line install for no-dependency users; a user who wants zero auto-install can decline every prompt (or run in a non-tty context) and follow the printed commands.
+
+**Residual risk — tar LINK-MEMBER extraction escape (accepted, spike pending)**: the npm-less registry-tarball channel (ADR-0016) unpacks a downloaded tarball into the vendored `app/` layout. WP-093's member-name preflight covers **name-based** escapes only — a member whose *name* contains `../` or an absolute path — plus the secure-temp / completeness-marker TOCTOU. It does **not** yet defend the **symlink/hardlink LINK-MEMBER vector**: a tar member with a perfectly safe name (`app/x`) that is itself a symlink or hardlink whose *link target* escapes the extraction root, so a later member written "through" it lands outside `app/`. This is a named, deliberately-deferred residual pending a wd-researcher spike on cross-tar (BSD/GNU/`node-tar`) link-member handling before a fix is spec'd; the sha512-SRI verification (ADR-0016) still gates the whole tarball's integrity against the pinned registry manifest, so exploitation requires a compromised registry AND a crafted link member.
 
 ## T5 — Installer / uninstaller overreach
 

--- a/docs/specs/ROADMAP.md
+++ b/docs/specs/ROADMAP.md
@@ -118,6 +118,8 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 | [WP-097](WP-097-scheduler-generator-path-escaping.md) | XML-escape launchd plist values and quote systemd ExecStart paths | M7 | sonnet | Draft | — |
 | [WP-098](WP-098-scheduler-secondary-call-fail-loud.md) | Surface best-effort systemd-call failures; report schedule-removal truthfully | M7 | sonnet | Draft | — |
 | [WP-099](WP-099-install-ps1-git-url-validation.md) | Validate the Git-for-Windows asset URL is HTTPS on a GitHub host before download | M7 | sonnet | Draft | — |
+| [WP-100](WP-100-codex-tool-output-and-fail-closed-roles.md) | Codex transcript parser — recognize the current tool-output item type (`custom_tool_call_output` + variants) and fail closed on unknown roles | M7 | sonnet | Draft | — |
+| [WP-101](WP-101-gws-oauth-state-pkce.md) | gws OAuth loopback — add `state` + PKCE (RFC 8252) | M7 | sonnet | Draft | — |
 
 > **First-production-night incident (2026-07-04).** WP-038, WP-039 and WP-041 form
 > a serial chain (they edit the shared `run-job.js` / `dream.js` / `validate.js`
@@ -758,6 +760,35 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 
 <!-- -->
 
+> **Post-audit wd-researcher checks (2026-07-13).** Two owner-approved
+> follow-ups landed after post-audit wd-researcher investigations verified a pair
+> of flagged-but-unresolved P2s against real, current systems (not code comments).
+> Both are Draft pending a Codex spec-review before Ready; neither depends on the
+> other. **WP-100** (S, sonnet, `src/core/transcripts/codex.js`) closes a verified
+> Codex-parser defect: `mapCodexItem` only recognized `function_call_output`, but
+> codex-cli 0.144.x emits tool/exec output as `custom_tool_call_output` (with
+> `function_call_output`/`local_shell_call`/`web_search_call`/`tool_search_output`
+> as legacy/alternate variants), so ~18% of Codex session content — all tool/exec
+> output — was silently DROPPED and the Codex `derived_from_untrusted` tagging path
+> never fired (memo `2026-07-13-codex-transcript-role-provenance.md`, verified
+> against a live codex-cli 0.144.1 machine + upstream `openai/codex` source). It
+> also replaces the default-trust `role !== 'assistant' → 'user'` logic with an
+> explicit trusted-role allowlist (`user`/`developer`/`system` → user; unrecognized
+> role → DROP, never trust), so the parser fails closed if Codex's untyped upstream
+> `Message.role` string ever routes tool content through a novel role — closing the
+> latent T1 provenance-bypass class. Adds a T1 THREAT-MODEL note recording the
+> parser-level provenance dependency. **WP-101** (S, sonnet, `src/gws/auth.js`)
+> adds `state` + PKCE to the OAuth loopback flow: RFC 8252 §6 makes PKCE a MUST for
+> this public Desktop-app/loopback client shape, and a verified `state` closes a
+> co-resident DoS/CSRF-injection variant on the one-shot listener (memo
+> `2026-07-13-gws-oauth-loopback-state-pkce.md`; PKCE API confirmed present in the
+> pinned `google-auth-library`). Adds a new T4b THREAT-MODEL subsection for the
+> OAuth handshake (previously uncovered — only token storage was). Both stay within
+> a single file each; no new dependency, no new ADR (each implements an explicit
+> spec MUST / verified fix within the existing design).
+
+<!-- -->
+
 ## Dependency graph
 
 ```mermaid
@@ -877,4 +908,6 @@ graph LR
   WP097[WP-097 scheduler generator path escaping]
   WP098[WP-098 scheduler secondary-call fail-loud + truthful remove]
   WP099[WP-099 install.ps1 Git-asset URL host/HTTPS validation]
+  WP100[WP-100 Codex tool-output recognition + fail-closed roles]
+  WP101[WP-101 gws OAuth loopback state + PKCE]
 ```

--- a/docs/specs/WP-095-tccguard-realpath-resolution.md
+++ b/docs/specs/WP-095-tccguard-realpath-resolution.md
@@ -1,6 +1,6 @@
 ---
 id: WP-095
-title: Realpath-resolve the vault path before the TCC guard so a symlinked vault can't reintroduce the unattended hang
+title: Resolve the vault path's symlinks component-wise before the TCC guard so a symlinked vault can't reintroduce the unattended hang
 status: In-Review
 model: sonnet
 size: S
@@ -9,7 +9,7 @@ adrs: []
 branch: wp/095-tccguard-realpath-resolution
 ---
 
-# WP-095: TCC-guard realpath resolution
+# WP-095: TCC-guard component-wise symlink resolution
 
 ## Context (read this, nothing else)
 
@@ -380,6 +380,6 @@ npm run lint
 
 1. All verification steps pass locally; output pasted into the PR body.
 2. Branch `wp/095-tccguard-realpath-resolution`; conventional commits; PR titled
-   `fix(run-job): realpath-resolve the vault before the TCC guard (WP-095)`.
+   `fix(run-job): resolve the vault's symlinks component-wise before the TCC guard (WP-095)` (the design deliberately AVOIDS `fs.realpathSync` — see the Exact contracts).
 3. PR template filled, including "Decisions made" (or "none") and `Generated-by:`.
 4. This spec's `status:` flipped to `In-Review` in the same PR.

--- a/docs/specs/WP-099-install-ps1-git-url-validation.md
+++ b/docs/specs/WP-099-install-ps1-git-url-validation.md
@@ -270,7 +270,7 @@ Behavior:
 
 ```bash
 pwsh -c "Invoke-Pester tests/ps/install-ps1.Tests.ps1"
-pwsh -c "Invoke-ScriptAnalyzer -Path install.ps1 -Settings tests/ps/PSScriptAnalyzerSettings.psd1"
+pwsh -c "Invoke-ScriptAnalyzer -Path install.ps1 -Settings ./PSScriptAnalyzerSettings.psd1"
 npm run lint
 ```
 

--- a/docs/specs/WP-100-codex-tool-output-and-fail-closed-roles.md
+++ b/docs/specs/WP-100-codex-tool-output-and-fail-closed-roles.md
@@ -1,0 +1,343 @@
+---
+id: WP-100
+title: Codex transcript parser — recognize the current tool-output item type and fail-closed role classification
+status: Draft
+model: sonnet
+size: S
+depends_on: []
+adrs: [ADR-0004]
+branch: wp/100-codex-tool-output-and-fail-closed-roles
+---
+
+# WP-100: Codex tool-output recognition + fail-closed roles
+
+## Context (read this, nothing else)
+
+Wienerdog reads AI-CLI session **transcripts** (Claude JSONL, Codex rollout
+files) and consolidates them into a markdown memory vault during the nightly
+**dream** run. A parser turns each transcript into an **Extract**: a normalized
+list of `messages`, each `{role, text, ts}` where `role` is one of
+`'user' | 'assistant' | 'tool_result'`.
+
+The `role` field is a **security boundary**, not a cosmetic label. The threat
+model (T1 — persistent prompt injection via memory) treats **user-authored text
+as trusted** and **tool-result content as untrusted**. Downstream, every dream
+candidate is tagged `derived_from_untrusted: true` when its supporting text came
+from `role: 'tool_result'` messages; Tier-3 destinations (identity, skills, the
+injected session digest) are **closed to untrusted-derived content**. So a
+message the parser emits as `role: 'tool_result'` is fenced off from the highest-
+trust memory; a message emitted as `role: 'user'` is eligible for it. Mislabeling
+tool output as `user` is a T1 provenance bypass; dropping tool output entirely is
+a completeness gap that also means the untrusted-tagging path never fires.
+
+Two verified defects exist in the Codex parser (`src/core/transcripts/codex.js`),
+confirmed against real `codex-cli 0.144.1` rollout data and upstream
+`openai/codex` source (memo `memory/research/2026-07-13-codex-transcript-role-provenance.md`):
+
+1. **Stale tool-output recognition.** `mapCodexItem` only recognizes
+   `function_call_output` as tool output. But codex-cli 0.144.x emits tool/exec
+   output as **`custom_tool_call_output`** (with `function_call_output` /
+   `local_shell_call` / `web_search_call` / `tool_search_output` as
+   legacy/alternate variants). In real sampled sessions **~18% of all
+   response items** (every tool/exec output) is therefore silently DROPPED — the
+   dream never sees it, and the Codex `derived_from_untrusted` tagging path
+   **never fires in practice**.
+2. **Default-trust role classification.** The `message` branch does
+   `role === 'assistant' ? 'assistant' : 'user'` — i.e. *trust everything that is
+   not literally `assistant`*. Codex's upstream `Message.role` is an **untyped
+   `String`** with no schema enforcement, so if the protocol ever routes tool /
+   external content through a `message` item under a novel role string (a future
+   MCP passthrough, a `"tool"` role convention, a provider bug), it is silently
+   absorbed as **trusted `user` text** — the exact T1 bypass, latent today
+   because tool output currently never rides in a `message` item.
+
+**Product invariant that bounds this WP:** Wienerdog is just files (ADR-0004) —
+this WP changes a pure parsing function and its tests; it starts nothing, adds no
+dependency. Fail-closed beats fail-open on a T1 surface: an unrecognized role
+must be **dropped**, never defaulted to trusted.
+
+## Current state
+
+`src/core/transcripts/codex.js` — `mapCodexItem` (the ONLY function this WP
+changes) and its exports:
+
+```js
+/**
+ * Map one response_item payload to a message, or null if it produces none.
+ * Isolated so M4 (WP-010) can correct field names cheaply against a live
+ * Codex CLI machine — this shape is UNVERIFIED against real output.
+ * @param {Object} payload
+ * @returns {{role:'user'|'assistant'|'tool_result', text:string, ts:null}|null}
+ */
+function mapCodexItem(payload) {
+  if (!payload) return null;
+  if (payload.type === 'message') {
+    const role = payload.role === 'assistant' ? 'assistant' : 'user';
+    const content = Array.isArray(payload.content) ? payload.content : [];
+    const text = content
+      .filter((block) => block && (block.type === 'input_text' || block.type === 'output_text'))
+      .map((block) => block.text)
+      .join('\n');
+    return { role, text, ts: null };
+  }
+  if (payload.type === 'function_call_output') {
+    return { role: 'tool_result', text: payload.output, ts: null };
+  }
+  return null;
+}
+
+module.exports = { discoverCodex, parseCodexTranscript, mapCodexItem };
+```
+
+`parseCodexTranscript` calls `mapCodexItem(obj.payload)` for each
+`type === 'response_item'` line and pushes non-null results into `messages`.
+That call site is **unchanged** by this WP.
+
+**Reference — how the Claude parser classifies (the pattern to match).**
+`src/core/transcripts/claude.js` classifies untrusted content by a **positive
+marker**, not by role elimination: a user-message block is emitted as
+`role: 'tool_result'` **only** when `block.type === 'tool_result'` is explicitly
+present; plain-string user content is trusted `role: 'user'`; array blocks that
+match no handled type are **silently skipped (dropped), not defaulted to
+trusted**. Codex must adopt the same fail-closed posture: recognize tool output
+by explicit item type → `tool_result`; trust `message` text only for an explicit
+role allowlist; drop anything else.
+
+**Redaction / capping (downstream, unchanged, shown for the golden fixture).**
+After `mapCodexItem`, `src/core/transcripts/index.js` redacts secret-looking
+substrings and applies size caps. Relevant here: the string
+`password=hunter2secret1234567` becomes `password=[REDACTED:generic-secret]`.
+The golden `.expected.json` reflects the **post-redaction** text.
+
+**Extract `messages` role type** (`src/core/transcripts/index.js`):
+`Array<{role:'user'|'assistant'|'tool_result', text:string, ts:string|null}>`.
+
+## Deliverables (permission boundary — touch ONLY these)
+
+<!-- Always allowed without listing: this spec file, docs/specs/ROADMAP.md, package-lock.json. -->
+
+| Action | Path | Notes |
+|--------|------|-------|
+| modify | src/core/transcripts/codex.js | Rewrite `mapCodexItem` per the Exact contract: (a) `message` branch uses an explicit trusted-role ALLOWLIST of EXACTLY {`user`, `developer`} → user (`assistant`→assistant); `system` AND any other/absent role → `null`/drop, NEVER default-trust; (b) recognize the tool-output item types (`custom_tool_call_output` primary + `function_call_output`/`local_shell_call`/`web_search_call`/`tool_search_output`) → `role:'tool_result'`; (c) replace the stale "UNVERIFIED / re-verify at M4 (WP-010)" comments (lines ~48–52 and ~74) with a citation of memo `memory/research/2026-07-13-codex-transcript-role-provenance.md`. NO change to `discoverCodex` or `parseCodexTranscript`. |
+| modify | tests/unit/transcripts.test.js | Add direct `mapCodexItem` acceptance tests (all 8 cases below). |
+| modify | tests/fixtures/transcripts/codex-rollout.jsonl | Add three response_item lines (a `custom_tool_call_output`, a `developer` message, and a `system` message that must be DROPPED) — golden update EXPLICITLY authorized by this WP. |
+| modify | tests/fixtures/transcripts/codex-rollout.expected.json | Reflect the new lines (developer→user, custom_tool_call_output→tool_result, `system`→dropped) — golden update EXPLICITLY authorized by this WP. |
+| modify | docs/THREAT-MODEL.md | Add the T1 note recorded under "THREAT-MODEL addition" below. |
+
+### Exact contracts
+
+Rewrite `mapCodexItem` (and add two small pure helpers in the same file) to
+exactly this:
+
+```js
+// Trusted `message` roles — EXACTLY {user, developer}. `user` = the user's own
+// prompts; `developer` = Codex-authored control/sandbox scaffolding (confirmed in
+// real codex-cli 0.144.1 rollout data — NOT tool-derived). FAIL CLOSED: any other
+// role — INCLUDING `system` — is DROPPED, never defaulted to trusted `user`,
+// because the upstream Message.role is an untyped String with no schema
+// enforcement. `system` is harness/control-plane instruction text, not
+// user-authored memory content the dream needs; dropping it loses nothing
+// valuable and avoids an unevidenced trust decision.
+// (memo 2026-07-13-codex-transcript-role-provenance)
+const TRUSTED_MESSAGE_ROLES = new Set(['user', 'developer']);
+
+// Tool/external-output item types → UNTRUSTED (role 'tool_result'). Primary on
+// codex-cli 0.144.x: custom_tool_call_output. Legacy/alternate variants:
+// function_call_output, local_shell_call, web_search_call, tool_search_output.
+// Each is a distinct response_item `type`, never a `message`.
+const TOOL_OUTPUT_TYPES = new Set([
+  'custom_tool_call_output',
+  'function_call_output',
+  'local_shell_call',
+  'web_search_call',
+  'tool_search_output',
+]);
+
+/** Join a message item's input_text/output_text content blocks. */
+function extractMessageText(payload) {
+  const content = Array.isArray(payload.content) ? payload.content : [];
+  return content
+    .filter((block) => block && (block.type === 'input_text' || block.type === 'output_text'))
+    .map((block) => block.text)
+    .join('\n');
+}
+
+/** Best-effort text from a tool-output item across the known shapes. Returns ''
+ *  when no known field is present — the item is STILL emitted as tool_result
+ *  (untrusted), never dropped or trusted. */
+function extractToolOutputText(payload) {
+  if (typeof payload.output === 'string') return payload.output;                    // legacy function_call_output
+  if (payload.output && typeof payload.output.content === 'string') return payload.output.content; // FunctionCallOutputPayload struct
+  if (Array.isArray(payload.content)) {                                             // observed custom_tool_call_output 0.144.x
+    return payload.content
+      .filter((block) => block && (block.type === 'input_text' || block.type === 'output_text'))
+      .map((block) => block.text)
+      .join('\n');
+  }
+  return ''; // unverified variant field shape — tagged tool_result regardless
+}
+
+/**
+ * Map one response_item payload to a message, or null if it produces none.
+ * Verified against codex-cli 0.144.1 + upstream openai/codex source
+ * (memo memory/research/2026-07-13-codex-transcript-role-provenance.md).
+ * @param {Object} payload
+ * @returns {{role:'user'|'assistant'|'tool_result', text:string, ts:null}|null}
+ */
+function mapCodexItem(payload) {
+  if (!payload) return null;
+  if (payload.type === 'message') {
+    if (payload.role === 'assistant') {
+      return { role: 'assistant', text: extractMessageText(payload), ts: null };
+    }
+    if (TRUSTED_MESSAGE_ROLES.has(payload.role)) {
+      return { role: 'user', text: extractMessageText(payload), ts: null };
+    }
+    return null; // FAIL CLOSED: unknown/absent role → drop, never trust
+  }
+  if (TOOL_OUTPUT_TYPES.has(payload.type)) {
+    return { role: 'tool_result', text: extractToolOutputText(payload), ts: null };
+  }
+  return null;
+}
+```
+
+Keep `module.exports = { discoverCodex, parseCodexTranscript, mapCodexItem };`
+(`mapCodexItem` is already exported and is the acceptance-test entry point).
+
+**Acceptance test cases (direct `mapCodexItem` unit tests).** Input → output:
+
+| # | Input `payload` | Expected result |
+|---|---|---|
+| 1 | `{type:'custom_tool_call_output', call_id:'c1', name:'exec', content:[{type:'input_text', text:'exec stdout: 3 files'}]}` | `{role:'tool_result', text:'exec stdout: 3 files', ts:null}` |
+| 2 | `{type:'function_call_output', output:'file bytes'}` | `{role:'tool_result', text:'file bytes', ts:null}` (legacy still works) |
+| 3 | `{type:'message', role:'developer', content:[{type:'input_text', text:'sandbox read-only'}]}` | `{role:'user', text:'sandbox read-only', ts:null}` |
+| 4 | `{type:'message', role:'system', content:[{type:'input_text', text:'sys'}]}` | `null` (FAIL CLOSED — `system` is control-plane text, NOT trusted; dropped) |
+| 5 | `{type:'message', role:'tool', content:[{type:'input_text', text:'MUST DROP'}]}` | `null` (FAIL CLOSED — unrecognized role) |
+| 6 | `{type:'message', role:'user', content:[{type:'input_text', text:'hi'}]}` | `{role:'user', text:'hi', ts:null}` (unchanged) |
+| 7 | `{type:'message', role:'assistant', content:[{type:'output_text', text:'yo'}]}` | `{role:'assistant', text:'yo', ts:null}` (unchanged) |
+| 8 | `{type:'local_shell_call', status:'completed', action:{}}` (source-only variant — output field shape UNobserved) | assert ONLY `result.role === 'tool_result'` (RECOGNIZED as untrusted); do NOT assert a specific `text` — its field shape is unverified, so text may be `''` |
+
+Case 8 is deliberately recognition-only: for the source-only variants
+(`local_shell_call`/`web_search_call`/`tool_search_output`) the invariant is
+"**recognized as `tool_result` (untrusted)**", NOT a specific extracted text. Do
+not fabricate an `output` field for them. The verified `custom_tool_call_output`
+(case 1, real-data shape) is the one that asserts extracted text.
+
+**Golden fixture extension.** Insert these three lines into
+`tests/fixtures/transcripts/codex-rollout.jsonl` **immediately after** the
+existing `function_call_output` line and **before** the `event_msg` line:
+
+```jsonl
+{"type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"Filesystem sandboxing is read-only."}]}}
+{"type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call_1","name":"exec","content":[{"type":"input_text","text":"exec stdout: 3 files"}]}}
+{"type":"response_item","payload":{"type":"message","role":"system","content":[{"type":"input_text","text":"MUST-DROP control-plane text"}]}}
+```
+
+The resulting `tests/fixtures/transcripts/codex-rollout.expected.json` `messages`
+array (post-redaction, in on-disk order) is exactly:
+
+```json
+"messages": [
+  { "role": "user", "text": "List my TODOs", "ts": null },
+  { "role": "assistant", "text": "Here are your TODOs.", "ts": null },
+  { "role": "tool_result", "text": "file contents: password=[REDACTED:generic-secret]", "ts": null },
+  { "role": "user", "text": "Filesystem sandboxing is read-only.", "ts": null },
+  { "role": "tool_result", "text": "exec stdout: 3 files", "ts": null }
+]
+```
+
+(The `role:'system'` message is DROPPED — it is absent from `messages`. The other
+top-level fields of `codex-rollout.expected.json` — `harness`, `session_id`,
+`started`, `cwd`, `truncated` — are unchanged.)
+
+### THREAT-MODEL addition (docs/THREAT-MODEL.md)
+
+Under **T1 — Persistent prompt injection via memory**, in the **Mitigations**
+list, append this bullet immediately after the existing "Provenance tracking at
+capture" bullet:
+
+> - **Parser-level provenance dependency (Codex).** The `derived_from_untrusted`
+>   tagging above is only correct if each transcript parser (a) recognizes the
+>   harness's *current* tool-output item type and routes it to `role:'tool_result'`,
+>   and (b) classifies `message` roles by an explicit **trusted-role allowlist**,
+>   dropping any unrecognized role rather than defaulting it to trusted `user`.
+>   For Codex this is load-bearing because upstream `Message.role` is an **untyped
+>   string** with no schema enforcement (verified against codex-cli 0.144.1 and
+>   `openai/codex` source, WP-100 / memo 2026-07-13): a future protocol change
+>   that routed tool/external content through a novel `message` role would
+>   otherwise be silently absorbed as trusted user text. **Residual (accepted):**
+>   a Codex CLI version bump can rename or add tool-output item types; the golden
+>   fixture (WP-100) catches a drop of the *known* types in CI, but a genuinely
+>   new type must be re-verified on the next Codex pin bump.
+
+## Implementation notes & constraints
+
+- Zero new dependencies; plain Node ≥ 18, JSDoc types only (CLAUDE.md).
+- **`system` is NOT trusted — it is dropped** (Codex spec-review decision). The
+  trusted allowlist is EXACTLY {`user`, `developer`}. `system`-role items are
+  harness/control-plane instruction text, not user-authored memory content the
+  dream needs — dropping them loses nothing valuable and removes an unevidenced
+  trust decision (the real 0.144.1 rollout sample never required trusting
+  `system`). Fail-closed: a dropped `system` message is never mis-trusted.
+- The unverified variants (`local_shell_call`, `web_search_call`,
+  `tool_search_output`) were read from upstream source only, not observed in real
+  sampled sessions; their exact output-text field is **not confirmed**. That is
+  why `extractToolOutputText` is best-effort and always returns a `tool_result`
+  entry even on empty text — recognizing the item as untrusted output is the
+  security-critical property; perfect text extraction is not. Do NOT special-case
+  these beyond the shared helper, and do NOT fabricate an `output` field for them
+  in tests — the acceptance test for these variants asserts ONLY
+  `role === 'tool_result'` (recognition), never a specific extracted text.
+- Do NOT capture the tool *invocation* items (`custom_tool_call` / `function_call`)
+  — those are the model's own actions, out of scope here (see Out of scope).
+- When uncertain: choose the simpler option and record it under "Decisions made"
+  in the PR. Do NOT expand scope.
+
+## Security checklist
+
+- [ ] Tool/external output is classified UNTRUSTED (`role:'tool_result'`) by
+      explicit item-type match, never trusted.
+- [ ] `message` text is trusted ONLY for the exact allowlist {`user`, `developer`}
+      (plus `assistant`→assistant); any other/absent role — INCLUDING `system` —
+      is DROPPED (returns `null`), never defaulted to trusted `user`, so the parser
+      fails closed if the Codex protocol changes.
+- [ ] No transcript content flows into a filesystem path or shell command in this
+      WP (pure in-memory parsing) — the path-traversal checklist item is N/A.
+
+## Acceptance criteria
+
+- [ ] All 8 direct `mapCodexItem` cases in the table above pass.
+- [ ] The extended Codex golden fixture parses to exactly the `messages` array
+      shown (developer→user, custom_tool_call_output→tool_result, `system`-role
+      dropped, existing three entries unchanged).
+- [ ] The existing legacy `function_call_output` golden entry still parses to a
+      `tool_result` (no regression).
+- [ ] `npm test` and `npm run lint` are green.
+
+## Verification steps (run these; paste output in the PR)
+
+```bash
+npm test -- --test-name-pattern "Codex|mapCodexItem|transcript"
+npm test
+npm run lint
+```
+
+## Out of scope (do NOT do these)
+
+- Capturing tool *invocation* items (`custom_tool_call`, `function_call`) — a
+  separate completeness enhancement, not this security/coverage fix.
+- Changing `discoverCodex` or `parseCodexTranscript` control flow.
+- The Claude parser (`claude.js`) — referenced only as the pattern to match.
+- Any new ADR — this is a verified bug fix + defense-in-depth consistent with the
+  existing T1 model, not a new architectural decision.
+
+## Definition of done
+
+1. All verification steps pass locally; output pasted into the PR body.
+2. Branch `wp/100-codex-tool-output-and-fail-closed-roles`; conventional commits;
+   PR titled `fix(transcripts): recognize Codex tool-output items and fail closed on unknown roles (WP-100)`.
+3. PR template filled, including "Decisions made" (or "none") and `Generated-by:`.
+4. This spec's `status:` flipped to `In-Review` in the same PR.
+</content>
+</invoke>

--- a/docs/specs/WP-101-gws-oauth-state-pkce.md
+++ b/docs/specs/WP-101-gws-oauth-state-pkce.md
@@ -1,0 +1,422 @@
+---
+id: WP-101
+title: gws OAuth loopback — add state + PKCE (RFC 8252)
+status: Draft
+model: sonnet
+size: S
+depends_on: []
+adrs: [ADR-0004]
+branch: wp/101-gws-oauth-state-pkce
+---
+
+# WP-101: gws OAuth loopback state + PKCE
+
+## Context (read this, nothing else)
+
+`wienerdog gws auth` connects a user's Google account with the **OAuth loopback
+flow** for Desktop-app clients: it starts a one-shot HTTP listener on an
+ephemeral `127.0.0.1` port, opens Google's consent URL in the browser, and
+Google redirects back to `http://127.0.0.1:<port>/?code=...`; the listener reads
+the code and exchanges it for tokens (stored 0600 under `~/.wienerdog/secrets/`).
+The client is a **per-user** Google Cloud "Desktop app" OAuth client whose
+`client_id`/`client_secret` the user pastes in; it is stored 0600, not baked into
+any distributed binary.
+
+Two verified gaps against the primary specs (memo
+`memory/research/2026-07-13-gws-oauth-loopback-state-pkce.md`, fetched RFC 8252 /
+RFC 7636 / Google's native-app doc / the `google-auth-library` API):
+
+1. **No `state`.** The auth URL carries no `state`, and the listener resolves on
+   the **first** request carrying a `?code=` (or `?error=`) with **no correlation
+   to the request Wienerdog actually made**. A co-resident process on the same
+   machine can enumerate loopback listeners (`lsof`/`netstat`, no privilege) and
+   race a bogus `GET /?code=garbage` into the one-shot listener before the real
+   browser callback, hijacking the promise with a code that fails `getToken`
+   (`invalid_grant`) — a **DoS/CSRF-injection** on the `auth` command. Google's
+   native-app doc recommends verifying `state` server-side "to ensure that the
+   user, not a malicious script, is making the request."
+2. **No PKCE.** RFC 8252 §6 makes PKCE a **MUST** for exactly this public
+   loopback/Desktop-app client shape (§8.1: the loopback redirect "may be
+   susceptible to interception by other apps accessing the same loopback
+   interface"). `google-auth-library` supports PKCE but it is **opt-in** — the
+   caller must call `generateCodeVerifierAsync()`, pass
+   `code_challenge`/`code_challenge_method=S256` into `generateAuthUrl`, and pass
+   `codeVerifier` into `getToken`. Wienerdog does none of this.
+
+The *credential-hijack* worst case is bounded by file permissions on the 0600
+`client_id` in Wienerdog's current per-user-client model (an attacker who can
+mint a redeemable code already has file-read/terminal access equivalent to a full
+local compromise — the memo's shape (B)).
+
+**Right-sizing the mitigations honestly (don't over-claim):** `state` is printed
+in the authorization URL (to stdout / the user's terminal), so it defends only
+the **BLIND co-resident race** — an attacker who guesses the ephemeral port
+WITHOUT seeing the URL cannot produce a matching `state` — plus standard CSRF
+correlation. It does **NOT** defend against an attacker who can OBSERVE the
+printed URL (same terminal/environment): such an attacker can craft a
+matching-`state` callback, and is already inside the user's session (out of
+scope). **PKCE** is the real defense against authorization-code injection
+(RFC 8252 §6 MUST): an intercepted code is not redeemable without the
+`code_verifier`, which never appears in the URL. A bounded **listener timeout**
+backstops both — an attacker flooding mismatched-`state` callbacks, or a user who
+never completes consent, can no longer wedge the process. All three are additive,
+contained to `src/gws/auth.js`, and do not change the persisted token/client JSON
+shape.
+
+**Product invariant that bounds this WP:** Wienerdog is just files (ADR-0004) —
+"no socket may outlive the command"; the listener is still closed in `finally`.
+No new dependency: `google-auth-library` (behind the pinned `googleapis@^173`
+already used by gws) provides `generateCodeVerifierAsync`.
+
+## Current state
+
+`src/gws/auth.js` — `run()` (loopback + URL + exchange) and the internal
+`startLoopback()` (NOT exported today):
+
+```js
+async function run(paths, opts = {}) {
+  // ... reads/persists client JSON, ensures googleapis ...
+
+  // 3. Start the loopback listener on an ephemeral port before building the URL.
+  const { server, port, waitForCode } = await startLoopback();
+
+  try {
+    const redirectUri = `http://127.0.0.1:${port}/`;
+    const oauth =
+      opts.oauthClient ||
+      new (opts.googleapis || loadGoogleapis(paths)).google.auth.OAuth2(
+        cfg.client_id, cfg.client_secret, redirectUri
+      );
+
+    // 4. Generate + present the consent URL.
+    const authUrl = oauth.generateAuthUrl({
+      access_type: 'offline',
+      prompt: 'consent',
+      scope: SCOPES,
+    });
+    process.stdout.write(`\nOpen this URL ...\n\n${authUrl}\n\n`);
+    if (opts.openBrowser) opts.openBrowser(authUrl);
+
+    // 5. Wait for the single loopback redirect carrying ?code=...
+    const code = await waitForCode;
+
+    // 6. Exchange the code for tokens and persist them.
+    const token = (await oauth.getToken(code)).tokens;
+    oauth.setCredentials(token);
+    persistToken(paths, token);
+    // 7. Best-effort email ...
+    return { email, tokenPath: require('./client').tokenPath(paths) };
+  } finally {
+    server.close(); // No socket may outlive the command (ADR-0004).
+  }
+}
+
+function startLoopback() {
+  return new Promise((resolve, reject) => {
+    let resolveCode; let rejectCode;
+    const waitForCode = new Promise((res, rej) => { resolveCode = res; rejectCode = rej; });
+    const server = http.createServer((req, res) => {
+      const url = new URL(req.url, 'http://127.0.0.1');
+      const code = url.searchParams.get('code');
+      const error = url.searchParams.get('error');
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(CLOSE_PAGE);
+      if (error) rejectCode(new WienerdogError(`Google denied authorization: ${error}`));
+      else if (code) resolveCode(code);
+    });
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve({ server, port: server.address().port, waitForCode }));
+  });
+}
+
+module.exports = { run };
+```
+
+`opts.oauthClient` and `opts.googleapis` are already injectable test seams.
+`node:crypto` is NOT yet required in this file; `node:http` is.
+
+**Verified library facts** (googleapis@^173 → google-auth-library, confirmed
+against the installed version):
+- `await oauth.generateCodeVerifierAsync()` → `{ codeVerifier, codeChallenge }`.
+- `oauth.generateAuthUrl({ ..., state, code_challenge, code_challenge_method: 'S256' })`
+  emits `state`, `code_challenge`, `code_challenge_method` as URL query params.
+- `oauth.getToken({ code, codeVerifier })` sends `code` + `code_verifier` in the
+  token exchange (the object form; the current string form `getToken(code)` is
+  what we replace).
+
+## Deliverables (permission boundary — touch ONLY these)
+
+<!-- Always allowed without listing: this spec file, docs/specs/ROADMAP.md, package-lock.json. -->
+
+| Action | Path | Notes |
+|--------|------|-------|
+| modify | src/gws/auth.js | Add `state` (random) + PKCE per the Exact contract; `startLoopback(expectedState)` VERIFIES `state` and ignores/keeps-listening on mismatch; add an `opts.startLoopback` injection seam; **export `startLoopback`** for direct testing. |
+| create | tests/unit/gws-auth.test.js | Acceptance tests (all cases below). No auth test exists today. |
+| modify | docs/THREAT-MODEL.md | Add the **T4b** subsection recorded under "THREAT-MODEL addition" below. |
+
+### Exact contracts
+
+**`run()` sequence (state generated before the listener; PKCE after the OAuth
+client exists):**
+
+```js
+const crypto = require('node:crypto'); // add near the other requires
+
+// inside run(), replacing steps 3–6:
+
+// A random, high-entropy state correlates the callback to the request we made.
+const state = crypto.randomBytes(32).toString('base64url');
+
+// Loopback listener verifies `state`; injectable for tests.
+const startLoopbackFn = opts.startLoopback || startLoopback;
+const { server, port, waitForCode } = await startLoopbackFn(state);
+
+try {
+  const redirectUri = `http://127.0.0.1:${port}/`;
+  const oauth =
+    opts.oauthClient ||
+    new (opts.googleapis || loadGoogleapis(paths)).google.auth.OAuth2(
+      cfg.client_id, cfg.client_secret, redirectUri
+    );
+
+  // PKCE (RFC 8252 MUST for this client shape). Opt-in in google-auth-library.
+  const { codeVerifier, codeChallenge } = await oauth.generateCodeVerifierAsync();
+
+  const authUrl = oauth.generateAuthUrl({
+    access_type: 'offline',
+    prompt: 'consent',
+    scope: SCOPES,
+    state,
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256',
+  });
+  process.stdout.write(`\nOpen this URL in your browser to authorize Wienerdog:\n\n${authUrl}\n\n`);
+  if (opts.openBrowser) opts.openBrowser(authUrl);
+
+  const code = await waitForCode;
+
+  const token = (await oauth.getToken({ code, codeVerifier })).tokens;
+  oauth.setCredentials(token);
+  persistToken(paths, token);
+  // ... step 7 (email) unchanged ...
+} finally {
+  server.close();
+}
+```
+
+**`startLoopback(expectedState, timeoutMs)` — verify `state`, ignore mismatches,
+BOUNDED by a timeout:**
+
+The keep-listening-on-mismatch behavior MUST be bounded, or a mismatched-`state`
+flood (or a user who never completes consent) would wedge the process forever.
+`auth.js` has no existing timeout to reuse, so introduce
+`CONSENT_TIMEOUT_MS = 5 * 60 * 1000` (a generous OAuth-consent window). Make the
+value injectable so tests can drive the abort path with a tiny value without a
+lingering 5-minute timer; `unref()` the timer so a pending timeout never keeps
+the event loop alive on its own.
+
+```js
+const CONSENT_TIMEOUT_MS = 5 * 60 * 1000; // 5 min — the OAuth consent window
+
+/**
+ * One-shot loopback listener on 127.0.0.1:0. Resolves the `code` ONLY from a
+ * request whose `state` matches `expectedState`; a request with a missing or
+ * mismatched `state` is answered with the close page but IGNORED (the listener
+ * keeps waiting for the correct one) — this drops a raced/CSRF callback instead
+ * of failing on it. An `error=` is honored only when its `state` matches. After
+ * `timeoutMs` with no matching callback the flow ABORTS: `waitForCode` rejects
+ * with a plain-language error (the caller's `finally` closes the server).
+ * @param {string} expectedState
+ * @param {number} [timeoutMs]
+ * @returns {Promise<{server:import('node:http').Server, port:number, waitForCode:Promise<string>}>}
+ */
+function startLoopback(expectedState, timeoutMs = CONSENT_TIMEOUT_MS) {
+  return new Promise((resolve, reject) => {
+    let resolveCode; let rejectCode; let timer;
+    const waitForCode = new Promise((res, rej) => {
+      resolveCode = (v) => { clearTimeout(timer); res(v); };
+      rejectCode = (e) => { clearTimeout(timer); rej(e); };
+    });
+    const server = http.createServer((req, res) => {
+      const url = new URL(req.url, 'http://127.0.0.1');
+      const state = url.searchParams.get('state');
+      const code = url.searchParams.get('code');
+      const error = url.searchParams.get('error');
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(CLOSE_PAGE);
+      if (state !== expectedState) return; // ignore raced/unrelated callbacks; keep listening
+      if (error) rejectCode(new WienerdogError(`Google denied authorization: ${error}`));
+      else if (code) resolveCode(code);
+    });
+    timer = setTimeout(() => {
+      rejectCode(new WienerdogError(
+        'Timed out waiting for Google authorization. Re-run `wienerdog gws auth` and complete the consent in your browser.'
+      ));
+    }, timeoutMs);
+    if (typeof timer.unref === 'function') timer.unref();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve({ server, port: server.address().port, waitForCode }));
+  });
+}
+
+module.exports = { run, startLoopback };
+```
+
+Behavior:
+- Auth URL now carries `state`, `code_challenge`, and `code_challenge_method=S256`.
+- A BLIND same-machine attacker's `GET /?code=garbage` (no/mismatched `state`) is
+  answered with the close page but **ignored** — `waitForCode` stays pending; the
+  real browser callback (correct `state`) still resolves it. This closes the
+  blind-race/CSRF variant; it does NOT stop an attacker who can read the printed
+  URL (out of scope — already inside the user's session).
+- The listener ABORTS after `CONSENT_TIMEOUT_MS` (5 min) with a plain-language
+  error, so a flood of mismatched-`state` callbacks or an abandoned consent can no
+  longer wedge the process.
+- Token exchange includes `code_verifier` — an intercepted code is not redeemable
+  without the verifier (RFC 7636 / RFC 8252 §6 MUST). This is the real
+  code-injection defense.
+- Persisted token/client JSON shapes are unchanged; `finally { server.close() }`
+  unchanged (ADR-0004).
+
+### Acceptance test cases (`tests/unit/gws-auth.test.js`)
+
+Two seams make this fully unit-testable without a live Google:
+
+**(i) `run()` with an injected `oauthClient` + `opts.startLoopback` fake** (no
+real network): the fake `startLoopback(state)` returns `{ server: {close(){}},
+port: 12345, waitForCode: Promise.resolve('the-code') }`; the mock `oauthClient`
+provides `generateCodeVerifierAsync` → `{codeVerifier:'ver', codeChallenge:'chal'}`,
+a `generateAuthUrl(opts)` that records `opts` and returns a URL, a
+`getToken(arg)` that records `arg` and returns `{tokens:{access_token:'a'}}`,
+`setCredentials(){}`, plus a stub `opts.googleapis` so `fetchEmail` returns null.
+Provide a real temp `clientPath` with a valid `{installed:{client_id,client_secret,...}}`
+JSON and a temp `paths`. Assert:
+- [ ] `generateAuthUrl` was called with a non-empty string `state`, and with
+      `code_challenge: 'chal'` and `code_challenge_method: 'S256'`.
+- [ ] `getToken` was called with `{ code: 'the-code', codeVerifier: 'ver' }`.
+
+**(ii) Real `startLoopback(expectedState, timeoutMs)` (exported) — state
+verification + timeout** (drive with real loopback HTTP requests to
+`127.0.0.1:<port>`; pass a generous `timeoutMs` for the state cases and a tiny one
+for the timeout case, so no test lingers on the 5-minute default):
+- [ ] A request with a **mismatched** `state` (`?state=wrong&code=x`) does NOT
+      resolve `waitForCode` (assert it is still pending after the response — e.g.
+      `Promise.race` against a short timer resolves to the timer sentinel).
+- [ ] A request with an **absent** `state` (`?code=x`) likewise does not resolve.
+- [ ] A subsequent request with the **matching** `state` (`?state=<expected>&code=good`)
+      resolves `waitForCode` to `'good'`.
+- [ ] A request with matching `state` and `?error=access_denied` rejects
+      `waitForCode`; a mismatched-`state` `error=` is ignored.
+- [ ] With a **tiny `timeoutMs`** (e.g. 50 ms) and NO matching callback (send
+      nothing, or only a mismatched-`state` request), `waitForCode` **rejects with
+      the plain-language timeout error** — the bounded-abort backstop.
+- Close the server at the end of each case.
+
+### THREAT-MODEL addition (docs/THREAT-MODEL.md)
+
+Add a new subsection immediately **after T4a** (before T5a):
+
+> ## T4b — OAuth handshake integrity (loopback state + PKCE)
+>
+> **Attack/hazard**: the `gws auth` loopback listener accepts a callback on an
+> ephemeral `127.0.0.1` port. A co-resident process can enumerate loopback
+> listeners without privilege and race a callback into the one-shot listener
+> (RFC 8252 §8.1: the loopback redirect "may be susceptible to interception by
+> other apps accessing the same loopback interface").
+>
+> **Mitigations (WP-101)**: the auth request carries a high-entropy `state`; the
+> listener resolves ONLY on a callback whose `state` matches, ignoring
+> (keep-listening on) any raced/unrelated request. `state` is a **partial**
+> mitigation: it is printed in the authorization URL, so it defends the BLIND
+> co-resident race (an attacker guessing the ephemeral port WITHOUT seeing the URL)
+> and provides CSRF correlation — it does **NOT** defend against an attacker who can
+> OBSERVE the printed URL (same terminal/environment), who can craft a
+> matching-`state` callback. **PKCE** (`code_challenge`/`S256` on the auth URL,
+> `code_verifier` on the token exchange, RFC 8252 §6 MUST) is the real defense
+> against authorization-code injection: an intercepted code is not redeemable
+> without the verifier (RFC 7636), which never appears in the URL. A bounded
+> **listener timeout** (5 min) backstops both a mismatched-`state` flood and an
+> abandoned consent, so neither can wedge the `auth` command.
+>
+> **Residual (accepted)**: a same-terminal / URL-observing attacker is out of
+> scope — they already hold the user's session. And in the current
+> per-user-client model the
+> *credential-hijack* variant (an attacker redeeming their OWN valid code) already
+> requires read access to the 0600 `client_id` — the same file-permission boundary
+> that guards the token itself (T4) — so state/PKCE are defense-in-depth there, not
+> the primary control. A future shared/multi-user client model would remove that
+> file-permission mitigation and make PKCE load-bearing; it must not ship
+> without state + PKCE.
+
+## Implementation notes & constraints
+
+- Zero new dependencies (`google-auth-library` via the existing `googleapis`
+  pin); plain Node ≥ 18, JSDoc types only (CLAUDE.md). `node:crypto` is a
+  built-in.
+- The PKCE API is **confirmed present** in the pinned `google-auth-library`
+  (`generateCodeVerifierAsync` → `{codeVerifier, codeChallenge}`;
+  `getToken({code, codeVerifier})` sends `code_verifier`). Do NOT add a fallback
+  for its absence — it is pinned by `googleapis@^173`.
+- `state` uses `crypto.randomBytes(32).toString('base64url')` (URL-safe, no query
+  escaping needed). Do not weaken the entropy source.
+- Mismatched-`state` callbacks are **ignored (keep listening)**, NOT rejected —
+  rejecting would reintroduce the very DoS the keep-listening design avoids (any
+  stray first `code=` request would kill the flow). This is load-bearing; keep it
+  exactly. The bounded timeout below is what prevents an unbounded keep-listening
+  wedge — the two work together.
+- The listener timeout is `CONSENT_TIMEOUT_MS = 5 * 60 * 1000` (5 min — a generous
+  OAuth-consent window). `auth.js` has no existing timeout to reuse. Make it the
+  default of an injectable `startLoopback(expectedState, timeoutMs)` so tests drive
+  the abort path with a tiny value; `unref()` the timer so a pending timeout never
+  keeps the event loop alive on its own. On timeout, `waitForCode` rejects with a
+  plain-language error and the caller's `finally` closes the server.
+- Do NOT change `persistToken` / `persistClientJson` / `fetchEmail` / `SCOPES`, or
+  the token/client JSON shapes. The `finally { server.close() }` (ADR-0004) stays.
+- When uncertain: choose the simpler option and record it under "Decisions made".
+  Do NOT expand scope (no keyring, no fixed-port registration, no multi-account).
+
+## Security checklist
+
+- [ ] The auth URL carries a high-entropy `state` and the listener resolves ONLY
+      on a matching-`state` callback; a mismatched/absent-`state` request is
+      ignored (keep listening), so a BLIND raced local callback cannot hijack the
+      one-shot promise (a URL-observing same-terminal attacker is out of scope).
+- [ ] The listener aborts after a bounded timeout (`CONSENT_TIMEOUT_MS`, 5 min)
+      with a plain-language error and the server is closed, so a mismatched-`state`
+      flood or an abandoned consent cannot wedge the process.
+- [ ] PKCE is wired end-to-end: `code_challenge` + `code_challenge_method=S256` on
+      the auth URL AND `code_verifier` in the token exchange (RFC 8252 §6 MUST) —
+      this is the real code-injection defense, not `state`.
+- [ ] No secret is logged or persisted beyond the existing 0600 token/client
+      files; the `state`/`code_verifier` live only in memory for the command's
+      lifetime, and the socket is still closed in `finally` (ADR-0004).
+
+## Acceptance criteria
+
+- [ ] All test cases (i) and (ii) above pass.
+- [ ] `npm test` and `npm run lint` are green.
+
+## Verification steps (run these; paste output in the PR)
+
+```bash
+npm test -- --test-name-pattern "gws-auth|auth|loopback|state|pkce"
+npm test
+npm run lint
+```
+
+## Out of scope (do NOT do these)
+
+- Fixed/registered redirect port, OS keyring storage, or multi-account support.
+- Any change to token/client persistence, scopes, or `fetchEmail`.
+- The scenario harness or the google-setup skill prose (WP-012) — unchanged.
+- A new ADR — this implements an explicit RFC 8252 MUST within the existing gws
+  design, not a new architectural decision.
+
+## Definition of done
+
+1. All verification steps pass locally; output pasted into the PR body.
+2. Branch `wp/101-gws-oauth-state-pkce`; conventional commits; PR titled
+   `feat(gws): add state + PKCE to the OAuth loopback flow (WP-101)`.
+3. PR template filled, including "Decisions made" (or "none") and `Generated-by:`.
+4. This spec's `status:` flipped to `In-Review` in the same PR.
+</content>


### PR DESCRIPTION
Post-audit cleanup + two new WP specs surfaced by the wd-researcher checks.

## New specs (Draft)
- **WP-100** — Codex transcript parser: recognize `custom_tool_call_output` (codex-cli 0.144.x renamed it from `function_call_output`) + legacy variants → `tool_result` (untrusted), and replace default-trust role logic with a fail-closed allowlist (`{user, developer}` trusted; everything else, incl. `system`, dropped). Fixes a verified functional bug where ~18% of Codex session content (all tool/exec output) is silently dropped and `derived_from_untrusted` tagging never fires. Backed by `memory/research/2026-07-13-codex-transcript-role-provenance.md`.
- **WP-101** — gws OAuth loopback: add `state` (verified on callback, blind-race + CSRF mitigation) + PKCE (RFC 8252 §6 code-injection defense) + a bounded consent timeout. Backed by `memory/research/2026-07-13-gws-oauth-loopback-state-pkce.md`.

Both revised per a Codex spec-review (system dropped from trusted; fabricated test shape corrected; loopback timeout added; security claims right-sized to what the design delivers).

## THREAT-MODEL touch-ups
- T4a residual: a local process that can write `config.yaml` (or call exported `saveGrant`) can forge a send grant — the typed-confirmation defends only against model/headless creation (accepted, same file-perm boundary as T4).
- T5b/ADR-0016 residual: WP-093's tar member preflight covers name-based `../`/absolute escapes + the temp-file TOCTOU only; the symlink/hardlink LINK-MEMBER vector is a named residual pending a spike.
- New T4b subsection (OAuth handshake) added by WP-101's deliverable at implementation time.

## Cosmetic spec-nit fixes
- WP-095: corrected stale "realpath-resolve" wording (final design uses component-wise symlink resolution, deliberately avoiding `realpathSync`).
- WP-099: fixed the PSScriptAnalyzer settings path (`./PSScriptAnalyzerSettings.psd1`, repo root).

---
Generated-by: claude-fable-5 (orchestrate) + wd-architect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uxThuapovGTPsbyn86BAf
