### PR TITLE
fix(transcripts): recognize Codex tool-output items + fail-closed role allowlist (WP-100)

### DIFF
--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -27,6 +27,19 @@ Wienerdog auto-writes persistent memory derived from conversation transcripts, i
 
 **Mitigations**:
 - **Provenance tracking at capture**: every dream candidate is tagged by whether its supporting text originated in tool-result blocks (`derived_from_untrusted: true`) or user-authored messages.
+- **Parser-level provenance dependency (Codex).** The `derived_from_untrusted`
+  tagging above is only correct if each transcript parser (a) recognizes the
+  harness's *current* tool-output item type and routes it to `role:'tool_result'`,
+  and (b) classifies `message` roles by an explicit **trusted-role allowlist**,
+  dropping any unrecognized role rather than defaulting it to trusted `user`.
+  For Codex this is load-bearing because upstream `Message.role` is an **untyped
+  string** with no schema enforcement (verified against codex-cli 0.144.1 and
+  `openai/codex` source, WP-100 / memo 2026-07-13): a future protocol change
+  that routed tool/external content through a novel `message` role would
+  otherwise be silently absorbed as trusted user text. **Residual (accepted):**
+  a Codex CLI version bump can rename or add tool-output item types; the golden
+  fixture (WP-100) catches a drop of the *known* types in CI, but a genuinely
+  new type must be re-verified on the next Codex pin bump.
 - **Tiered gates**: Tier 3 destinations — `06-Identity/`, `05-Skills/`, anything that feeds the injected digest — require score ≥ 0.85 AND recurrence across ≥ 3 distinct sessions AND `derived_from_untrusted: false`. Untrusted-derived content can exist only in Tier 1/2 notes, flagged, and is excluded from digest rendering. One scoped exception: per-skill `LEARNINGS.md` ledgers under `05-Skills/` are quarantined observation data — never injected into sessions, never executed — and may record single-session and untrusted-derived entries by design; whether an entry can *authorize* a skill revision is governed by ADR-0020's mechanical trust rules instead.
 - **Code, not the model, enforces the boundary**: the orchestrator validates the post-dream git diff; any write violating tier rules is reverted and flagged in the dream report.
 - **One commit per dream** → `git revert <sha>` undoes an entire night.

--- a/docs/specs/WP-100-codex-tool-output-and-fail-closed-roles.md
+++ b/docs/specs/WP-100-codex-tool-output-and-fail-closed-roles.md
@@ -1,7 +1,7 @@
 ---
 id: WP-100
 title: Codex transcript parser — recognize the current tool-output item type and fail-closed role classification
-status: Draft
+status: In-Review
 model: sonnet
 size: S
 depends_on: []

--- a/src/core/transcripts/codex.js
+++ b/src/core/transcripts/codex.js
@@ -45,26 +45,73 @@ function discoverCodex(sessionsDir, opts) {
   return results;
 }
 
