### PR TITLE
fix(gws): add OAuth state + PKCE + consent timeout to the loopback flow (WP-101)

### DIFF
--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -67,6 +67,38 @@ As of ADR-0020, dream-created skills can also be **revised** automatically from 
 
 **Residual (accepted, v1)**: the CLI typed-confirmation defends only against *model/headless* grant creation — any local process able to write `config.yaml` directly (or to load the project modules and call the exported `saveGrant`) can forge a send grant, since a grant is an unauthenticated YAML fact with no provenance or signature marker. This is the same OS-user file-permission boundary that guards the OAuth tokens (T4); a provenance/signature marker on grants is deliberately **not** built in v1 (it would not raise the boundary above file permissions an already-local attacker has cleared). Accepted; revisit if grants ever move outside a single-user-machine trust model.
 
+## T4b — OAuth handshake integrity (loopback state + PKCE)
+
+**Attack/hazard**: the `gws auth` loopback listener accepts a callback on an
+ephemeral `127.0.0.1` port. A co-resident process can enumerate loopback
+listeners without privilege and race a callback into the one-shot listener
+(RFC 8252 §8.1: the loopback redirect "may be susceptible to interception by
+other apps accessing the same loopback interface").
+
+**Mitigations (WP-101)**: the auth request carries a high-entropy `state`; the
+listener resolves ONLY on a callback whose `state` matches, ignoring
+(keep-listening on) any raced/unrelated request. `state` is a **partial**
+mitigation: it is printed in the authorization URL, so it defends the BLIND
+co-resident race (an attacker guessing the ephemeral port WITHOUT seeing the URL)
+and provides CSRF correlation — it does **NOT** defend against an attacker who can
+OBSERVE the printed URL (same terminal/environment), who can craft a
+matching-`state` callback. **PKCE** (`code_challenge`/`S256` on the auth URL,
+`code_verifier` on the token exchange, RFC 8252 §6 MUST) is the real defense
+against authorization-code injection: an intercepted code is not redeemable
+without the verifier (RFC 7636), which never appears in the URL. A bounded
+**listener timeout** (5 min) backstops both a mismatched-`state` flood and an
+abandoned consent, so neither can wedge the `auth` command.
+
+**Residual (accepted)**: a same-terminal / URL-observing attacker is out of
+scope — they already hold the user's session. And in the current
+per-user-client model the
+*credential-hijack* variant (an attacker redeeming their OWN valid code) already
+requires read access to the 0600 `client_id` — the same file-permission boundary
+that guards the token itself (T4) — so state/PKCE are defense-in-depth there, not
+the primary control. A future shared/multi-user client model would remove that
+file-permission mitigation and make PKCE load-bearing; it must not ship
+without state + PKCE.
+
 ## T5a — curl|bash entry point
 
 **Hazard**: the default install is `curl … | bash` (ADR-0006), a pattern users are right to be wary of.

--- a/docs/specs/WP-101-gws-oauth-state-pkce.md
+++ b/docs/specs/WP-101-gws-oauth-state-pkce.md
@@ -1,7 +1,7 @@
 ---
 id: WP-101
 title: gws OAuth loopback — add state + PKCE (RFC 8252)
-status: Draft
+status: In-Review
 model: sonnet
 size: S
 depends_on: []

--- a/src/gws/auth.js
+++ b/src/gws/auth.js
@@ -2,6 +2,7 @@
 
 const fs = require('node:fs');
 const http = require('node:http');
+const crypto = require('node:crypto');
 
 const { WienerdogError } = require('../core/errors');
 const { SCOPES, persistToken, persistClientJson } = require('./client');
@@ -16,11 +17,16 @@ const CLOSE_PAGE =
   '<h2>Wienerdog is connected.</h2><p>You can close this tab and return to your terminal.</p>' +
   '</body></html>';
 
+// 5 min — a generous OAuth-consent window. Injectable so tests can drive the
+// abort path with a tiny value instead of waiting on the real default.
+const CONSENT_TIMEOUT_MS = 5 * 60 * 1000;
+
 /**
  * Run the interactive OAuth loopback flow and persist the token.
  * @param {WienerdogPaths} paths
  * @param {{clientPath?: string, googleapis?: object, oauthClient?: object,
- *          openBrowser?: (url:string)=>void}} opts
+ *          openBrowser?: (url:string)=>void,
+ *          startLoopback?: (expectedState:string, timeoutMs?:number)=>Promise<{server:object,port:number,waitForCode:Promise<string>}>}} opts
  * @returns {Promise<{email:string|null, tokenPath:string}>}
  */
 async function run(paths, opts = {}) {
@@ -55,8 +61,13 @@ async function run(paths, opts = {}) {
     runInstall: opts.runInstall,
   });
 
+  // A random, high-entropy state correlates the callback to the request we made.
+  const state = crypto.randomBytes(32).toString('base64url');
+
   // 3. Start the loopback listener on an ephemeral port before building the URL.
-  const { server, port, waitForCode } = await startLoopback();
+  // Loopback listener verifies `state`; injectable for tests.
+  const startLoopbackFn = opts.startLoopback || startLoopback;
+  const { server, port, waitForCode } = await startLoopbackFn(state);
 
   try {
     const redirectUri = `http://127.0.0.1:${port}/`;
@@ -70,11 +81,17 @@ async function run(paths, opts = {}) {
         redirectUri
       );
 
+    // PKCE (RFC 8252 MUST for this client shape). Opt-in in google-auth-library.
+    const { codeVerifier, codeChallenge } = await oauth.generateCodeVerifierAsync();
+
     // 4. Generate + present the consent URL.
     const authUrl = oauth.generateAuthUrl({
       access_type: 'offline',
       prompt: 'consent',
       scope: SCOPES,
+      state,
+      code_challenge: codeChallenge,
+      code_challenge_method: 'S256',
     });
     process.stdout.write(
       `\nOpen this URL in your browser to authorize Wienerdog:\n\n${authUrl}\n\n`
@@ -85,7 +102,7 @@ async function run(paths, opts = {}) {
     const code = await waitForCode;
 
     // 6. Exchange the code for tokens and persist them.
-    const token = (await oauth.getToken(code)).tokens;
+    const token = (await oauth.getToken({ code, codeVerifier })).tokens;
     oauth.setCredentials(token);
     persistToken(paths, token);
 
@@ -119,37 +136,44 @@ async function fetchEmail(oauth, opts, paths) {
 }
 
 /**
- * Start a one-shot loopback HTTP listener on 127.0.0.1:0. Resolves the code
- * from the first request's `?code=` query param; the listener is closed by the
- * caller's finally block.
- * @returns {Promise<{server:import('node:http').Server, port:number,
- *   waitForCode:Promise<string>}>}
+ * One-shot loopback listener on 127.0.0.1:0. Resolves the `code` ONLY from a
+ * request whose `state` matches `expectedState`; a request with a missing or
+ * mismatched `state` is answered with the close page but IGNORED (the listener
+ * keeps waiting for the correct one) — this drops a raced/CSRF callback instead
+ * of failing on it. An `error=` is honored only when its `state` matches. After
+ * `timeoutMs` with no matching callback the flow ABORTS: `waitForCode` rejects
+ * with a plain-language error (the caller's `finally` closes the server).
+ * @param {string} expectedState
+ * @param {number} [timeoutMs]
+ * @returns {Promise<{server:import('node:http').Server, port:number, waitForCode:Promise<string>}>}
  */
-function startLoopback() {
+function startLoopback(expectedState, timeoutMs = CONSENT_TIMEOUT_MS) {
   return new Promise((resolve, reject) => {
-    let resolveCode;
-    let rejectCode;
+    let resolveCode; let rejectCode; let timer;
     const waitForCode = new Promise((res, rej) => {
-      resolveCode = res;
-      rejectCode = rej;
+      resolveCode = (v) => { clearTimeout(timer); res(v); };
+      rejectCode = (e) => { clearTimeout(timer); rej(e); };
     });
-
     const server = http.createServer((req, res) => {
       const url = new URL(req.url, 'http://127.0.0.1');
+      const state = url.searchParams.get('state');
       const code = url.searchParams.get('code');
       const error = url.searchParams.get('error');
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
       res.end(CLOSE_PAGE);
+      if (state !== expectedState) return; // ignore raced/unrelated callbacks; keep listening
       if (error) rejectCode(new WienerdogError(`Google denied authorization: ${error}`));
       else if (code) resolveCode(code);
     });
-
+    timer = setTimeout(() => {
+      rejectCode(new WienerdogError(
+        'Timed out waiting for Google authorization. Re-run `wienerdog gws auth` and complete the consent in your browser.'
+      ));
+    }, timeoutMs);
+    if (typeof timer.unref === 'function') timer.unref();
     server.on('error', reject);
-    server.listen(0, '127.0.0.1', () => {
-      const port = server.address().port;
-      resolve({ server, port, waitForCode });
-    });
+    server.listen(0, '127.0.0.1', () => resolve({ server, port: server.address().port, waitForCode }));
   });
 }
 
-module.exports = { run };
+module.exports = { run, startLoopback };

--- a/tests/unit/gws-auth.test.js
+++ b/tests/unit/gws-auth.test.js
@@ -1,0 +1,177 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { getPaths } = require('../../src/core/paths');
+const auth = require('../../src/gws/auth');
+
+/** Fresh, isolated temp core (no app/deps installed). */
+function tempPaths() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-gws-auth-'));
+  const core = path.join(root, 'wd');
+  return getPaths({ HOME: root, WIENERDOG_HOME: core });
+}
+
+/** Write a valid Desktop-app OAuth client JSON to a temp file; return its path. */
+function tempClientPath() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-gws-client-'));
+  const file = path.join(dir, 'client.json');
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      installed: {
+        client_id: 'id123',
+        client_secret: 'sec123',
+        redirect_uris: ['http://localhost'],
+      },
+    })
+  );
+  return file;
+}
+
+// ---------------------------------------------------------------------------
+// (i) run() with an injected oauthClient + opts.startLoopback fake.
+// ---------------------------------------------------------------------------
+
+test('run() sends state + PKCE on the auth URL and codeVerifier on the token exchange', async () => {
+  const paths = tempPaths();
+  const clientPath = tempClientPath();
+
+  const fakeStartLoopback = (_expectedState) =>
+    Promise.resolve({
+      server: { close() {} },
+      port: 12345,
+      waitForCode: Promise.resolve('the-code'),
+    });
+
+  let generateAuthUrlOpts;
+  let getTokenArg;
+  const oauthClient = {
+    generateCodeVerifierAsync: async () => ({ codeVerifier: 'ver', codeChallenge: 'chal' }),
+    generateAuthUrl: (opts) => {
+      generateAuthUrlOpts = opts;
+      return 'https://accounts.google.com/o/oauth2/v2/auth?fake=1';
+    },
+    getToken: async (arg) => {
+      getTokenArg = arg;
+      return { tokens: { access_token: 'a' } };
+    },
+    setCredentials() {},
+  };
+
+  const googleapisStub = {
+    google: {
+      gmail: () => {
+        throw new Error('no gmail in this test');
+      },
+    },
+  };
+
+  const result = await auth.run(paths, {
+    clientPath,
+    startLoopback: fakeStartLoopback,
+    oauthClient,
+    googleapis: googleapisStub,
+    yes: true,
+    runInstall: () => ({ status: 0 }),
+  });
+
+  assert.equal(typeof generateAuthUrlOpts.state, 'string');
+  assert.ok(generateAuthUrlOpts.state.length > 0);
+  assert.equal(generateAuthUrlOpts.code_challenge, 'chal');
+  assert.equal(generateAuthUrlOpts.code_challenge_method, 'S256');
+
+  assert.deepEqual(getTokenArg, { code: 'the-code', codeVerifier: 'ver' });
+
+  assert.equal(result.email, null);
+});
+
+// ---------------------------------------------------------------------------
+// (ii) Real startLoopback(expectedState, timeoutMs) — state verification +
+// timeout. Driven with real loopback HTTP requests.
+// ---------------------------------------------------------------------------
+
+const PENDING = Symbol('pending');
+
+/** Resolve to PENDING if `p` has not settled within `ms`; else to `p`'s outcome. */
+function raceIsPending(p, ms) {
+  const timer = new Promise((resolve) => setTimeout(() => resolve(PENDING), ms));
+  return Promise.race([p.then((v) => ({ settled: 'resolved', v })).catch((e) => ({ settled: 'rejected', e })), timer]);
+}
+
+test('startLoopback ignores a mismatched-state callback and keeps listening', async () => {
+  const expected = 'expected-state-value';
+  const { server, port, waitForCode } = await auth.startLoopback(expected, 60_000);
+  try {
+    await fetch(`http://127.0.0.1:${port}/?state=wrong&code=x`);
+    const outcome = await raceIsPending(waitForCode, 50);
+    assert.equal(outcome, PENDING, 'waitForCode must still be pending after a mismatched-state callback');
+  } finally {
+    server.close();
+  }
+});
+
+test('startLoopback ignores an absent-state callback and keeps listening', async () => {
+  const expected = 'expected-state-value';
+  const { server, port, waitForCode } = await auth.startLoopback(expected, 60_000);
+  try {
+    await fetch(`http://127.0.0.1:${port}/?code=x`);
+    const outcome = await raceIsPending(waitForCode, 50);
+    assert.equal(outcome, PENDING, 'waitForCode must still be pending after an absent-state callback');
+  } finally {
+    server.close();
+  }
+});
+
+test('startLoopback resolves waitForCode only on a matching-state callback, after ignoring mismatches', async () => {
+  const expected = 'expected-state-value';
+  const { server, port, waitForCode } = await auth.startLoopback(expected, 60_000);
+  try {
+    await fetch(`http://127.0.0.1:${port}/?state=wrong&code=x`);
+    await fetch(`http://127.0.0.1:${port}/?code=x`); // absent state
+    await fetch(`http://127.0.0.1:${port}/?state=${expected}&code=good`);
+    const code = await waitForCode;
+    assert.equal(code, 'good');
+  } finally {
+    server.close();
+  }
+});
+
+test('startLoopback rejects on a matching-state error= callback; a mismatched-state error= is ignored', async () => {
+  const expected = 'expected-state-value';
+  const { server, port, waitForCode } = await auth.startLoopback(expected, 60_000);
+  try {
+    // Mismatched-state error is ignored — still pending.
+    await fetch(`http://127.0.0.1:${port}/?state=wrong&error=access_denied`);
+    let outcome = await raceIsPending(waitForCode, 50);
+    assert.equal(outcome, PENDING);
+
+    // Matching-state error rejects.
+    await fetch(`http://127.0.0.1:${port}/?state=${expected}&error=access_denied`);
+    await assert.rejects(waitForCode, (err) => {
+      assert.match(err.message, /Google denied authorization: access_denied/);
+      return true;
+    });
+  } finally {
+    server.close();
+  }
+});
+
+test('startLoopback rejects with a plain-language timeout error when no matching callback arrives', async () => {
+  const expected = 'expected-state-value';
+  const { server, port, waitForCode } = await auth.startLoopback(expected, 50);
+  try {
+    // Only a mismatched-state request arrives before the tiny timeout fires.
+    await fetch(`http://127.0.0.1:${port}/?state=wrong&code=x`);
+    await assert.rejects(waitForCode, (err) => {
+      assert.match(err.message, /Timed out waiting for Google authorization/);
+      return true;
+    });
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
Spec: docs/specs/WP-101-gws-oauth-state-pkce.md

Hardens the gws OAuth loopback flow (post-audit wd-researcher check, memo `memory/research/2026-07-13-gws-oauth-loopback-state-pkce.md`). Adds a random `state` verified on the callback (`startLoopback` resolves only on matching state; mismatched/absent state is ignored and it keeps listening), a 5-minute bounded consent timeout (rejects with a plain-language error rather than hanging), and PKCE (`generateCodeVerifierAsync()` → `code_challenge`/`S256` on the URL, `codeVerifier` on token exchange — RFC 8252 §6). `state` mitigates the blind co-resident port-guess race + CSRF (a URL-observer is out of scope); PKCE is the code-injection defense. New THREAT-MODEL T4b entry documents the handshake.

## Deliverables checklist
- [x] Changed files in the Deliverables table (`src/gws/auth.js`, `tests/unit/gws-auth.test.js`, `docs/THREAT-MODEL.md` T4b)
- [x] Spec status flipped to In-Review

## Verification output
```
npm test : 755 pass / 0 fail / 4 skip (pre-existing)
npm run lint : clean
node scripts/boundary-check.js : exit 0
```
PKCE API verified against the installed google-auth-library (`generateCodeVerifierAsync()` → `{codeVerifier, codeChallenge}`; `getToken({code, codeVerifier})` sends `code_verifier`). 6 new gws-auth tests incl. mismatched/absent-state-ignored, matching-state-resolves, and a 50ms-timeout rejection.

## Decisions made
- none (followed the revised spec's exact contracts).

## Discovered issues (out of scope, not fixed)
- none.

---
Generated-by: claude-sonnet (implement) + claude-fable-5 (orchestrate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uxThuapovGTPsbyn86BAf