+// Trusted `message` roles — EXACTLY {user, developer}. `user` = the user's own
+// prompts; `developer` = Codex-authored control/sandbox scaffolding (confirmed in
+// real codex-cli 0.144.1 rollout data — NOT tool-derived). FAIL CLOSED: any other
+// role — INCLUDING `system` — is DROPPED, never defaulted to trusted `user`,
+// because the upstream Message.role is an untyped String with no schema
+// enforcement. `system` is harness/control-plane instruction text, not
+// user-authored memory content the dream needs; dropping it loses nothing
+// valuable and avoids an unevidenced trust decision.
+// (memo memory/research/2026-07-13-codex-transcript-role-provenance.md)
+const TRUSTED_MESSAGE_ROLES = new Set(['user', 'developer']);
+
+// Tool/external-output item types → UNTRUSTED (role 'tool_result'). Primary on
+// codex-cli 0.144.x: custom_tool_call_output. Legacy/alternate variants:
+// function_call_output, local_shell_call, web_search_call, tool_search_output.
+// Each is a distinct response_item `type`, never a `message`.
+const TOOL_OUTPUT_TYPES = new Set([
+  'custom_tool_call_output',
+  'function_call_output',
+  'local_shell_call',
+  'web_search_call',
+  'tool_search_output',
+]);
+
+/** Join a message item's input_text/output_text content blocks. */
+function extractMessageText(payload) {
+  const content = Array.isArray(payload.content) ? payload.content : [];
+  return content
+    .filter((block) => block && (block.type === 'input_text' || block.type === 'output_text'))
+    .map((block) => block.text)
+    .join('\n');
+}
+
+/** Best-effort text from a tool-output item across the known shapes. Returns ''
+ *  when no known field is present — the item is STILL emitted as tool_result
+ *  (untrusted), never dropped or trusted. */
+function extractToolOutputText(payload) {
+  if (typeof payload.output === 'string') return payload.output;                    // legacy function_call_output
+  if (payload.output && typeof payload.output.content === 'string') return payload.output.content; // FunctionCallOutputPayload struct
+  if (Array.isArray(payload.content)) {                                             // observed custom_tool_call_output 0.144.x
+    return payload.content
+      .filter((block) => block && (block.type === 'input_text' || block.type === 'output_text'))
+      .map((block) => block.text)
+      .join('\n');
+  }
+  return ''; // unverified variant field shape — tagged tool_result regardless
+}
+
 /**
  * Map one response_item payload to a message, or null if it produces none.
- * Isolated so M4 (WP-010) can correct field names cheaply against a live
- * Codex CLI machine — this shape is UNVERIFIED against real output.
+ * Verified against codex-cli 0.144.1 + upstream openai/codex source
+ * (memo memory/research/2026-07-13-codex-transcript-role-provenance.md).
  * @param {Object} payload
  * @returns {{role:'user'|'assistant'|'tool_result', text:string, ts:null}|null}
  */
 function mapCodexItem(payload) {
   if (!payload) return null;
   if (payload.type === 'message') {
-    const role = payload.role === 'assistant' ? 'assistant' : 'user';
-    const content = Array.isArray(payload.content) ? payload.content : [];
-    const text = content
-      .filter((block) => block && (block.type === 'input_text' || block.type === 'output_text'))
-      .map((block) => block.text)
-      .join('\n');
-    return { role, text, ts: null };
+    if (payload.role === 'assistant') {
+      return { role: 'assistant', text: extractMessageText(payload), ts: null };
+    }
+    if (TRUSTED_MESSAGE_ROLES.has(payload.role)) {
+      return { role: 'user', text: extractMessageText(payload), ts: null };
+    }
+    return null; // FAIL CLOSED: unknown/absent role → drop, never trust
   }
-  if (payload.type === 'function_call_output') {
-    return { role: 'tool_result', text: payload.output, ts: null };
+  if (TOOL_OUTPUT_TYPES.has(payload.type)) {
+    return { role: 'tool_result', text: extractToolOutputText(payload), ts: null };
   }
   return null;
 }

--- a/tests/fixtures/transcripts/codex-rollout.expected.json
+++ b/tests/fixtures/transcripts/codex-rollout.expected.json
@@ -7,6 +7,8 @@
   "messages": [
     { "role": "user", "text": "List my TODOs", "ts": null },
     { "role": "assistant", "text": "Here are your TODOs.", "ts": null },
-    { "role": "tool_result", "text": "file contents: password=[REDACTED:generic-secret]", "ts": null }
+    { "role": "tool_result", "text": "file contents: password=[REDACTED:generic-secret]", "ts": null },
+    { "role": "user", "text": "Filesystem sandboxing is read-only.", "ts": null },
+    { "role": "tool_result", "text": "exec stdout: 3 files", "ts": null }
   ]
 }

--- a/tests/fixtures/transcripts/codex-rollout.jsonl
+++ b/tests/fixtures/transcripts/codex-rollout.jsonl
@@ -3,4 +3,7 @@
 {"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"List my TODOs"}]}}
 {"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Here are your TODOs."}]}}
 {"type":"response_item","payload":{"type":"function_call_output","output":"file contents: password=hunter2secret1234567"}}
+{"type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"Filesystem sandboxing is read-only."}]}}
+{"type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call_1","name":"exec","content":[{"type":"input_text","text":"exec stdout: 3 files"}]}}
+{"type":"response_item","payload":{"type":"message","role":"system","content":[{"type":"input_text","text":"MUST-DROP control-plane text"}]}}
 {"type":"event_msg","payload":{"type":"agent_message","message":"duplicate — ignored"}}

--- a/tests/unit/transcripts.test.js
+++ b/tests/unit/transcripts.test.js
@@ -7,6 +7,7 @@ const os = require('node:os');
 const path = require('node:path');
 
 const { discover, parse, redact, rebaseInvocations, MAX_MESSAGES } = require('../../src/core/transcripts');
+const { mapCodexItem } = require('../../src/core/transcripts/codex');
 
 const fixturesDir = path.join(__dirname, '..', 'fixtures', 'transcripts');
 
@@ -37,7 +38,8 @@ test('parse: Claude skill-invocation extract matches fixture', () => {
 });
 
 test('parse: Codex golden extract matches fixture', () => {
-  // UNVERIFIED against live Codex CLI — re-verify at M4 (WP-010)
+  // Verified against codex-cli 0.144.1 + upstream openai/codex source
+  // (memo memory/research/2026-07-13-codex-transcript-role-provenance.md)
   const inputPath = path.join(fixturesDir, 'codex-rollout.jsonl');
   const expected = JSON.parse(fs.readFileSync(path.join(fixturesDir, 'codex-rollout.expected.json'), 'utf8'));
 
@@ -45,6 +47,71 @@ test('parse: Codex golden extract matches fixture', () => {
 
   assert.deepEqual(withoutSourcePath(extract), expected);
   assert.equal(extract.source_path, inputPath);
+});
+
+test('mapCodexItem: custom_tool_call_output (0.144.x primary shape) -> tool_result', () => {
+  const result = mapCodexItem({
+    type: 'custom_tool_call_output',
+    call_id: 'c1',
+    name: 'exec',
+    content: [{ type: 'input_text', text: 'exec stdout: 3 files' }],
+  });
+  assert.deepEqual(result, { role: 'tool_result', text: 'exec stdout: 3 files', ts: null });
+});
+
+test('mapCodexItem: legacy function_call_output still works -> tool_result', () => {
+  const result = mapCodexItem({ type: 'function_call_output', output: 'file bytes' });
+  assert.deepEqual(result, { role: 'tool_result', text: 'file bytes', ts: null });
+});
+
+test('mapCodexItem: message role developer (trusted allowlist) -> user', () => {
+  const result = mapCodexItem({
+    type: 'message',
+    role: 'developer',
+    content: [{ type: 'input_text', text: 'sandbox read-only' }],
+  });
+  assert.deepEqual(result, { role: 'user', text: 'sandbox read-only', ts: null });
+});
+
+test('mapCodexItem: message role system -> FAIL CLOSED, dropped', () => {
+  const result = mapCodexItem({
+    type: 'message',
+    role: 'system',
+    content: [{ type: 'input_text', text: 'sys' }],
+  });
+  assert.equal(result, null);
+});
+
+test('mapCodexItem: message role unrecognized (e.g. "tool") -> FAIL CLOSED, dropped', () => {
+  const result = mapCodexItem({
+    type: 'message',
+    role: 'tool',
+    content: [{ type: 'input_text', text: 'MUST DROP' }],
+  });
+  assert.equal(result, null);
+});
+
+test('mapCodexItem: message role user (unchanged) -> user', () => {
+  const result = mapCodexItem({
+    type: 'message',
+    role: 'user',
+    content: [{ type: 'input_text', text: 'hi' }],
+  });
+  assert.deepEqual(result, { role: 'user', text: 'hi', ts: null });
+});
+
+test('mapCodexItem: message role assistant (unchanged) -> assistant', () => {
+  const result = mapCodexItem({
+    type: 'message',
+    role: 'assistant',
+    content: [{ type: 'output_text', text: 'yo' }],
+  });
+  assert.deepEqual(result, { role: 'assistant', text: 'yo', ts: null });
+});
+
+test('mapCodexItem: local_shell_call (source-only variant) -> recognized as tool_result, text unverified', () => {
+  const result = mapCodexItem({ type: 'local_shell_call', status: 'completed', action: {} });
+  assert.equal(result.role, 'tool_result');
 });
 
 test('redact: every REDACTIONS pattern fires, ordinary text untouched', () => {


### PR DESCRIPTION
Spec: docs/specs/WP-100-codex-tool-output-and-fail-closed-roles.md

Fixes a verified functional bug in the Codex transcript parser (found by the post-audit wd-researcher check, memo `memory/research/2026-07-13-codex-transcript-role-provenance.md`). `mapCodexItem` checked for `function_call_output`, but codex-cli 0.144.x renamed the item type to `custom_tool_call_output` — so **~18% of every Codex session (all tool/exec output) was silently dropped**, the dream never saw it, and Codex `derived_from_untrusted` tagging never fired. Now tool-output item types (`custom_tool_call_output` + legacy `function_call_output`/`local_shell_call`/`web_search_call`/`tool_search_output`) route to `role:'tool_result'` (untrusted), and the `message` branch uses a fail-closed trusted-role allowlist (`{user, developer}` → user; `assistant`; **everything else, incl. `system`, dropped**) so the parser can't be tricked into trusting content by an unexpected role.

## Deliverables checklist
- [x] Changed files in the Deliverables table (`src/core/transcripts/codex.js`, `tests/unit/transcripts.test.js`, the golden fixture pair, `docs/THREAT-MODEL.md` T1 note)
- [x] Spec status flipped to In-Review

## Verification output
```
npm test : 757 pass / 0 fail / 4 skip (pre-existing)
npm run lint : clean
node scripts/boundary-check.js : exit 0
```
All 8 mapCodexItem acceptance cases pass (incl. system→dropped, custom_tool_call_output→tool_result with real text, source-only variants asserting only role==='tool_result').

## Decisions made
- none (followed the revised spec's exact contracts).

## Discovered issues (out of scope, not fixed)
- `parseCodexTranscript`'s docstring still carries a stale "UNVERIFIED / re-verify at M4" note; the spec scoped the comment fix to `mapCodexItem` only, so left untouched — worth a follow-up.

---
Generated-by: claude-sonnet (implement) + claude-fable-5 (orchestrate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uxThuapovGTPsbyn86BAf
