### PR TITLE
docs: WP-102..104 specs — gws deps self-heal, doctor probe, drive search UX

### DIFF
--- a/docs/specs/ROADMAP.md
+++ b/docs/specs/ROADMAP.md
@@ -848,6 +848,17 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 > Finding 4 (MINIMAL VALIDATION) — WP-103 validates the token; WP-102's `hasToken`
 > stays existence-only (documented asymmetry — worst case there is a benign
 > consented install offer).
+> **Codex round-2 spec review (2026-07-13, 3 new defects in the revised material,
+> all inside the already-approved dispositions):** (1, high, WP-105) the backfill
+> insertion sat between sync's disk mutations and `manifestMod.save`, so an
+> interrupt at the prompt / during npm could strand unpersisted manifest entries —
+> moved to run **after** the manifest save, the final statement of `run()` (the
+> install is not manifest-tracked). (2, medium, WP-103) the single "missing or
+> broken" warn falsely promised self-heal for the corrupt-but-resolvable case
+> (self-heal no-ops there) — split into two messages via `isInstalled`: **absent**
+> keeps the offer, **broken** points only to `npm` reinstall. (3, medium, WP-103)
+> `refresh_token` validation was truthiness-only — tightened to a non-empty string.
+> Revision logs on WP-103/105 record the deltas; WP-104 untouched.
 
 <!-- -->
 

--- a/docs/specs/ROADMAP.md
+++ b/docs/specs/ROADMAP.md
@@ -917,6 +917,25 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 > considered), cache-immune, symlink defense preserved. Containment tests (:205–230) stay
 > byte-identical; new in-process case (a4) FAILS on the old walk and passes on the
 > rewrite. WP-103's probe inherits it (no code change). WP-104/105 untouched.
+> **Closing Codex PR pass, round-6 (2026-07-13, two findings; deps.js + prompt.js +
+> doctor.js):** **P1 (high user-visibility, stdout hygiene)** — the self-heal wrote
+> its notice, consent prompt, and npm output to STDOUT, corrupting a connected
+> user's `gws … --json | jq` (and, with stdout piped + a TTY stdin, the prompt was
+> written into the pipe, invisible, while it waited). Routed ALL chatter to stderr:
+> notice → `process.stderr.write`; npm → `defaultRunInstall` `stdio: ['inherit', 2, 2]`;
+> prompt → a new backward-compatible `opts.output` on `confirm` that
+> `ensureGoogleapis` sets to stderr (grows WP-102 by `src/core/prompt.js` + test).
+> **P2 (classification gap the §0 rewrite opened)** — a package.json-present-but-
+> unresolvable (missing-main) tree made `resolveFromDeps` throw → `isInstalled`
+> false → classified ABSENT → self-heal `npm`-over-corrupt → arborist no-op → loop
+> again. Re-keyed the absent/broken split AND the self-heal gate onto **physical
+> presence** (`depsPresent`, the §0 existence check, now exported): every present-yet-
+> unusable state (resolve-throw/require-throw/shape-fail/symlink-out) classifies
+> broken; `ensureGoogleReady` gates on `depsPresent`; `ensureGoogleapis` fails to the
+> honest delete-then-reinstall remedy for a present-but-broken tree on the auth path
+> (owner no-auto-repair); WP-103's doctor swaps its broken-vs-missing key
+> `isInstalled` → `depsPresent`. New tests a5/h/i/j + a doctor missing-main case;
+> a2/a3/a4 + containment probes stay green. `index.js` unchanged. WP-104/105 untouched.
 
 <!-- -->
 

--- a/docs/specs/ROADMAP.md
+++ b/docs/specs/ROADMAP.md
@@ -813,8 +813,8 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 > unchanged connect message; token present + library absent → "needs a one-time
 > install … the next `wienerdog gws` command will offer to install it"; token
 > present + library resolvable-but-unloadable → "broken (installed but not
-> loadable) — reinstall it", no offer claim, mirroring WP-103), the defensive
-> backstop for any direct caller. The
+> loadable) — delete the folder `<depsDir>`, then reinstall it", no offer claim,
+> mirroring WP-103), the defensive backstop for any direct caller. The
 > containment guard (`resolveFromDeps`) is untouched. The existing no-token test
 > assertions stay valid (they exercise the unchanged branch) and are **not**
 > modified. **WP-103** (S, sonnet, depends WP-102, `src/cli/doctor.js` + its test)
@@ -870,6 +870,16 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 > state-aware (same absent/broken split as WP-103's warns), keyed on a `resolvable`
 > flag reused from the resolve attempt already made; added a corrupt-deps
 > `loadGoogleapis` test. WP-103/104/105 untouched.
+> **Codex round-4 spec review (2026-07-13, one finding, WP-102 + WP-103 mirror):**
+> the broken-state remedy `npm install --prefix <deps> …` can **no-op** on a corrupt
+> install — npm/arborist compares tree metadata, not file contents, so a
+> resolvable-but-corrupt `googleapis` reads as "up to date" and stays unloadable.
+> Both broken messages now prescribe a **clean reinstall — delete the folder
+> `<depsDir>` first, then install** (platform-neutral prose; the deps dir is
+> single-purpose so wholesale removal is safe). WP-102's corrupt test now also
+> executes the repair (rmSync + fake install) and asserts `loadGoogleapis` succeeds,
+> proving the flow shape (real npm no-op semantics are out of unit-test reach).
+> WP-104/105 untouched.
 
 <!-- -->
 

--- a/docs/specs/ROADMAP.md
+++ b/docs/specs/ROADMAP.md
@@ -121,8 +121,9 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 | [WP-100](WP-100-codex-tool-output-and-fail-closed-roles.md) | Codex transcript parser — recognize the current tool-output item type (`custom_tool_call_output` + variants) and fail closed on unknown roles | M7 | sonnet | Done | — |
 | [WP-101](WP-101-gws-oauth-state-pkce.md) | gws OAuth loopback — add `state` + PKCE (RFC 8252) | M7 | sonnet | Done | — |
 | [WP-102](WP-102-gws-deps-self-heal.md) | gws read-path self-heal + disambiguated deps error (fix the post-upgrade dead-end) | M5/M7 | sonnet | Ready | — |
-| [WP-103](WP-103-doctor-gws-deps-probe.md) | doctor probe — connected Google account with a missing client library | M5/M7 | sonnet | Ready | WP-102 |
+| [WP-103](WP-103-doctor-gws-deps-probe.md) | doctor probe — connected Google account with a missing/broken client library | M5/M7 | sonnet | Ready | WP-102 |
 | [WP-104](WP-104-gws-drive-search-friendly-query.md) | gws drive search — friendly term search by default, `--raw` for Drive query language | M5 | sonnet | Ready | — |
+| [WP-105](WP-105-sync-interactive-gws-backfill.md) | sync interactive backfill of the on-demand googleapis install (headless-only users) | M5/M7 | sonnet | Draft | WP-102 |
 
 > **First-production-night incident (2026-07-04).** WP-038, WP-039 and WP-041 form
 > a serial chain (they edit the shared `run-job.js` / `dream.js` / `validate.js`
@@ -813,21 +814,40 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 > needs a one-time install"), the defensive backstop for any direct caller. The
 > containment guard (`resolveFromDeps`) is untouched. The existing no-token test
 > assertions stay valid (they exercise the unchanged branch) and are **not**
-> modified. **WP-103** (S, sonnet, depends WP-102 — remedy-wording coherence only,
-> no code dep — `src/cli/doctor.js` + its test) adds the matching visibility: a
-> read-only `doctor` probe that reports **token present + `googleapis`
-> unresolvable from `app/deps`** as a WARN with the one-line remedy (silent when
-> Google is not connected; never a fail). **The report's fix 3 (update-time
-> migration/backfill) is deliberately SKIPPED** — once self-heal-on-read exists it
-> adds a consent/network dependency to the `update` path for no extra coverage
-> (the first read heals it). No new ADR: this implements the existing
-> ADR-0011/0013 on-demand-consented-install design on a code path (read) that WP-047
-> missed; no architectural decision changes. **WP-104** (S, sonnet, independent)
-> captures the report's separate appendix papercut: `gws drive search` passes its
-> arg verbatim as Drive `q`, so a bare word (`budget`) hits `Invalid Value`; the
-> fix wraps a plain term as `fullText contains '…'` by default and adds `--raw`
-> for literal Drive query language — a **default-behavior change the owner
-> confirmed (option B) on 2026-07-13**.
+> modified. **WP-103** (S, sonnet, depends WP-102, `src/cli/doctor.js` + its test)
+> adds the matching visibility: a read-only `doctor` probe that reports a connected
+> account whose client library is missing **or broken** as a WARN with the one-line
+> npm remedy (silent when Google is not connected; never a fail). Per the Codex
+> round-1 review it uses a containment-guarded **LOAD** probe (`loadGoogleapis` in
+> try/catch — not resolve-only, so a corrupt/partial install warns instead of
+> falsely reading `[ok]`) and minimally validates the token (valid JSON +
+> `refresh_token`, else a separate "sign-in file looks damaged" warn). No new ADR:
+> this implements the existing ADR-0011/0013 on-demand-consented-install design on
+> the read path that WP-047 missed. **WP-105** (S, sonnet, depends WP-102, Draft,
+> `src/cli/sync.js` + a new test) **reverses the report's fix-3 "skip"** after the
+> Codex review showed it was wrong for **headless-only (routines-only) users**:
+> their routines run non-TTY and decline the consented install by design, so the
+> read-path self-heal never populates their `app/deps`. WP-105 adds a **consented,
+> interactive-only** backfill in the `sync` flow (which `wienerdog update` hands
+> off to with `stdio: 'inherit'`); a non-TTY `sync` stays mutation-free, and the
+> backfill is best-effort (a decline/failure never fails `sync`). **WP-104** (S,
+> sonnet, independent) captures the report's separate appendix papercut: `gws drive
+> search` passes its arg verbatim as Drive `q`, so a bare word (`budget`) hits
+> `Invalid Value`; the fix wraps a plain term as `fullText contains '…'` by default
+> and adds `--raw` for literal Drive query language — a **default-behavior change
+> the owner confirmed (option B) on 2026-07-13**.
+> **Codex round-1 spec review (2026-07-13, 4 findings, all owner-dispositioned;
+> WP-102/103 already implemented so the revisions land as surgical patches):**
+> Finding 3 (MUST FIX) — WP-102/103 messages wrongly told users to run `wienerdog
+> gws auth` "(no browser needed …)"; `auth.run` throws without `--client <path>`
+> and always opens the full browser OAuth loopback with it. Both messages now lead
+> with the self-heal + the exact npm one-liner and drop the `gws auth` / browser-
+> free claim. Finding 1 (TARGETED) — WP-103 upgraded to a load probe (above); WP-102
+> keeps its cheap resolve-only read-path check with the corrupt-install case
+> recorded as an accepted residual. Finding 2 (ADD BACKFILL) — became WP-105.
+> Finding 4 (MINIMAL VALIDATION) — WP-103 validates the token; WP-102's `hasToken`
+> stays existence-only (documented asymmetry — worst case there is a benign
+> consented install offer).
 
 <!-- -->
 
@@ -953,6 +973,7 @@ graph LR
   WP100[WP-100 Codex tool-output recognition + fail-closed roles]
   WP101[WP-101 gws OAuth loopback state + PKCE]
   WP102[WP-102 gws read-path self-heal + disambiguated deps error]
-  WP102 --> WP103[WP-103 doctor: connected Google + missing client library]
+  WP102 --> WP103[WP-103 doctor: connected Google + missing/broken client library]
+  WP102 --> WP105[WP-105 sync interactive backfill — headless-only users, Draft]
   WP104[WP-104 gws drive search friendly term + --raw]
 ```

--- a/docs/specs/ROADMAP.md
+++ b/docs/specs/ROADMAP.md
@@ -120,6 +120,9 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 | [WP-099](WP-099-install-ps1-git-url-validation.md) | Validate the Git-for-Windows asset URL is HTTPS on a GitHub host before download | M7 | sonnet | Done | — |
 | [WP-100](WP-100-codex-tool-output-and-fail-closed-roles.md) | Codex transcript parser — recognize the current tool-output item type (`custom_tool_call_output` + variants) and fail closed on unknown roles | M7 | sonnet | Done | — |
 | [WP-101](WP-101-gws-oauth-state-pkce.md) | gws OAuth loopback — add `state` + PKCE (RFC 8252) | M7 | sonnet | Done | — |
+| [WP-102](WP-102-gws-deps-self-heal.md) | gws read-path self-heal + disambiguated deps error (fix the post-upgrade dead-end) | M5/M7 | sonnet | Ready | — |
+| [WP-103](WP-103-doctor-gws-deps-probe.md) | doctor probe — connected Google account with a missing client library | M5/M7 | sonnet | Ready | WP-102 |
+| [WP-104](WP-104-gws-drive-search-friendly-query.md) | gws drive search — friendly term search by default, `--raw` for Drive query language | M5 | sonnet | Ready | — |
 
 > **First-production-night incident (2026-07-04).** WP-038, WP-039 and WP-041 form
 > a serial chain (they edit the shared `run-job.js` / `dream.js` / `validate.js`
@@ -789,6 +792,45 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 
 <!-- -->
 
+> **gws post-upgrade dead-end (2026-07-13, `BUG-gws-deps-missing-after-upgrade.md`,
+> credit: owner dogfooding).** A user who connected Google **before** WP-047's
+> on-demand `googleapis` deps-dir scheme has a **valid token** but an **absent**
+> `~/.wienerdog/app/deps/`; after `wienerdog update` across that boundary, every
+> gws read fails with the misleading `Google isn't set up yet — run
+> /wienerdog-google-setup` — a **permanent dead-end** (nothing on the read path
+> backfills `app/deps`) that also silently breaks headless routines (digest,
+> inbox triage). Root cause: `loadGoogleapis` (read path) only *throws*, never
+> installs; the installer `ensureGoogleapis` is called **only** by `gws auth`.
+> Three WPs close it, split by surface. **WP-102** (S, sonnet, `src/gws/deps.js` +
+> `src/gws/index.js` + its test) is the fix: a read command with a valid token but
+> absent deps now **self-heals** — `ensureGoogleReady()` runs the same consented
+> `ensureGoogleapis` install on first read (interactive: consent prompt like first
+> auth; non-TTY/headless: fails to the accurate, browser-free `npm install`
+> remedy, no worse than today); an **unauthed** user (no token) is a no-op and
+> keeps the existing connect-Google flow. `loadGoogleapis` — the sole emit site of
+> the misleading string — is made **token-aware** (no token → unchanged connect
+> message; token present → accurate "Google is connected, but its client library
+> needs a one-time install"), the defensive backstop for any direct caller. The
+> containment guard (`resolveFromDeps`) is untouched. The existing no-token test
+> assertions stay valid (they exercise the unchanged branch) and are **not**
+> modified. **WP-103** (S, sonnet, depends WP-102 — remedy-wording coherence only,
+> no code dep — `src/cli/doctor.js` + its test) adds the matching visibility: a
+> read-only `doctor` probe that reports **token present + `googleapis`
+> unresolvable from `app/deps`** as a WARN with the one-line remedy (silent when
+> Google is not connected; never a fail). **The report's fix 3 (update-time
+> migration/backfill) is deliberately SKIPPED** — once self-heal-on-read exists it
+> adds a consent/network dependency to the `update` path for no extra coverage
+> (the first read heals it). No new ADR: this implements the existing
+> ADR-0011/0013 on-demand-consented-install design on a code path (read) that WP-047
+> missed; no architectural decision changes. **WP-104** (S, sonnet, independent)
+> captures the report's separate appendix papercut: `gws drive search` passes its
+> arg verbatim as Drive `q`, so a bare word (`budget`) hits `Invalid Value`; the
+> fix wraps a plain term as `fullText contains '…'` by default and adds `--raw`
+> for literal Drive query language — a **default-behavior change the owner
+> confirmed (option B) on 2026-07-13**.
+
+<!-- -->
+
 ## Dependency graph
 
 ```mermaid
@@ -910,4 +952,7 @@ graph LR
   WP099[WP-099 install.ps1 Git-asset URL host/HTTPS validation]
   WP100[WP-100 Codex tool-output recognition + fail-closed roles]
   WP101[WP-101 gws OAuth loopback state + PKCE]
+  WP102[WP-102 gws read-path self-heal + disambiguated deps error]
+  WP102 --> WP103[WP-103 doctor: connected Google + missing client library]
+  WP104[WP-104 gws drive search friendly term + --raw]
 ```

--- a/docs/specs/ROADMAP.md
+++ b/docs/specs/ROADMAP.md
@@ -809,9 +809,12 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 > auth; non-TTY/headless: fails to the accurate, browser-free `npm install`
 > remedy, no worse than today); an **unauthed** user (no token) is a no-op and
 > keeps the existing connect-Google flow. `loadGoogleapis` — the sole emit site of
-> the misleading string — is made **token-aware** (no token → unchanged connect
-> message; token present → accurate "Google is connected, but its client library
-> needs a one-time install"), the defensive backstop for any direct caller. The
+> the misleading string — is made **token-aware and state-aware** (no token →
+> unchanged connect message; token present + library absent → "needs a one-time
+> install … the next `wienerdog gws` command will offer to install it"; token
+> present + library resolvable-but-unloadable → "broken (installed but not
+> loadable) — reinstall it", no offer claim, mirroring WP-103), the defensive
+> backstop for any direct caller. The
 > containment guard (`resolveFromDeps`) is untouched. The existing no-token test
 > assertions stay valid (they exercise the unchanged branch) and are **not**
 > modified. **WP-103** (S, sonnet, depends WP-102, `src/cli/doctor.js` + its test)
@@ -859,6 +862,14 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 > keeps the offer, **broken** points only to `npm` reinstall. (3, medium, WP-103)
 > `refresh_token` validation was truthiness-only — tightened to a non-empty string.
 > Revision logs on WP-103/105 record the deltas; WP-104 untouched.
+> **Codex round-3 spec review (2026-07-13, one localized finding, WP-102 only —
+> the mirror of round-2 Finding 2):** WP-102's token-present `loadGoogleapis` error
+> still claimed the next `wienerdog gws` command "will offer to install it" for the
+> corrupt-but-resolvable case, where the read-path self-heal has just no-op'd — so
+> the user would loop on a contradictory message. Fixed by making that branch
+> state-aware (same absent/broken split as WP-103's warns), keyed on a `resolvable`
+> flag reused from the resolve attempt already made; added a corrupt-deps
+> `loadGoogleapis` test. WP-103/104/105 untouched.
 
 <!-- -->
 

--- a/docs/specs/ROADMAP.md
+++ b/docs/specs/ROADMAP.md
@@ -120,10 +120,10 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 | [WP-099](WP-099-install-ps1-git-url-validation.md) | Validate the Git-for-Windows asset URL is HTTPS on a GitHub host before download | M7 | sonnet | Done | — |
 | [WP-100](WP-100-codex-tool-output-and-fail-closed-roles.md) | Codex transcript parser — recognize the current tool-output item type (`custom_tool_call_output` + variants) and fail closed on unknown roles | M7 | sonnet | Done | — |
 | [WP-101](WP-101-gws-oauth-state-pkce.md) | gws OAuth loopback — add `state` + PKCE (RFC 8252) | M7 | sonnet | Done | — |
-| [WP-102](WP-102-gws-deps-self-heal.md) | gws read-path self-heal + disambiguated deps error (fix the post-upgrade dead-end) | M5/M7 | sonnet | Ready | — |
-| [WP-103](WP-103-doctor-gws-deps-probe.md) | doctor probe — connected Google account with a missing/broken client library | M5/M7 | sonnet | Ready | WP-102 |
+| [WP-102](WP-102-gws-deps-self-heal.md) | gws read-path self-heal + disambiguated deps error (fix the post-upgrade dead-end) | M5/M7 | sonnet | In-Review | — |
+| [WP-103](WP-103-doctor-gws-deps-probe.md) | doctor probe — connected Google account with a missing/broken client library | M5/M7 | sonnet | In-Review | WP-102 |
 | [WP-104](WP-104-gws-drive-search-friendly-query.md) | gws drive search — friendly term search by default, `--raw` for Drive query language | M5 | sonnet | Ready | — |
-| [WP-105](WP-105-sync-interactive-gws-backfill.md) | sync interactive backfill of the on-demand googleapis install (headless-only users) | M5/M7 | sonnet | Draft | WP-102 |
+| [WP-105](WP-105-sync-interactive-gws-backfill.md) | sync interactive backfill of the on-demand googleapis install (headless-only users) | M5/M7 | sonnet | In-Review | WP-102 |
 
 > **First-production-night incident (2026-07-04).** WP-038, WP-039 and WP-041 form
 > a serial chain (they edit the shared `run-job.js` / `dream.js` / `validate.js`

--- a/docs/specs/ROADMAP.md
+++ b/docs/specs/ROADMAP.md
@@ -903,6 +903,20 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 > `WienerdogError` not a `TypeError`; WP-103 adds an empty-module → `[warn]` case.
 > Shape check is minimal (presence of `.google`), not full API-surface validation —
 > accepted residual. WP-104/105 untouched.
+> **Containment-guard rewrite (2026-07-13, owner-approved — reverses the guard's
+> DO-NOT-CHANGE status):** the closing review found a second real P2 — `resolveFromDeps`
+> resolved the **bare** `googleapis` request (ancestor walk), so on a machine with an
+> ancestor/global copy + empty deps dir, `isInstalled()` resolved+rejected the ancestor
+> but Node cached that resolution in `Module._pathCache`; the consented self-heal then
+> installed into the deps dir and same-process `loadGoogleapis()` re-resolved to the
+> cached ancestor → threw "needs a one-time install" right after consent+`npm` succeeded
+> (first-run failure in exactly the env the guard exists for). Fixed by rewriting
+> `resolveFromDeps` to **direct-path construction** (gate on the deps-dir copy's own
+> `package.json`; resolve the absolute in-dir candidate, never the bare request; retain
+> the realpath containment check). Strictly stronger containment (ancestor copies never
+> considered), cache-immune, symlink defense preserved. Containment tests (:205–230) stay
+> byte-identical; new in-process case (a4) FAILS on the old walk and passes on the
+> rewrite. WP-103's probe inherits it (no code change). WP-104/105 untouched.
 
 <!-- -->
 

--- a/docs/specs/ROADMAP.md
+++ b/docs/specs/ROADMAP.md
@@ -892,6 +892,17 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 > self-heal makes this the primary recovery prompt); fixed to
 > `ask('Install it now? [Y/n] ', {defaultYes:true})` (not `opts.yes`, which bypasses
 > consent) + a seam-capture test. WP-104/105 untouched.
+> **Closing PR-gate (2026-07-13; wd-reviewer re-APPROVED all three, Codex PR review
+> found one real P2 on WP-103 — plus a rejected P1 stacking artifact):** the load
+> probe treated any successfully-required module as usable, so a shape-broken
+> install (zero-byte `index.js` → `{}`) passed → `doctor` falsely `[ok]` and the
+> next gws read crashed with a raw `TypeError` in `getServices`. Fixed at a single
+> point in WP-102's `loadGoogleapis` (validate a truthy `.google` object after the
+> require; a shape-fail is classified **broken**), which fixes the read path AND is
+> inherited by WP-103's probe (no `doctor.js` change). Tests: WP-102 (a3) asserts a
+> `WienerdogError` not a `TypeError`; WP-103 adds an empty-module → `[warn]` case.
+> Shape check is minimal (presence of `.google`), not full API-surface validation —
+> accepted residual. WP-104/105 untouched.
 
 <!-- -->
 

--- a/docs/specs/ROADMAP.md
+++ b/docs/specs/ROADMAP.md
@@ -880,6 +880,18 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 > executes the repair (rmSync + fake install) and asserts `loadGoogleapis` succeeds,
 > proving the flow shape (real npm no-op semantics are out of unit-test reach).
 > WP-104/105 untouched.
+> **PR-gate review (2026-07-13; wd-reviewer re-APPROVED both branches, Codex PR
+> review found one P2 each — both spot-checked):** **P2-A** (WP-102 + WP-103) — every
+> emitted npm command interpolated the deps dir **unquoted**, so a home path with
+> spaces (`C:\Users\John Smith\…`) splits when pasted; now `--prefix "<dir>"` in
+> every user-facing command string (`loadGoogleapis`'s two messages,
+> `ensureGoogleapis`'s prompt/decline/failed messages, WP-103's two warns);
+> `defaultRunInstall`'s argv array unchanged (no shell). **P2-B** (WP-102) —
+> `ensureGoogleapis` advertised default-yes but called `confirm` without
+> `{defaultYes:true}`, so Enter *declined* (latent WP-047 defect; in-scope because
+> self-heal makes this the primary recovery prompt); fixed to
+> `ask('Install it now? [Y/n] ', {defaultYes:true})` (not `opts.yes`, which bypasses
+> consent) + a seam-capture test. WP-104/105 untouched.
 
 <!-- -->
 

--- a/docs/specs/WP-102-gws-deps-self-heal.md
+++ b/docs/specs/WP-102-gws-deps-self-heal.md
@@ -58,11 +58,15 @@ the same misleading error and cannot self-heal (they can't run interactive
    than today). An **unauthed** user (no token) is untouched — they still get the
    existing "connect Google" flow.
 2. **Disambiguate the error.** `loadGoogleapis` (the sole emit site of the
-   misleading string) branches on token presence: no token → the current
-   connect-Google message (unchanged); token present → an accurate "Google is
-   connected, but its client library needs a one-time install" message naming the
-   concrete remedy. This is the defensive backstop for any caller that reaches
-   `loadGoogleapis` without going through the self-heal wrapper.
+   misleading string) branches on token presence and then on resolvability: no
+   token → the current connect-Google message (unchanged); token present + library
+   **absent** → "needs a one-time install … the next `wienerdog gws` command will
+   offer to install it"; token present + library **resolvable-but-unloadable**
+   (corrupt) → "broken (installed but not loadable) — reinstall it", with no
+   offer claim (the self-heal cannot fire on a resolvable install). Both name the
+   concrete npm remedy. This is the defensive backstop for any caller that reaches
+   `loadGoogleapis` without going through the self-heal wrapper, and it mirrors
+   WP-103's doctor split exactly.
 
 **Product invariants that bound this WP.** Wienerdog is just files (ADR-0004): the
 self-heal runs `npm install` synchronously and returns; it starts nothing that
@@ -213,22 +217,41 @@ function hasToken(paths) {
 }
 ```
 
-**2. `loadGoogleapis(paths)` — branch on token presence.** Keep the resolve
-attempt and the no-token message byte-for-byte; add the token-present branch:
+**2. `loadGoogleapis(paths)` — branch on token presence, then on resolvability.**
+Keep the resolve attempt and the no-token message byte-for-byte; add the
+token-present branch, split into **absent** vs **broken** exactly as WP-103's
+doctor probe does (Codex round-3 Finding). Capture resolvability from the resolve
+attempt already made — `resolveFromDeps` returns non-null iff `googleapis` resolves
+from **inside** the deps dir (== `isInstalled`), and the require can still throw
+afterward for a corrupt install — so a single `resolvable` flag set **before** the
+require distinguishes the two failure modes without a second resolve:
 
 ```js
 function loadGoogleapis(paths) {
+  let resolvable = false;
   try {
     const hit = resolveFromDeps(paths);
-    if (hit) return hit.req(hit.resolved);
+    if (hit) {
+      resolvable = true;              // resolves from inside the deps dir (== isInstalled)...
+      return hit.req(hit.resolved);   // ...but a corrupt/partial install can still throw on require
+    }
   } catch {
-    /* treated as absent */
+    /* resolve failed (absent), OR require threw (corrupt); `resolvable` tells them apart */
   }
-  // Disambiguate the two states that share this failure (BUG-gws-deps-missing):
-  // a CONNECTED account (token present) needs only the client library, NOT a
-  // reconnect; an unauthed user needs the full connect flow.
+  // Disambiguate the states that share this failure (BUG-gws-deps-missing):
   if (hasToken(paths)) {
     const cmd = `npm install --ignore-scripts --prefix ${depsDir(paths)} ${GOOGLEAPIS_SPEC}`;
+    if (resolvable) {
+      // CONNECTED but the library is installed-yet-unloadable (corrupt/partial):
+      // the read-path self-heal NO-OPs here (isInstalled is true), so promising an
+      // "offer to install" would make the user loop on a contradictory message.
+      // Reinstall only — the same npm command overwrites the corrupt copy.
+      throw new WienerdogError(
+        'Google is connected, but its client library is broken (installed but not loadable) — reinstall it:\n  ' +
+          cmd
+      );
+    }
+    // CONNECTED and the library is ABSENT: the next gws read WILL self-heal.
     throw new WienerdogError(
       'Google is connected, but its client library needs a one-time install. ' +
         'The next `wienerdog gws` command will offer to install it, or run:\n  ' +
@@ -241,22 +264,25 @@ function loadGoogleapis(paths) {
 }
 ```
 
-The token-present message MUST contain the literal substring `Google is
-connected, but its client library needs a one-time install` AND the exact
-`npm install --ignore-scripts --prefix <deps> googleapis@^173` command, and MUST
-NOT contain `/wienerdog-google-setup`, `gws auth`, or any "no browser" claim
-(Codex Finding 3: recommending `wienerdog gws auth` here is factually wrong —
-`auth.run` throws without `--client <path>` and always opens the full browser
-OAuth loopback with it; the self-heal + the npm one-liner are the accurate
-remedies). The no-token branch is unchanged.
+Message contract (parity with WP-103's two warns):
+- **Absent** (token present, not resolvable): MUST contain `Google is connected,
+  but its client library needs a one-time install` AND `The next \`wienerdog gws\`
+  command will offer to install it` AND the exact npm command.
+- **Broken** (token present, resolvable but the require threw): MUST contain
+  `Google is connected, but its client library is broken (installed but not
+  loadable) — reinstall it` AND the exact npm command, and MUST **NOT** contain
+  `will offer to install` (the self-heal cannot fire — `isInstalled` is true).
+- **Both** branches MUST NOT contain `/wienerdog-google-setup`, `gws auth`, or any
+  "no browser" claim (Codex Finding 3: recommending `wienerdog gws auth` here is
+  factually wrong — `auth.run` throws without `--client <path>` and always opens
+  the full browser OAuth loopback with it; the accurate remedies are the self-heal
+  / the npm one-liner).
+- The **no-token** branch is unchanged (byte-for-byte the same
+  `/wienerdog-google-setup` message).
 
-This same message is also emitted when `googleapis` is **resolvable but
-un-loadable** (a corrupt/partial install whose `require` throws): the require in
-`loadGoogleapis` is inside the same `try`, so a load failure is caught and falls
-through to this token-aware throw. The `npm install` one-liner is the universal
-remedy for both the absent and the corrupt case; the self-heal sentence is
-accurate for the (dominant) absent case and harmless for the corrupt case (see
-the Finding-1(b) residual in Implementation notes).
+`resolvable` is captured from the resolve attempt already performed (cheaper than
+and equivalent to a second `isInstalled(paths)` call, since both mean
+"`resolveFromDeps` returned non-null"); keep the predicate explicit as shown.
 
 **3. `ensureGoogleReady(paths, opts)` — new, exported.** The read-path self-heal.
 
@@ -311,8 +337,9 @@ against `ensureGoogleReady` (§5); the index wiring is this thin call.
 build services. If a future gws verb is added that needs no services, it must be
 excluded from this gate too (note it then).
 
-**5. Tests (`tests/unit/gws-deps.test.js`).** Add a helper and six cases. Reuse
-the existing `tempPaths()`, `fakeInstall`, `WienerdogError`, `path`, `fs`.
+**5. Tests (`tests/unit/gws-deps.test.js`).** Add two helpers and seven cases.
+Reuse the existing `tempPaths()`, `fakeInstall`, `deps`, `WienerdogError`, `path`,
+`fs`.
 
 ```js
 /** Write a valid-looking Google token so hasToken()/self-heal see a connected core. */
@@ -323,16 +350,36 @@ function plantToken(paths) {
     JSON.stringify({ access_token: 'a', refresh_token: 'r' })
   );
 }
+/** Plant a CORRUPT googleapis in the deps dir: it RESOLVES (containment guard
+ *  passes) but its entry point THROWS on require — the corrupt/partial-install
+ *  state (WP-102 broken branch). */
+function plantCorruptDeps(paths) {
+  const pkgDir = path.join(deps.depsDir(paths), 'node_modules', 'googleapis');
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(path.join(pkgDir, 'package.json'),
+    JSON.stringify({ name: 'googleapis', version: '173.0.0', main: 'index.js' }));
+  fs.writeFileSync(path.join(pkgDir, 'index.js'), "throw new Error('corrupt googleapis entry point');\n");
+}
 ```
 
-- **(a) loadGoogleapis — token present + deps absent → the "client library"
-  message.** `plantToken(paths)` on a fresh `tempPaths()`; assert `loadGoogleapis`
-  throws a `WienerdogError` whose message matches `/Google is connected, but its
-  client library needs a one-time install/`, **includes** `npm install
-  --ignore-scripts --prefix ${deps.depsDir(paths)} ${deps.GOOGLEAPIS_SPEC}`, does
-  **not** match `/\/wienerdog-google-setup/`, does **not** match `/gws auth/`,
-  does **not** match `/no browser/i` (Finding 3), and does **not** match
-  `/MODULE_NOT_FOUND/`.
+- **(a) loadGoogleapis — token present + deps ABSENT → the "needs a one-time
+  install" message with the self-heal offer.** `plantToken(paths)` on a fresh
+  `tempPaths()`; assert `loadGoogleapis` throws a `WienerdogError` whose message
+  matches `/Google is connected, but its client library needs a one-time install/`,
+  matches `/will offer to install it/`, **includes** `npm install --ignore-scripts
+  --prefix ${deps.depsDir(paths)} ${deps.GOOGLEAPIS_SPEC}`, does **not** match
+  `/\/wienerdog-google-setup/`, does **not** match `/gws auth/`, does **not** match
+  `/no browser/i` (Finding 3), and does **not** match `/MODULE_NOT_FOUND/`.
+- **(a2) loadGoogleapis — token present + deps RESOLVABLE-BUT-BROKEN → the
+  "reinstall it" message, NO offer claim (round-3 Finding).** `plantToken(paths)`
+  **and** `plantCorruptDeps(paths)` on a fresh `tempPaths()`; assert
+  `loadGoogleapis` throws a `WienerdogError` whose message matches `/Google is
+  connected, but its client library is broken \(installed but not loadable\) —
+  reinstall it/`, **includes** the exact npm command (as in (a)), does **NOT**
+  match `/will offer to install/`, does **not** match `/\/wienerdog-google-setup/`,
+  and does **not** match `/gws auth/`. (Node does not cache a module that throws at
+  load, and each case uses a fresh `tempPaths()`, so run this in-process like (a) —
+  no child process needed.)
 - **(b) ensureGoogleReady — token present + deps absent + consent-yes →
   installs.** `plantToken`; `await ensureGoogleReady(paths, {confirm: async () =>
   true, runInstall: (dir, spec) => fakeInstall(dir, spec)})`; assert the injected
@@ -382,18 +429,22 @@ unchanged**. Do not touch them.
   deliberate supply-chain control locked by the existing tests. Self-heal
   populates the deps dir *through* the guard's install path; it never bypasses
   the guard.
-- **Accepted residual — the read path keeps the cheap resolve-only check
-  (Codex Finding 1b).** `ensureGoogleReady` gates on `isInstalled`, which only
+- **Accepted residual — self-heal SKIPS the corrupt state (Codex Finding 1b;
+  narrowed in round-3).** `ensureGoogleReady` gates on `isInstalled`, which only
   *resolves* `googleapis` (via `resolveFromDeps`), it does not *load* it. So a
   **corrupt/partial** install (interrupted `npm`, missing transitive dep, broken
-  entry point) that still resolves reads as installed → self-heal no-ops. This is
-  a **deliberate, accepted residual on the read path** (loading the heavy
-  `googleapis` on every read to detect corruption is not worth it): the user is
-  not stranded, because `getServices` → `loadGoogleapis` then *loads* the module,
-  fails, and its token-present message delivers the working `npm install` remedy
-  (a manual reinstall overwrites the corrupt copy). The `doctor` probe (WP-103)
-  uses a full **load** probe to surface this state actively. Do NOT change the
-  read-path `isInstalled` check to a load probe here.
+  entry point) that still resolves reads as installed → self-heal no-ops. Keeping
+  the resolve-only check on the read path is deliberate (loading the heavy
+  `googleapis` on every read to detect corruption is not worth it). **The residual
+  is now ONLY that self-heal does not auto-repair a corrupt install — the MESSAGE
+  is no longer misleading:** since round-3, `loadGoogleapis` detects this exact
+  state (resolvable + require threw) and emits the **broken** message ("installed
+  but not loadable — reinstall it: <npm>"), which makes no self-heal promise and
+  points to the reinstall that actually fixes it (a manual `npm install` overwrites
+  the corrupt copy). So a user in this state gets an accurate, actionable message
+  and never loops. The `doctor` probe (WP-103) surfaces the same state with the
+  same split. Do NOT change the read-path `isInstalled` check to a load probe here
+  — the accurate message, not auto-repair, is what closes the loop.
 - **`hasToken` stays existence-only (Codex Finding 4 asymmetry).** `hasToken`
   checks only that `google-token.json` *exists*, not that it is valid JSON with a
   `refresh_token`. This asymmetry with `doctor`'s minimal token validation
@@ -440,9 +491,12 @@ unchanged**. Do not touch them.
       token — no re-auth, no browser (self-heal).
 - [ ] The same on a non-TTY fails with the accurate npm-install remedy (naming the
       exact command), never the misleading "isn't set up yet".
-- [ ] `loadGoogleapis` with a token present + deps absent throws the "Google is
-      connected, but its client library needs a one-time install" message with the
-      npm command, not `/wienerdog-google-setup`.
+- [ ] `loadGoogleapis` with a token present + deps **absent** throws the "Google is
+      connected, but its client library needs a one-time install … will offer to
+      install it" message with the npm command, not `/wienerdog-google-setup`.
+- [ ] `loadGoogleapis` with a token present + a **resolvable-but-unloadable**
+      (corrupt) install throws the "broken (installed but not loadable) — reinstall
+      it" message with the npm command and **no** "will offer to install" claim.
 - [ ] An **unauthed** user (no token) is unaffected: `ensureGoogleReady` is a
       no-op and the existing "no Google sign-in found — run `wienerdog gws auth`
       first" / connect flow is unchanged.
@@ -510,3 +564,21 @@ npm run lint
   - **Finding 4 (owner: MINIMAL VALIDATION).** No change to `hasToken` (stays
     existence-only); the deliberate asymmetry with WP-103's token validation is now
     documented in Implementation notes.
+- **2026-07-13 — Codex round-3 review (one finding, WP-102 only — the mirror of
+  round-2 Finding 2).** The token-present `loadGoogleapis` message was still a
+  single string claiming "The next `wienerdog gws` command will offer to install
+  it" for BOTH the absent and the corrupt-but-resolvable case — but for the corrupt
+  case the read-path self-heal has just no-op'd (accepted residual), so the offer
+  can never occur and the user loops on a contradictory message (while WP-103's
+  broken warn correctly says reinstall-only). Fix: the token-present branch is now
+  **state-aware** (same split as WP-103), keyed on a `resolvable` flag captured from
+  the resolve attempt already made (== `isInstalled`, no second resolve): **absent**
+  (`resolvable` false) keeps the "needs a one-time install … will offer to install
+  it" message; **broken** (`resolvable` true, require threw) emits "broken
+  (installed but not loadable) — reinstall it: <npm>", with no offer claim. Added
+  test (a2): plant a corrupt googleapis in the deps dir (throws on require) + a
+  token, assert the broken message includes the exact npm command and does NOT match
+  `/will offer to install/` or `/wienerdog-google-setup/`. The Finding-1(b) residual
+  note was narrowed — the residual is now ONLY that self-heal skips the corrupt
+  state; the message is accurate. No-token branch and all previously pinned
+  assertions untouched.

--- a/docs/specs/WP-102-gws-deps-self-heal.md
+++ b/docs/specs/WP-102-gws-deps-self-heal.md
@@ -444,8 +444,8 @@ function plantCorruptDeps(paths) {
   with `confirm: async () => false` and a spying `runInstall` (sets `ran = true`).
   Assert via `assert.rejects` that it throws a `WienerdogError` whose message
   includes the exact quoted-prefix command `npm install --ignore-scripts --prefix
-  "<depsDir>" googleapis@^173` (build the expectation as `\`npm install
-  --ignore-scripts --prefix "${deps.depsDir(paths)}" ${deps.GOOGLEAPIS_SPEC}\``,
+  "<depsDir>" googleapis@^173` (build the expectation as
+  `` `npm install --ignore-scripts --prefix "${deps.depsDir(paths)}" ${deps.GOOGLEAPIS_SPEC}` ``,
   with the double quotes — P2-A); then assert `ran === false` and
   `deps.isInstalled(paths) === false`. (This is the headless-equivalent: the real
   `confirm` returns false on a non-TTY, so the same throw fires.)

--- a/docs/specs/WP-102-gws-deps-self-heal.md
+++ b/docs/specs/WP-102-gws-deps-self-heal.md
@@ -194,7 +194,7 @@ cases — see "Do NOT modify these" below.
 
 | Action | Path | Notes |
 |--------|------|-------|
-| modify | src/gws/deps.js | (a) make `loadGoogleapis` token-aware per the Exact contract; (b) add + export `ensureGoogleReady(paths, opts)`; (c) add an internal `hasToken(paths)` helper (lazy `require('./client')`). |
+| modify | src/gws/deps.js | (a) make `loadGoogleapis` token-aware + state-aware per the Exact contract; (b) add + export `ensureGoogleReady(paths, opts)`; (c) add an internal `hasToken(paths)` helper (lazy `require('./client')`); (d) two one-line edits to `ensureGoogleapis` — quote the `--prefix` in its `cmd` string (P2-A) and pass `{defaultYes:true}` to the confirm call (P2-B), per contract §3b. |
 | modify | src/gws/index.js | import `ensureGoogleReady` from `./deps`; call `await ensureGoogleReady(paths)` for every non-`auth` command, before services are built. |
 | modify | tests/unit/gws-deps.test.js | add a `plantToken(paths)` helper + the six new cases below. Do NOT modify the existing no-token assertions. |
 
@@ -242,7 +242,10 @@ function loadGoogleapis(paths) {
   // Disambiguate the states that share this failure (BUG-gws-deps-missing):
   if (hasToken(paths)) {
     const dir = depsDir(paths);
-    const cmd = `npm install --ignore-scripts --prefix ${dir} ${GOOGLEAPIS_SPEC}`;
+    // Quote the prefix (P2-A): a home path with spaces (e.g. Windows
+    // C:\Users\John Smith\...) would otherwise split the argument when the user
+    // pastes the command. Double quotes work in POSIX shells, cmd, and PowerShell.
+    const cmd = `npm install --ignore-scripts --prefix "${dir}" ${GOOGLEAPIS_SPEC}`;
     if (resolvable) {
       // CONNECTED but the library is installed-yet-unloadable (corrupt/partial):
       // the read-path self-heal NO-OPs here (isInstalled is true), so promising an
@@ -272,17 +275,21 @@ function loadGoogleapis(paths) {
 }
 ```
 
+The exact npm command in every message is the **quoted-prefix** form
+`npm install --ignore-scripts --prefix "<depsDir>" googleapis@^173` (P2-A — see
+below).
+
 Message contract (parity with WP-103's two warns):
 - **Absent** (token present, not resolvable): MUST contain `Google is connected,
   but its client library needs a one-time install` AND `The next \`wienerdog gws\`
-  command will offer to install it` AND the exact npm command.
+  command will offer to install it` AND the exact quoted-prefix npm command.
 - **Broken** (token present, resolvable but the require threw): MUST contain
   `Google is connected, but its client library is broken (installed but not
-  loadable)` AND `delete the folder <depsDir>` AND the exact npm command, and MUST
-  **NOT** contain `will offer to install` (the self-heal cannot fire —
-  `isInstalled` is true). The **delete-first** instruction is load-bearing: a bare
-  `npm install` over a corrupt-but-resolvable tree can no-op (npm compares tree
-  metadata, not file contents), leaving the user looping (round-4 Finding).
+  loadable)` AND `delete the folder <depsDir>` AND the exact quoted-prefix npm
+  command, and MUST **NOT** contain `will offer to install` (the self-heal cannot
+  fire — `isInstalled` is true). The **delete-first** instruction is load-bearing:
+  a bare `npm install` over a corrupt-but-resolvable tree can no-op (npm compares
+  tree metadata, not file contents), leaving the user looping (round-4 Finding).
 - **Both** branches MUST NOT contain `/wienerdog-google-setup`, `gws auth`, or any
   "no browser" claim (Codex Finding 3: recommending `wienerdog gws auth` here is
   factually wrong — `auth.run` throws without `--client <path>` and always opens
@@ -320,6 +327,31 @@ async function ensureGoogleReady(paths, opts = {}) {
 ```
 
 Add `ensureGoogleReady` to `module.exports` (keep the existing exports).
+
+**3b. `ensureGoogleapis` — two one-line changes (PR-gate P2-A + P2-B).** The
+existing WP-047 installer body gets exactly two edits; nothing else in it changes:
+
+- **P2-A — quote the prefix in its `cmd` template** (same reason and form as
+  `loadGoogleapis`; leaving it unquoted breaks parity — this `cmd` is what its
+  prompt line and its decline / install-failed messages show the user):
+  - OLD: `` const cmd = `npm install --ignore-scripts --prefix ${dir} ${GOOGLEAPIS_SPEC}`; ``
+  - NEW: `` const cmd = `npm install --ignore-scripts --prefix "${dir}" ${GOOGLEAPIS_SPEC}`; ``
+- **P2-B — pass `{ defaultYes: true }` to the production confirm** so pressing
+  Enter at the `[Y/n]` prompt ACCEPTS (the prompt, the function's own doc comment,
+  and ADR-0011's posture all advertise default-yes, but `src/core/prompt.js`
+  `confirm(question, opts)` defaults `defaultYes` **false**, so today Enter
+  *declines* — a latent WP-047 defect that WP-102's self-heal makes the primary
+  recovery path, so it is in-scope here):
+  - OLD: `const ok = opts.yes || (await ask('Install it now? [Y/n] '));`
+  - NEW: `const ok = opts.yes || (await ask('Install it now? [Y/n] ', { defaultYes: true }));`
+  - `ask = opts.confirm || confirm`; production `confirm` accepts `(question,
+    opts)`. Do **NOT** use `opts.yes` for this (that bypasses consent entirely).
+    The injected test seams have signature `(q) => Promise<boolean>`; passing a
+    second arg to them is harmless.
+
+`defaultRunInstall`'s `spawnSync` arg array is **unchanged** — it invokes `npm`
+with an argv array (no shell), so the prefix needs no quoting there; only the
+human-facing command STRINGS are quoted.
 
 **4. `src/gws/index.js` wiring.** Add the import near the existing requires:
 
@@ -377,8 +409,9 @@ function plantCorruptDeps(paths) {
   install" message with the self-heal offer.** `plantToken(paths)` on a fresh
   `tempPaths()`; assert `loadGoogleapis` throws a `WienerdogError` whose message
   matches `/Google is connected, but its client library needs a one-time install/`,
-  matches `/will offer to install it/`, **includes** `npm install --ignore-scripts
-  --prefix ${deps.depsDir(paths)} ${deps.GOOGLEAPIS_SPEC}`, does **not** match
+  matches `/will offer to install it/`, **includes** the quoted-prefix command
+  `npm install --ignore-scripts --prefix "${deps.depsDir(paths)}" ${deps.GOOGLEAPIS_SPEC}`
+  (note the double quotes around the prefix — P2-A), does **not** match
   `/\/wienerdog-google-setup/`, does **not** match `/gws auth/`, does **not** match
   `/no browser/i` (Finding 3), and does **not** match `/MODULE_NOT_FOUND/`.
 - **(a2) loadGoogleapis — token present + deps RESOLVABLE-BUT-BROKEN → the
@@ -410,9 +443,10 @@ function plantCorruptDeps(paths) {
   npm command, no install.** `plantToken`; call `ensureGoogleReady(paths, ...)`
   with `confirm: async () => false` and a spying `runInstall` (sets `ran = true`).
   Assert via `assert.rejects` that it throws a `WienerdogError` whose message
-  includes the exact `npm install --ignore-scripts --prefix <depsDir>
-  googleapis@^173` command (build the expectation from `deps.depsDir(paths)` and
-  `deps.GOOGLEAPIS_SPEC`); then assert `ran === false` and
+  includes the exact quoted-prefix command `npm install --ignore-scripts --prefix
+  "<depsDir>" googleapis@^173` (build the expectation as `\`npm install
+  --ignore-scripts --prefix "${deps.depsDir(paths)}" ${deps.GOOGLEAPIS_SPEC}\``,
+  with the double quotes — P2-A); then assert `ran === false` and
   `deps.isInstalled(paths) === false`. (This is the headless-equivalent: the real
   `confirm` returns false on a non-TTY, so the same throw fires.)
 - **(d) ensureGoogleReady — NO token → no-op (unauthed path unchanged).** No
@@ -428,6 +462,26 @@ function plantCorruptDeps(paths) {
   without prompting.** `plantToken`; `await ensureGoogleReady(paths, {yes: true,
   confirm: async () => {asked = true; return false;}, runInstall: fakeInstall})`;
   assert `asked === false` and `deps.isInstalled(paths) === true`.
+- **(g) ensureGoogleapis passes `{ defaultYes: true }` to confirm (P2-B — locks
+  the default against regression).** On a fresh `tempPaths()` (deps absent, so the
+  prompt/install path runs), `let seenQ, seenOpts; await deps.ensureGoogleapis(
+  paths, {confirm: async (q, opts) => { seenQ = q; seenOpts = opts; return true; },
+  runInstall: fakeInstall});` then `assert.equal(seenQ, 'Install it now? [Y/n] ');
+  assert.deepEqual(seenOpts, { defaultYes: true });`. (Tested directly on
+  `ensureGoogleapis`, the sole consent site; `ensureGoogleReady` passes the same
+  seam straight through.)
+
+### Update these existing `ensureGoogleapis` assertions to the quoted command (P2-A)
+
+Two pre-existing WP-047 tests pin the **unquoted** command and MUST be updated to
+the quoted-prefix form (same file, a WP-102 deliverable): the consent-**decline**
+test (`ensureGoogleapis on consent-no throws with the exact npm install command`,
+~lines 167–187) and the installer-**failure** test (`ensureGoogleapis surfaces a
+non-zero installer status with the command`, ~lines 189–203). In both, change the
+pinned `` `npm install --ignore-scripts --prefix ${deps.depsDir(paths)}
+${deps.GOOGLEAPIS_SPEC}` `` expectation to `` `npm install --ignore-scripts
+--prefix "${deps.depsDir(paths)}" ${deps.GOOGLEAPIS_SPEC}` `` (add the double
+quotes). No other change to those tests.
 
 ### Do NOT modify these existing tests (answer to the report's fix-5 question)
 
@@ -491,6 +545,13 @@ unchanged**. Do not touch them.
   fix-2 "Google is connected, but…" wording is delivered by `loadGoogleapis` for
   any caller that reaches it directly (the defensive backstop); the two messages
   are consistent (both name the connected-account remedy).
+- **Consent stays intact under the P2-B default-yes fix.** The self-heal prompt
+  now honors ADR-0011's default-yes (Enter accepts) via `{ defaultYes: true }` on
+  the `confirm` call — NOT via `opts.yes`, which would skip the prompt entirely and
+  break consent. A non-TTY still aborts (mode 3 in `src/core/prompt.js` ignores
+  `defaultYes` and returns false), so headless installs are never silently
+  performed. Every user-facing command string is quoted (`--prefix "<dir>"`, P2-A);
+  `defaultRunInstall`'s argv array is untouched (no shell).
 - When uncertain: choose the simpler option and record it under "Decisions made".
   Do NOT expand scope (no update-time backfill — see Out of scope; no keyring; no
   changes to token/client persistence, scopes, or the containment guard).
@@ -528,6 +589,13 @@ unchanged**. Do not touch them.
       no-op and the existing "no Google sign-in found — run `wienerdog gws auth`
       first" / connect flow is unchanged.
 - [ ] `ensureGoogleReady` is a no-op when `googleapis` is already installed.
+- [ ] Every user-facing npm command string quotes the prefix (`--prefix
+      "<depsDir>"`) in `loadGoogleapis` (both branches) and `ensureGoogleapis`
+      (prompt line + decline + install-failed) so a home path with spaces is not
+      split when pasted (P2-A).
+- [ ] The self-heal prompt honors default-yes: pressing Enter at `Install it now?
+      [Y/n]` ACCEPTS (`{ defaultYes: true }` on the production confirm), while a
+      non-TTY still aborts and installs nothing (P2-B).
 - [ ] Running a read twice after a successful self-heal is idempotent (second run:
       `isInstalled` true → no install attempted).
 - [ ] The existing no-token assertions in `gws-deps.test.js` are unchanged and
@@ -624,3 +692,22 @@ npm run lint
   proving the flow shape end-to-end (real npm metadata-vs-content no-op behavior is
   out of unit-test reach, noted honestly). Absent-state message, self-heal contract,
   `ensureGoogleapis`/`ensureGoogleReady` logic, no-token branch all unchanged.
+- **2026-07-13 — PR-gate review (Codex PR review; two P2s, WP-102).**
+  - **P2-A (also WP-103).** Every emitted npm command interpolated the deps dir
+    **unquoted** (`--prefix ${dir}`), so a home path with spaces (common on Windows:
+    `C:\Users\John Smith\…`) splits the argument when pasted. Quoted the prefix in
+    every user-facing command STRING — `loadGoogleapis`'s two token-present messages
+    AND `ensureGoogleapis`'s prompt line + decline + install-failed messages (same
+    `cmd` template; leaving those unquoted would break parity). `defaultRunInstall`'s
+    `spawnSync` argv array is unchanged (no shell). Updated the pinned assertions in
+    new cases (a)/(a2)/(c) and the two pre-existing `ensureGoogleapis`
+    decline/failure tests.
+  - **P2-B (WP-102).** `ensureGoogleapis`'s prompt advertises default-yes
+    (`[Y/n]`, its doc comment, ADR-0011) but called the production `confirm`
+    WITHOUT `{ defaultYes: true }` — `src/core/prompt.js` defaults it false, so
+    pressing Enter *declined*. A latent WP-047 defect made in-scope because WP-102's
+    self-heal makes this prompt the primary recovery path (and `deps.js` is a WP-102
+    deliverable). Fixed the one line to `await ask('Install it now? [Y/n] ',
+    { defaultYes: true })` (NOT `opts.yes`, which would bypass consent). Added
+    test (g): a confirm seam captures its 2nd arg and asserts it deep-equals
+    `{ defaultYes: true }`. Existing accept/decline consent tests unchanged.

--- a/docs/specs/WP-102-gws-deps-self-heal.md
+++ b/docs/specs/WP-102-gws-deps-self-heal.md
@@ -70,11 +70,11 @@ outlives the command. The on-demand install is **consented** (ADR-0011/0013):
 show the exact command, prompt (default yes), fail-to-print on decline. Zero new
 runtime dependencies; plain Node ≥ 18; JSDoc types only (CLAUDE.md).
 
-**Out of scope by explicit decision:** an `update`-time migration/backfill
-(report fix 3). Once self-heal-on-read exists it is redundant, and adding a
-consent/network dependency to the `update` path buys no extra coverage. Recorded
-under "Out of scope" below. The `doctor` probe (report fix 4) is a **separate**
-WP (WP-103) because it touches a different surface (`src/cli/doctor.js`).
+**Not in this WP (separate WPs):** the `doctor` probe (report fix 4) is **WP-103**
+(a different surface, `src/cli/doctor.js`); the interactive `sync`/`update`-time
+**backfill** (report fix 3) is **WP-105** (`src/cli/sync.js`). Fix 3 is NOT
+skipped — after the Codex review it was reinstated for headless-only users; see
+"Out of scope" below for the corrected rationale.
 
 ## Current state
 
@@ -231,7 +231,7 @@ function loadGoogleapis(paths) {
     const cmd = `npm install --ignore-scripts --prefix ${depsDir(paths)} ${GOOGLEAPIS_SPEC}`;
     throw new WienerdogError(
       'Google is connected, but its client library needs a one-time install. ' +
-        'Run `wienerdog gws auth` to finish setup (no browser needed if your sign-in is still valid), or run:\n  ' +
+        'The next `wienerdog gws` command will offer to install it, or run:\n  ' +
         cmd
     );
   }
@@ -244,7 +244,19 @@ function loadGoogleapis(paths) {
 The token-present message MUST contain the literal substring `Google is
 connected, but its client library needs a one-time install` AND the exact
 `npm install --ignore-scripts --prefix <deps> googleapis@^173` command, and MUST
-NOT contain `/wienerdog-google-setup`. The no-token branch is unchanged.
+NOT contain `/wienerdog-google-setup`, `gws auth`, or any "no browser" claim
+(Codex Finding 3: recommending `wienerdog gws auth` here is factually wrong —
+`auth.run` throws without `--client <path>` and always opens the full browser
+OAuth loopback with it; the self-heal + the npm one-liner are the accurate
+remedies). The no-token branch is unchanged.
+
+This same message is also emitted when `googleapis` is **resolvable but
+un-loadable** (a corrupt/partial install whose `require` throws): the require in
+`loadGoogleapis` is inside the same `try`, so a load failure is caught and falls
+through to this token-aware throw. The `npm install` one-liner is the universal
+remedy for both the absent and the corrupt case; the self-heal sentence is
+accurate for the (dominant) absent case and harmless for the corrupt case (see
+the Finding-1(b) residual in Implementation notes).
 
 **3. `ensureGoogleReady(paths, opts)` — new, exported.** The read-path self-heal.
 
@@ -318,7 +330,8 @@ function plantToken(paths) {
   throws a `WienerdogError` whose message matches `/Google is connected, but its
   client library needs a one-time install/`, **includes** `npm install
   --ignore-scripts --prefix ${deps.depsDir(paths)} ${deps.GOOGLEAPIS_SPEC}`, does
-  **not** match `/\/wienerdog-google-setup/`, and does **not** match
+  **not** match `/\/wienerdog-google-setup/`, does **not** match `/gws auth/`,
+  does **not** match `/no browser/i` (Finding 3), and does **not** match
   `/MODULE_NOT_FOUND/`.
 - **(b) ensureGoogleReady — token present + deps absent + consent-yes →
   installs.** `plantToken`; `await ensureGoogleReady(paths, {confirm: async () =>
@@ -369,6 +382,27 @@ unchanged**. Do not touch them.
   deliberate supply-chain control locked by the existing tests. Self-heal
   populates the deps dir *through* the guard's install path; it never bypasses
   the guard.
+- **Accepted residual — the read path keeps the cheap resolve-only check
+  (Codex Finding 1b).** `ensureGoogleReady` gates on `isInstalled`, which only
+  *resolves* `googleapis` (via `resolveFromDeps`), it does not *load* it. So a
+  **corrupt/partial** install (interrupted `npm`, missing transitive dep, broken
+  entry point) that still resolves reads as installed → self-heal no-ops. This is
+  a **deliberate, accepted residual on the read path** (loading the heavy
+  `googleapis` on every read to detect corruption is not worth it): the user is
+  not stranded, because `getServices` → `loadGoogleapis` then *loads* the module,
+  fails, and its token-present message delivers the working `npm install` remedy
+  (a manual reinstall overwrites the corrupt copy). The `doctor` probe (WP-103)
+  uses a full **load** probe to surface this state actively. Do NOT change the
+  read-path `isInstalled` check to a load probe here.
+- **`hasToken` stays existence-only (Codex Finding 4 asymmetry).** `hasToken`
+  checks only that `google-token.json` *exists*, not that it is valid JSON with a
+  `refresh_token`. This asymmetry with `doctor`'s minimal token validation
+  (WP-103) is deliberate: on the read/self-heal path the worst case of a
+  zero-byte/damaged token is a **benign consented install offer** (the user is
+  prompted to install `googleapis`; the damaged token then surfaces its own error
+  downstream in `getServices` → `loadToken`), whereas `doctor` is a diagnostic
+  surface where a damaged token must not read as healthy. Do not add token
+  parsing to `hasToken`.
 - **`_alert` is included in the self-heal gate** (`key !== 'auth'` covers it).
   `_alert` is internal and headless-only in practice: with deps absent it fails
   today too (via `loadGoogleapis`), and run-job's fail-loud already falls back to
@@ -428,11 +462,16 @@ npm run lint
 
 ## Out of scope (do NOT do these)
 
-- **Update-time migration/backfill (report fix 3) — deliberately skipped.** Once
-  self-heal-on-read exists, an install during `wienerdog update` adds a
-  consent/network dependency to the update path for **no extra coverage** (the
-  first read heals it anyway). Do not add any `app/deps` creation to
-  `src/cli/update.js` or `src/core/vendor.js`.
+- **Update/sync-time backfill (report fix 3) — moved to a SEPARATE WP (WP-105),
+  not skipped.** The original "no extra coverage" rationale was **wrong for
+  headless-only (routines-only) users** (Codex Finding 2, owner disposition ADD
+  BACKFILL): such a user never reaches an *interactive* read to self-heal (a
+  non-TTY read declines the consented install by design), so their `app/deps` is
+  never populated by this WP alone. **WP-105** reinstates a **consented,
+  interactive-only** backfill in the `sync` flow (which `wienerdog update` hands
+  off to). This WP still adds **no** `app/deps` creation to `src/cli/update.js`
+  or `src/core/vendor.js` — the backfill lives in `src/cli/sync.js` and belongs to
+  WP-105, not here.
 - **The `doctor` probe (report fix 4)** — that is **WP-103**
   (`src/cli/doctor.js` plus its test), a separate surface.
 - Any change to the containment guard `resolveFromDeps`, to `GOOGLEAPIS_SPEC`, or
@@ -446,3 +485,28 @@ npm run lint
    `fix(gws): self-heal googleapis on read + disambiguate the deps error (WP-102)`.
 3. PR template filled, including "Decisions made" (or "none") and `Generated-by:`.
 4. This spec's `status:` flipped to `In-Review` in the same PR.
+
+## Revision log
+
+- **2026-07-13 — Codex round-1 review + owner dispositions.** Applied after the
+  implementer had already coded this spec verbatim (PR #105); the deltas below are
+  surgical patches to the same branch.
+  - **Finding 3 (MUST FIX).** The `loadGoogleapis` token-present message told users
+    to run `wienerdog gws auth` "(no browser needed if your sign-in is still
+    valid)" — factually false (`auth.run` throws without `--client <path>` and
+    always runs the full browser OAuth loopback with it). Message rewritten to lead
+    with the accurate remedies (self-heal + the npm one-liner) and drop the bare
+    `gws auth` suggestion and the browser-free claim. Test (a) gained
+    `!/gws auth/` and `!/no browser/i` negative assertions. Kept consistent with
+    WP-103's doctor message.
+  - **Finding 1 (owner: TARGETED).** The read-path `isInstalled` (resolve-only)
+    check is **kept**; the corrupt-but-resolvable case is recorded as an accepted
+    residual (the token-present `loadGoogleapis` message still delivers the working
+    npm remedy). The active detection of that state is WP-103's load probe.
+  - **Finding 2 (owner: ADD BACKFILL).** The fix-3 "skip" was reversed: the
+    "Out of scope" rationale is corrected and the interactive backfill is spec'd as
+    the new **WP-105** (`src/cli/sync.js`), not folded here (WP-102 is already
+    implemented; its Deliverables stay honest).
+  - **Finding 4 (owner: MINIMAL VALIDATION).** No change to `hasToken` (stays
+    existence-only); the deliberate asymmetry with WP-103's token validation is now
+    documented in Implementation notes.

--- a/docs/specs/WP-102-gws-deps-self-heal.md
+++ b/docs/specs/WP-102-gws-deps-self-heal.md
@@ -22,7 +22,10 @@ the vendored app copy carries no `node_modules`, so `googleapis` is installed
 remove it). This was WP-047. A **containment guard** (`resolveFromDeps` in
 `src/gws/deps.js`) then resolves `googleapis` strictly from inside that deps dir
 and treats any copy resolving outside it as absent — a deliberate supply-chain
-guard. **Keep that guard exactly as-is.**
+guard. **This WP rewrites that guard** (contract §0, owner-approved 2026-07-13) to
+close a `Module._pathCache` cache-poisoning P2 — its accept/reject semantics are
+**preserved-or-strengthened** (ancestor copies never considered; symlink defense
+kept); it is not weakened.
 
 **The bug this WP fixes (`userreports/BUG-gws-deps-missing-after-upgrade.md`).**
 The library-presence check and the installer live on **different code paths, and
@@ -91,10 +94,20 @@ const GOOGLEAPIS_SPEC = 'googleapis@^173';
 /** <core>/app/deps */
 function depsDir(paths) { return path.join(paths.core, 'app', 'deps'); }
 
-/** Resolve googleapis strictly from within the deps dir (containment-guarded);
- *  a copy resolving outside the deps dir is treated as absent. Returns
- *  {req, resolved} | null. DO NOT CHANGE. */
-function resolveFromDeps(paths) { /* ... */ }
+/** CURRENT (ancestor-walk) implementation — BEING REPLACED by contract §0 (the
+ *  cache-poisoning fix). Shown so you know what you are replacing. Resolves the
+ *  BARE `googleapis` request, which walks EVERY ancestor node_modules, then
+ *  rejects out-of-dir hits — but Node caches that successful ancestor resolution
+ *  in Module._pathCache, which is the P2 §0 fixes. */
+function resolveFromDeps(paths) {
+  const dir = depsDir(paths);
+  const req = createRequire(path.join(dir, 'noop.js'));
+  const resolved = req.resolve('googleapis');   // <-- ancestor-walk; cache-poisoning source
+  let real = dir;
+  try { real = fs.realpathSync(dir); } catch { /* deps dir absent */ }
+  if (!resolved.startsWith(real + path.sep)) return null;
+  return { req, resolved };
+}
 
 /** Whether googleapis resolves from within the deps dir. */
 function isInstalled(paths) {
@@ -194,11 +207,63 @@ cases — see "Do NOT modify these" below.
 
 | Action | Path | Notes |
 |--------|------|-------|
-| modify | src/gws/deps.js | (a) make `loadGoogleapis` token-aware + state-aware per the Exact contract; (b) add + export `ensureGoogleReady(paths, opts)`; (c) add an internal `hasToken(paths)` helper (lazy `require('./client')`); (d) two one-line edits to `ensureGoogleapis` — quote the `--prefix` in its `cmd` string (P2-A) and pass `{defaultYes:true}` to the confirm call (P2-B), per contract §3b. |
+| modify | src/gws/deps.js | (0) **rewrite `resolveFromDeps` to direct-path construction** (owner-approved guard change, contract §0 — cache-poisoning fix); (a) make `loadGoogleapis` token-aware + state-aware + shape-check per the Exact contract; (b) add + export `ensureGoogleReady(paths, opts)`; (c) add an internal `hasToken(paths)` helper (lazy `require('./client')`); (d) two one-line edits to `ensureGoogleapis` — quote the `--prefix` in its `cmd` string (P2-A) and pass `{defaultYes:true}` to the confirm call (P2-B), per contract §3b. |
 | modify | src/gws/index.js | import `ensureGoogleReady` from `./deps`; call `await ensureGoogleReady(paths)` for every non-`auth` command, before services are built. |
-| modify | tests/unit/gws-deps.test.js | add a `plantToken(paths)` helper + the six new cases below. Do NOT modify the existing no-token assertions. |
+| modify | tests/unit/gws-deps.test.js | add the `plantToken`/`plantCorruptDeps`/`plantShapelessDeps` helpers + the new cases below (incl. the §0 cache-regression case **(a4)**). Do NOT modify the existing no-token / containment assertions (they stay byte-identical — behavior is unchanged). |
 
 ### Exact contracts
+
+**0. Rewrite `resolveFromDeps(paths)` — direct-path construction (owner-approved
+guard change; land this first).** This reverses the guard's former "DO NOT CHANGE"
+status. **Owner sign-off recorded 2026-07-13.**
+
+*The defect (PR-gate P2).* The current guard resolves the **bare** `googleapis`
+request via `createRequire(depsDir/noop.js).resolve('googleapis')`, which walks
+**every** ancestor `node_modules`. When an ancestor has `googleapis` and the deps
+dir is empty, `isInstalled()` resolves the ancestor and correctly rejects it — but
+Node caches that **successful** resolution in `Module._pathCache` (keyed by request
++ lookup-path list). The consented self-heal then installs into the deps dir, and
+`loadGoogleapis()` **in the same process** re-resolves the bare request → gets the
+**cached ancestor path** → rejects again → throws "needs a one-time install"
+*immediately after* the user consented and `npm` succeeded. It self-corrects next
+process, but that is a first-run UX failure in exactly the environment the guard
+exists for (a machine with a global/ancestor `googleapis`).
+
+*The fix — no ancestor walk at all.* Construct the deps-dir path directly and
+resolve it absolutely:
+
+```js
+function resolveFromDeps(paths) {
+  const dir = depsDir(paths);
+  const candidate = path.join(dir, 'node_modules', 'googleapis');
+  // (1) Absent unless the deps-dir copy's OWN package.json exists. Pure existence
+  //     check — no resolution, so nothing is looked up in ancestors or cached.
+  if (!fs.existsSync(path.join(candidate, 'package.json'))) return null;
+  // (2) Resolve the ABSOLUTE candidate path (never the bare 'googleapis' request),
+  //     so resolution targets exactly this dir, never walks ancestors, and is not
+  //     served from Module._pathCache (the bare-request cache key is never used).
+  const req = createRequire(path.join(dir, 'noop.js'));
+  const resolved = req.resolve(candidate);
+  // (3) RETAIN the realpath containment check — the resolved entry must live inside
+  //     realpath(depsDir). `req.resolve` returns a symlink-resolved path, so a
+  //     planted symlink deps/node_modules/googleapis -> elsewhere resolves OUTSIDE
+  //     and is still rejected exactly as today (symlink defense preserved).
+  let real = dir;
+  try { real = fs.realpathSync(dir); } catch { /* deps dir absent — handled at (1) */ }
+  if (!resolved.startsWith(real + path.sep)) return null;
+  return { req, resolved };
+}
+```
+
+*Threat posture: preserved-or-strengthened.* Containment is **strictly stronger** —
+an ancestor/global `googleapis` is now never even considered (step 1 gates on the
+deps-dir copy's own `package.json`; step 2 resolves only the absolute in-dir path).
+The **symlink defense is unchanged**: step 3's realpath containment still rejects a
+symlinked-inside copy that points outside the deps dir. The walk had to go because
+it was the source of the `Module._pathCache` poisoning above; direct-path
+resolution is simpler and cache-immune. `isInstalled` and `loadGoogleapis` above
+the resolver are **unchanged** (they still call `resolveFromDeps` and branch on
+non-null / null).
 
 **1. `hasToken(paths)` — new internal helper in `deps.js`.** Lazy-require
 `./client` to avoid a load-time cycle (`client.js` requires `deps.js` at top
@@ -395,9 +460,10 @@ against `ensureGoogleReady` (§5); the index wiring is this thin call.
 build services. If a future gws verb is added that needs no services, it must be
 excluded from this gate too (note it then).
 
-**5. Tests (`tests/unit/gws-deps.test.js`).** Add three helpers and eight cases.
-Reuse the existing `tempPaths()`, `fakeInstall`, `deps`, `WienerdogError`, `path`,
-`fs`.
+**5. Tests (`tests/unit/gws-deps.test.js`).** Add three helpers and ten cases
+(a, a2, a3, a4, b–g). Reuse the existing `tempPaths()`, `fakeInstall`,
+`plantGoogleapis(base, which)` (already in the file — used by (a4) for the ancestor
+copy), `deps`, `WienerdogError`, `path`, `fs`.
 
 ```js
 /** Write a valid-looking Google token so hasToken()/self-heal see a connected core. */
@@ -470,6 +536,23 @@ function plantShapelessDeps(paths) {
   case: a zero-byte/stub entry point requires cleanly but has no `.google`, so
   without the shape check `getServices` would later crash at `new
   google.auth.OAuth2`.
+- **(a4) `resolveFromDeps` is cache-immune — an ANCESTOR googleapis never
+  satisfies the guard, and a deps-dir install loads in the SAME process (§0
+  regression).** On a fresh `tempPaths()`, plant an ancestor copy
+  `plantGoogleapis(paths.home, 'ancestor')` (`paths.home` is an ancestor of
+  `<core>/app/deps`, so the OLD ancestor walk would find it) and
+  `plantToken(paths)`. **Ancestor-alone → absent, end-to-end:** assert
+  `deps.isInstalled(paths) === false`, and `loadGoogleapis` throws a
+  `WienerdogError` matching `/needs a one-time install/` (the ABSENT message — deps
+  dir empty), NOT `/broken/`. **Then install into the deps dir and re-check in the
+  SAME process:** `fakeInstall(deps.depsDir(paths)); assert.equal(deps.isInstalled(
+  paths), true); const g = deps.loadGoogleapis(paths); assert.equal(g.google.WHICH,
+  'deps');` — it loads the deps-dir copy, not the ancestor. **This case FAILS on the
+  old ancestor-walk implementation** (the first `isInstalled`/`loadGoogleapis`
+  caches the ancestor resolution in `Module._pathCache`, so the post-install
+  `loadGoogleapis` cache-hits the ancestor and throws "needs a one-time install")
+  **and passes on the §0 direct-path guard.** Run **in-process** (the whole point is
+  the intra-process cache) — do NOT use `probeInChild` here.
 - **(b) ensureGoogleReady — token present + deps absent + consent-yes →
   installs.** `plantToken`; `await ensureGoogleReady(paths, {confirm: async () =>
   true, runInstall: (dir, spec) => fakeInstall(dir, spec)})`; assert the injected
@@ -528,6 +611,14 @@ the no-token branch of `loadGoogleapis` still emits the identical
 `/wienerdog-google-setup` message, so those tests remain valid and **must stay
 unchanged**. Do not touch them.
 
+**The §0 `resolveFromDeps` rewrite keeps these byte-identical** — its external
+behavior is unchanged: an ancestor/out-of-dir `googleapis` still classifies as
+**absent** (`null`) — now by construction (step 1's `package.json` gate) rather
+than by resolve-then-reject — and a deps-dir copy (real or symlinked-inside) is
+handled exactly as before (loaded if inside `realpath(depsDir)`, rejected if the
+symlink points outside). So the `probeInChild` ancestor-decoy cases (:205–230)
+still pass verbatim; only the NEW in-process case (a4) distinguishes old from new.
+
 ## Implementation notes & constraints
 
 - **Zero new dependencies.** No new require beyond the lazy `require('./client')`
@@ -536,10 +627,12 @@ unchanged**. Do not touch them.
   `deps.js` must reference `./client` **only** lazily (inside `hasToken`, at call
   time). Do not add a top-level `require('./client')` to `deps.js` — it would
   create a load-time cycle and `tokenPath` could be `undefined`.
-- **Keep the containment guard (`resolveFromDeps`) unchanged** — it is a
-  deliberate supply-chain control locked by the existing tests. Self-heal
-  populates the deps dir *through* the guard's install path; it never bypasses
-  the guard.
+- **The containment guard (`resolveFromDeps`) is rewritten, not bypassed
+  (contract §0, owner-approved).** It stays a deliberate supply-chain control —
+  the rewrite makes it **stricter** (ancestor copies never considered) and
+  cache-immune while preserving the symlink defense. Self-heal still populates the
+  deps dir *through* the guard's install path and never bypasses it. Do not
+  reintroduce the bare-`googleapis` ancestor walk.
 - **Accepted residual — self-heal SKIPS the corrupt state (Codex Finding 1b;
   narrowed in round-3).** `ensureGoogleReady` gates on `isInstalled`, which only
   *resolves* `googleapis` (via `resolveFromDeps`), it does not *load* it. So a
@@ -612,6 +705,11 @@ unchanged**. Do not touch them.
       printed remedy and installs nothing.
 - [ ] No process outlives the command (ADR-0004): `ensureGoogleapis` runs
       `npm install` synchronously and returns.
+- [ ] The §0 guard rewrite does not weaken the supply-chain control: `googleapis`
+      is still loaded ONLY from inside `realpath(<core>/app/deps)`; an
+      ancestor/global copy is now rejected **by construction** (never resolved), and
+      a symlinked-inside copy pointing outside the deps dir is still rejected by the
+      retained realpath check.
 
 ## Acceptance criteria
 
@@ -642,8 +740,14 @@ unchanged**. Do not touch them.
       non-TTY still aborts and installs nothing (P2-B).
 - [ ] Running a read twice after a successful self-heal is idempotent (second run:
       `isInstalled` true → no install attempted).
-- [ ] The existing no-token assertions in `gws-deps.test.js` are unchanged and
-      still pass. `npm test` and `npm run lint` are green.
+- [ ] `resolveFromDeps` uses direct-path construction (no ancestor walk): on a
+      machine with an ancestor/global `googleapis`, a consented self-heal in the
+      **same process** succeeds — the post-install read loads the deps-dir copy, not
+      the cached ancestor (§0; case (a4)). Ancestor-only stays classified absent;
+      a symlinked-inside copy pointing outside the deps dir stays rejected.
+- [ ] The existing no-token AND containment (:205–230) assertions in
+      `gws-deps.test.js` are byte-unchanged and still pass. `npm test` and
+      `npm run lint` are green.
 
 ## Verification steps (run these; paste output in the PR)
 
@@ -667,8 +771,9 @@ npm run lint
   WP-105, not here.
 - **The `doctor` probe (report fix 4)** — that is **WP-103**
   (`src/cli/doctor.js` plus its test), a separate surface.
-- Any change to the containment guard `resolveFromDeps`, to `GOOGLEAPIS_SPEC`, or
-  to token/client persistence, scopes, or the OAuth flow.
+- Beyond the §0 direct-path rewrite, any *behavioral* change to the containment
+  guard `resolveFromDeps` (its accept/reject semantics stay identical), and any
+  change to `GOOGLEAPIS_SPEC`, token/client persistence, scopes, or the OAuth flow.
 - The `gws drive search` bare-term query papercut — separate backlog WP-104.
 
 ## Definition of done
@@ -773,3 +878,25 @@ npm run lint
   message and no offer claim. Recorded the accepted residual: the check is minimal
   (presence of a truthy `.google`), not a full API-surface validation — deeper
   corruption still surfaces at call time.
+- **2026-07-13 — post-approval containment-guard rewrite (owner sign-off recorded
+  2026-07-13; reverses the guard's former DO-NOT-CHANGE status).** The closing
+  Codex review found a real P2 in the self-heal flow: `resolveFromDeps` resolved the
+  **bare** `googleapis` request (ancestor walk), so on a machine with an
+  ancestor/global `googleapis` + empty deps dir, `isInstalled()` resolved+rejected
+  the ancestor but Node cached that resolution in `Module._pathCache`; the consented
+  self-heal then installed into the deps dir, and same-process `loadGoogleapis()`
+  re-resolved to the **cached ancestor** → rejected → threw "needs a one-time
+  install" right after the user consented and `npm` succeeded (first-run UX failure
+  in exactly the environment the guard exists for). Fix (contract §0): rewrite
+  `resolveFromDeps` to **direct-path construction** — gate on the deps-dir copy's
+  own `package.json` (existence, no resolution), resolve the **absolute** in-dir
+  candidate (never the bare request, so no ancestor walk and no `_pathCache`
+  poisoning), and **retain** the realpath containment check (symlink defense
+  preserved). Net: strictly stronger containment (ancestor copies never considered),
+  simpler, cache-immune. `isInstalled`/`loadGoogleapis`/`ensureGoogleReady`/
+  `ensureGoogleapis` above the resolver unchanged. Containment tests (:205–230) stay
+  byte-identical (behavior unchanged); NEW in-process case (a4) plants an ancestor
+  copy, asserts `isInstalled === false`, then `fakeInstall`s the deps dir and asserts
+  same-process `loadGoogleapis` loads the deps copy — FAILS on the old walk, passes
+  on the rewrite. Documented the preserved-or-strengthened threat posture and why
+  the walk had to go.

--- a/docs/specs/WP-102-gws-deps-self-heal.md
+++ b/docs/specs/WP-102-gws-deps-self-heal.md
@@ -1060,8 +1060,8 @@ npm run lint
   same-process `loadGoogleapis` loads the deps copy — FAILS on the old walk, passes
   on the rewrite. Documented the preserved-or-strengthened threat posture and why
   the walk had to go.
-- **2026-07-13 — closing Codex PR pass, round-6 (two findings; deps.js + prompt.js
-  + doctor.js/WP-103).**
+- **2026-07-13 — closing Codex PR pass, round-6 (two findings; deps.js +
+  prompt.js + doctor.js/WP-103).**
   - **P1 (high user-visibility — stdout hygiene).** The self-heal wrote its notice,
     consent prompt, and npm output to STDOUT, so a connected user's `gws … --json |
     jq` got invalid JSON (and, with stdout piped + a TTY stdin, the prompt question

--- a/docs/specs/WP-102-gws-deps-self-heal.md
+++ b/docs/specs/WP-102-gws-deps-self-heal.md
@@ -221,8 +221,8 @@ status. **Owner sign-off recorded 2026-07-13.**
 request via `createRequire(depsDir/noop.js).resolve('googleapis')`, which walks
 **every** ancestor `node_modules`. When an ancestor has `googleapis` and the deps
 dir is empty, `isInstalled()` resolves the ancestor and correctly rejects it — but
-Node caches that **successful** resolution in `Module._pathCache` (keyed by request
-+ lookup-path list). The consented self-heal then installs into the deps dir, and
+Node caches that **successful** resolution in `Module._pathCache` (keyed by
+request + lookup-path list). The consented self-heal then installs into the deps dir, and
 `loadGoogleapis()` **in the same process** re-resolves the bare request → gets the
 **cached ancestor path** → rejects again → throws "needs a one-time install"
 *immediately after* the user consented and `npm` succeeded. It self-corrects next

--- a/docs/specs/WP-102-gws-deps-self-heal.md
+++ b/docs/specs/WP-102-gws-deps-self-heal.md
@@ -62,11 +62,12 @@ the same misleading error and cannot self-heal (they can't run interactive
    token → the current connect-Google message (unchanged); token present + library
    **absent** → "needs a one-time install … the next `wienerdog gws` command will
    offer to install it"; token present + library **resolvable-but-unloadable**
-   (corrupt) → "broken (installed but not loadable) — reinstall it", with no
-   offer claim (the self-heal cannot fire on a resolvable install). Both name the
-   concrete npm remedy. This is the defensive backstop for any caller that reaches
-   `loadGoogleapis` without going through the self-heal wrapper, and it mirrors
-   WP-103's doctor split exactly.
+   (corrupt) → "broken (installed but not loadable) — delete the folder `<depsDir>`,
+   then reinstall it", with no offer claim (the self-heal cannot fire on a
+   resolvable install, and a bare `npm install` can no-op on a corrupt tree — see
+   round-4 below). Both name the concrete npm remedy. This is the defensive backstop
+   for any caller that reaches `loadGoogleapis` without going through the self-heal
+   wrapper, and it mirrors WP-103's doctor split exactly.
 
 **Product invariants that bound this WP.** Wienerdog is just files (ADR-0004): the
 self-heal runs `npm install` synchronously and returns; it starts nothing that
@@ -240,15 +241,22 @@ function loadGoogleapis(paths) {
   }
   // Disambiguate the states that share this failure (BUG-gws-deps-missing):
   if (hasToken(paths)) {
-    const cmd = `npm install --ignore-scripts --prefix ${depsDir(paths)} ${GOOGLEAPIS_SPEC}`;
+    const dir = depsDir(paths);
+    const cmd = `npm install --ignore-scripts --prefix ${dir} ${GOOGLEAPIS_SPEC}`;
     if (resolvable) {
       // CONNECTED but the library is installed-yet-unloadable (corrupt/partial):
       // the read-path self-heal NO-OPs here (isInstalled is true), so promising an
       // "offer to install" would make the user loop on a contradictory message.
-      // Reinstall only — the same npm command overwrites the corrupt copy.
+      // A plain reinstall can NO-OP too: npm compares tree metadata (recorded
+      // version/integrity), NOT file contents, so a corrupt-but-resolvable tree
+      // reads as "up to date" and stays broken (round-4 Finding). The corrupt tree
+      // must be REMOVED first. The deps dir is single-purpose (it exists solely to
+      // hold the consented googleapis tree), so deleting it wholesale is safe.
+      // Platform-neutral prose (not a per-OS rm/Remove-Item one-liner) — plain
+      // language for knowledge workers, CLAUDE.md.
       throw new WienerdogError(
-        'Google is connected, but its client library is broken (installed but not loadable) — reinstall it:\n  ' +
-          cmd
+        'Google is connected, but its client library is broken (installed but not loadable). ' +
+          `To repair it, delete the folder ${dir}, then reinstall it:\n  ${cmd}`
       );
     }
     // CONNECTED and the library is ABSENT: the next gws read WILL self-heal.
@@ -270,8 +278,11 @@ Message contract (parity with WP-103's two warns):
   command will offer to install it` AND the exact npm command.
 - **Broken** (token present, resolvable but the require threw): MUST contain
   `Google is connected, but its client library is broken (installed but not
-  loadable) — reinstall it` AND the exact npm command, and MUST **NOT** contain
-  `will offer to install` (the self-heal cannot fire — `isInstalled` is true).
+  loadable)` AND `delete the folder <depsDir>` AND the exact npm command, and MUST
+  **NOT** contain `will offer to install` (the self-heal cannot fire —
+  `isInstalled` is true). The **delete-first** instruction is load-bearing: a bare
+  `npm install` over a corrupt-but-resolvable tree can no-op (npm compares tree
+  metadata, not file contents), leaving the user looping (round-4 Finding).
 - **Both** branches MUST NOT contain `/wienerdog-google-setup`, `gws auth`, or any
   "no browser" claim (Codex Finding 3: recommending `wienerdog gws auth` here is
   factually wrong — `auth.run` throws without `--client <path>` and always opens
@@ -371,15 +382,25 @@ function plantCorruptDeps(paths) {
   `/\/wienerdog-google-setup/`, does **not** match `/gws auth/`, does **not** match
   `/no browser/i` (Finding 3), and does **not** match `/MODULE_NOT_FOUND/`.
 - **(a2) loadGoogleapis — token present + deps RESOLVABLE-BUT-BROKEN → the
-  "reinstall it" message, NO offer claim (round-3 Finding).** `plantToken(paths)`
-  **and** `plantCorruptDeps(paths)` on a fresh `tempPaths()`; assert
-  `loadGoogleapis` throws a `WienerdogError` whose message matches `/Google is
-  connected, but its client library is broken \(installed but not loadable\) —
-  reinstall it/`, **includes** the exact npm command (as in (a)), does **NOT**
-  match `/will offer to install/`, does **not** match `/\/wienerdog-google-setup/`,
-  and does **not** match `/gws auth/`. (Node does not cache a module that throws at
-  load, and each case uses a fresh `tempPaths()`, so run this in-process like (a) —
-  no child process needed.)
+  "delete + reinstall" message, NO offer claim (round-3 + round-4 Findings), and
+  the prescribed repair actually works.** `plantToken(paths)` **and**
+  `plantCorruptDeps(paths)` on a fresh `tempPaths()`. First assert `loadGoogleapis`
+  throws a `WienerdogError` whose message matches `/Google is connected, but its
+  client library is broken \(installed but not loadable\)/`, matches `/delete the
+  folder/` and **includes** the literal `deps.depsDir(paths)` path, **includes** the
+  exact npm command (as in (a)), does **NOT** match `/will offer to install/`, does
+  **not** match `/\/wienerdog-google-setup/`, and does **not** match `/gws auth/`.
+  Then **execute the prescribed repair flow** and assert it succeeds: `fs.rmSync(
+  deps.depsDir(paths), {recursive:true, force:true}); fakeInstall(deps.depsDir(
+  paths)); const g = deps.loadGoogleapis(paths); assert.equal(g.google.FAKE, true);`
+  — proving delete-then-reinstall makes the library loadable (whereas a reinstall
+  over the un-deleted corrupt tree is what round-4 flagged as a possible no-op).
+  (Node does not cache a module that throws at load, and the deps-dir path is
+  identical before/after the repair, so run this in-process like (a) — no child
+  process needed. **Note honestly in the test:** the fake install seam proves the
+  *flow shape* (remove → reinstall → loadable); real npm's metadata-vs-content
+  no-op behavior is out of unit-test reach — the delete-first instruction exists
+  precisely to defeat it.)
 - **(b) ensureGoogleReady — token present + deps absent + consent-yes →
   installs.** `plantToken`; `await ensureGoogleReady(paths, {confirm: async () =>
   true, runInstall: (dir, spec) => fakeInstall(dir, spec)})`; assert the injected
@@ -438,13 +459,16 @@ unchanged**. Do not touch them.
   `googleapis` on every read to detect corruption is not worth it). **The residual
   is now ONLY that self-heal does not auto-repair a corrupt install — the MESSAGE
   is no longer misleading:** since round-3, `loadGoogleapis` detects this exact
-  state (resolvable + require threw) and emits the **broken** message ("installed
-  but not loadable — reinstall it: <npm>"), which makes no self-heal promise and
-  points to the reinstall that actually fixes it (a manual `npm install` overwrites
-  the corrupt copy). So a user in this state gets an accurate, actionable message
-  and never loops. The `doctor` probe (WP-103) surfaces the same state with the
-  same split. Do NOT change the read-path `isInstalled` check to a load probe here
-  — the accurate message, not auto-repair, is what closes the loop.
+  state (resolvable + require threw) and emits the **broken** message, which makes
+  no self-heal promise and points to the repair that actually fixes it. Since
+  round-4 that repair is **delete the folder `<depsDir>`, then reinstall** — a bare
+  `npm install` can no-op over a corrupt-but-resolvable tree (npm compares tree
+  metadata, not file contents), so the corrupt tree must be removed first (the deps
+  dir is single-purpose). So a user in this state gets an accurate, actionable
+  message and never loops. The `doctor` probe (WP-103) surfaces the same state with
+  the same delete-then-reinstall remedy. Do NOT change the read-path `isInstalled`
+  check to a load probe here — the accurate message, not auto-repair, is what
+  closes the loop.
 - **`hasToken` stays existence-only (Codex Finding 4 asymmetry).** `hasToken`
   checks only that `google-token.json` *exists*, not that it is valid JSON with a
   `refresh_token`. This asymmetry with `doctor`'s minimal token validation
@@ -495,8 +519,11 @@ unchanged**. Do not touch them.
       connected, but its client library needs a one-time install … will offer to
       install it" message with the npm command, not `/wienerdog-google-setup`.
 - [ ] `loadGoogleapis` with a token present + a **resolvable-but-unloadable**
-      (corrupt) install throws the "broken (installed but not loadable) — reinstall
-      it" message with the npm command and **no** "will offer to install" claim.
+      (corrupt) install throws the "broken (installed but not loadable) — delete the
+      folder `<depsDir>`, then reinstall it" message naming the deps folder and the
+      npm command, with **no** "will offer to install" claim; and the prescribed
+      delete-then-reinstall flow makes the library loadable again (verified with the
+      test seams).
 - [ ] An **unauthed** user (no token) is unaffected: `ensureGoogleReady` is a
       no-op and the existing "no Google sign-in found — run `wienerdog gws auth`
       first" / connect flow is unchanged.
@@ -582,3 +609,18 @@ npm run lint
   note was narrowed — the residual is now ONLY that self-heal skips the corrupt
   state; the message is accurate. No-token branch and all previously pinned
   assertions untouched.
+- **2026-07-13 — Codex round-4 review (one finding, WP-102 + WP-103 mirror).** The
+  broken-state remedy `npm install --prefix <deps> …` can **no-op** on a corrupt
+  install: npm/arborist compares tree metadata (recorded version/integrity), not
+  installed file contents, so a resolvable-but-corrupt `googleapis` reads as "up to
+  date" and stays unloadable — the user loops. Fix (broken state only): the remedy
+  now prescribes a **clean reinstall** — delete the single-purpose deps dir first,
+  then install. Wording is **platform-neutral prose** ("To repair it, delete the
+  folder `<depsDir>`, then reinstall it:\n  `<npm cmd>`") rather than a per-OS
+  `rm -rf`/`Remove-Item` matrix — matching the codebase convention of plain-language
+  remedies (CLAUDE.md); recorded as the chosen option. Test (a2) extended: after the
+  message assertions, execute the prescribed repair with the seams
+  (`fs.rmSync(depsDir)` + `fakeInstall`) and assert `loadGoogleapis` then succeeds —
+  proving the flow shape end-to-end (real npm metadata-vs-content no-op behavior is
+  out of unit-test reach, noted honestly). Absent-state message, self-heal contract,
+  `ensureGoogleapis`/`ensureGoogleReady` logic, no-token branch all unchanged.

--- a/docs/specs/WP-102-gws-deps-self-heal.md
+++ b/docs/specs/WP-102-gws-deps-self-heal.md
@@ -233,8 +233,16 @@ function loadGoogleapis(paths) {
   try {
     const hit = resolveFromDeps(paths);
     if (hit) {
-      resolvable = true;              // resolves from inside the deps dir (== isInstalled)...
-      return hit.req(hit.resolved);   // ...but a corrupt/partial install can still throw on require
+      resolvable = true;                 // resolves from inside the deps dir (== isInstalled)...
+      const mod = hit.req(hit.resolved); // ...but the require can throw (corrupt), or...
+      // ...load a SHAPE-BROKEN module: a zero-byte / stub `index.js` requires to
+      // `{}` (valid JS, no throw) but has no `.google`, so getServices would later
+      // crash with a raw TypeError at `new google.auth.OAuth2`. Validate the shape
+      // here and treat a missing `.google` object exactly as the BROKEN state
+      // (resolvable is already true), so both the read path and doctor get the
+      // friendly broken message instead of a TypeError (PR-gate P2).
+      if (mod && typeof mod.google === 'object' && mod.google) return mod;
+      // else: shape-broken — fall through to the BROKEN classification below.
     }
   } catch {
     /* resolve failed (absent), OR require threw (corrupt); `resolvable` tells them apart */
@@ -283,13 +291,17 @@ Message contract (parity with WP-103's two warns):
 - **Absent** (token present, not resolvable): MUST contain `Google is connected,
   but its client library needs a one-time install` AND `The next \`wienerdog gws\`
   command will offer to install it` AND the exact quoted-prefix npm command.
-- **Broken** (token present, resolvable but the require threw): MUST contain
-  `Google is connected, but its client library is broken (installed but not
-  loadable)` AND `delete the folder <depsDir>` AND the exact quoted-prefix npm
-  command, and MUST **NOT** contain `will offer to install` (the self-heal cannot
-  fire — `isInstalled` is true). The **delete-first** instruction is load-bearing:
-  a bare `npm install` over a corrupt-but-resolvable tree can no-op (npm compares
-  tree metadata, not file contents), leaving the user looping (round-4 Finding).
+- **Broken** (token present, resolvable but the require threw **OR** the loaded
+  module is shape-invalid — no truthy `.google` object): MUST contain `Google is
+  connected, but its client library is broken (installed but not loadable)` AND
+  `delete the folder <depsDir>` AND the exact quoted-prefix npm command, and MUST
+  **NOT** contain `will offer to install` (the self-heal cannot fire — `isInstalled`
+  is true). The **delete-first** instruction is load-bearing: a bare `npm install`
+  over a corrupt-but-resolvable tree can no-op (npm compares tree metadata, not file
+  contents), leaving the user looping (round-4 Finding). The **shape check** (a
+  zero-byte / stub `index.js` requires to `{}` without throwing) routes here too,
+  so a shape-broken install yields this friendly message rather than a raw
+  TypeError from `getServices` (PR-gate P2).
 - **Both** branches MUST NOT contain `/wienerdog-google-setup`, `gws auth`, or any
   "no browser" claim (Codex Finding 3: recommending `wienerdog gws auth` here is
   factually wrong — `auth.run` throws without `--client <path>` and always opens
@@ -300,7 +312,10 @@ Message contract (parity with WP-103's two warns):
 
 `resolvable` is captured from the resolve attempt already performed (cheaper than
 and equivalent to a second `isInstalled(paths)` call, since both mean
-"`resolveFromDeps` returned non-null"); keep the predicate explicit as shown.
+"`resolveFromDeps` returned non-null"); keep the predicate explicit as shown. A
+shape-broken module (loaded but no `.google`) implies `resolvable === true` by
+construction — it resolved and required — so it falls through to the **broken**
+classification automatically; no separate flag is needed.
 
 **3. `ensureGoogleReady(paths, opts)` — new, exported.** The read-path self-heal.
 
@@ -380,7 +395,7 @@ against `ensureGoogleReady` (§5); the index wiring is this thin call.
 build services. If a future gws verb is added that needs no services, it must be
 excluded from this gate too (note it then).
 
-**5. Tests (`tests/unit/gws-deps.test.js`).** Add two helpers and seven cases.
+**5. Tests (`tests/unit/gws-deps.test.js`).** Add three helpers and eight cases.
 Reuse the existing `tempPaths()`, `fakeInstall`, `deps`, `WienerdogError`, `path`,
 `fs`.
 
@@ -402,6 +417,16 @@ function plantCorruptDeps(paths) {
   fs.writeFileSync(path.join(pkgDir, 'package.json'),
     JSON.stringify({ name: 'googleapis', version: '173.0.0', main: 'index.js' }));
   fs.writeFileSync(path.join(pkgDir, 'index.js'), "throw new Error('corrupt googleapis entry point');\n");
+}
+/** Plant a SHAPE-BROKEN googleapis: it resolves AND requires cleanly, but exports
+ *  no `.google` (a zero-byte / stub index.js → `{}`). The canonical false-[ok]
+ *  case the load-probe shape check must catch (PR-gate P2). */
+function plantShapelessDeps(paths) {
+  const pkgDir = path.join(deps.depsDir(paths), 'node_modules', 'googleapis');
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(path.join(pkgDir, 'package.json'),
+    JSON.stringify({ name: 'googleapis', version: '173.0.0', main: 'index.js' }));
+  fs.writeFileSync(path.join(pkgDir, 'index.js'), 'module.exports = {};\n');
 }
 ```
 
@@ -434,6 +459,17 @@ function plantCorruptDeps(paths) {
   *flow shape* (remove → reinstall → loadable); real npm's metadata-vs-content
   no-op behavior is out of unit-test reach — the delete-first instruction exists
   precisely to defeat it.)
+- **(a3) loadGoogleapis — token present + deps SHAPE-BROKEN (loads to `{}`) → the
+  broken message, NOT a TypeError (PR-gate P2).** `plantToken(paths)` **and**
+  `plantShapelessDeps(paths)` on a fresh `tempPaths()`; assert `loadGoogleapis`
+  throws — and that the thrown value **`instanceof WienerdogError`** (proving the
+  shape check fired, not a raw `TypeError`) — whose message matches `/Google is
+  connected, but its client library is broken \(installed but not loadable\)/`,
+  matches `/delete the folder/`, does **NOT** match `/will offer to install/`, and
+  does **not** match `/\/wienerdog-google-setup/`. This is the canonical false-`[ok]`
+  case: a zero-byte/stub entry point requires cleanly but has no `.google`, so
+  without the shape check `getServices` would later crash at `new
+  google.auth.OAuth2`.
 - **(b) ensureGoogleReady — token present + deps absent + consent-yes →
   installs.** `plantToken`; `await ensureGoogleReady(paths, {confirm: async () =>
   true, runInstall: (dir, spec) => fakeInstall(dir, spec)})`; assert the injected
@@ -523,6 +559,14 @@ unchanged**. Do not touch them.
   the same delete-then-reinstall remedy. Do NOT change the read-path `isInstalled`
   check to a load probe here — the accurate message, not auto-repair, is what
   closes the loop.
+- **The shape check is minimal (PR-gate P2).** `loadGoogleapis` validates only that
+  the required module exposes a truthy `.google` object — enough to catch the
+  canonical shape-broken case (a zero-byte / stub `index.js` → `{}`) and convert it
+  from a raw downstream `TypeError` into the friendly broken message. It is **not** a
+  full API-surface validation: a module with `.google` present but internally
+  corrupt (e.g. missing `google.auth.OAuth2`) still surfaces at call time. That
+  deeper corruption is an **accepted residual** — validating the full surface on
+  every load is not worth it, and the remedy (delete + reinstall) is identical.
 - **`hasToken` stays existence-only (Codex Finding 4 asymmetry).** `hasToken`
   checks only that `google-token.json` *exists*, not that it is valid JSON with a
   `refresh_token`. This asymmetry with `doctor`'s minimal token validation
@@ -711,3 +755,21 @@ npm run lint
     { defaultYes: true })` (NOT `opts.yes`, which would bypass consent). Added
     test (g): a confirm seam captures its 2nd arg and asserts it deep-equals
     `{ defaultYes: true }`. Existing accept/decline consent tests unchanged.
+- **2026-07-13 — closing PR-gate (Codex PR review; one P2, WP-102 fix serves
+  WP-103 too).** The load probe treated **any** successfully-required module as
+  usable, so a shape-broken install whose `index.js` requires to `{}` (canonical:
+  zero-byte entry point) passed `loadGoogleapis` → `doctor` reported `[ok]` and the
+  next gws read crashed with a raw `TypeError` at `new google.auth.OAuth2` in
+  `getServices`. Fix (single point in `loadGoogleapis`): after a successful require,
+  validate the module shape — `if (mod && typeof mod.google === 'object' &&
+  mod.google) return mod;` else fall through to the existing classification. A
+  shape-fail implies `resolvable === true` (it resolved and loaded), so it is
+  classified **broken** automatically — the read path gets the friendly broken
+  message, and `doctor` inherits the fix (its probe calls `loadGoogleapis`).
+  `ensureGoogleReady`/`isInstalled` unchanged (owner's targeted disposition: the
+  resolve-only read gate stays; a shape-broken install is manual-remedy). Added test
+  (a3): `plantShapelessDeps` (`module.exports = {}`) → `loadGoogleapis` throws a
+  `WienerdogError` (asserted `instanceof`, NOT a `TypeError`) with the broken
+  message and no offer claim. Recorded the accepted residual: the check is minimal
+  (presence of a truthy `.google`), not a full API-surface validation — deeper
+  corruption still surfaces at call time.

--- a/docs/specs/WP-102-gws-deps-self-heal.md
+++ b/docs/specs/WP-102-gws-deps-self-heal.md
@@ -61,15 +61,16 @@ the same misleading error and cannot self-heal (they can't run interactive
    than today). An **unauthed** user (no token) is untouched — they still get the
    existing "connect Google" flow.
 2. **Disambiguate the error.** `loadGoogleapis` (the sole emit site of the
-   misleading string) branches on token presence and then on resolvability: no
-   token → the current connect-Google message (unchanged); token present + library
-   **absent** → "needs a one-time install … the next `wienerdog gws` command will
-   offer to install it"; token present + library **resolvable-but-unloadable**
-   (corrupt) → "broken (installed but not loadable) — delete the folder `<depsDir>`,
-   then reinstall it", with no offer claim (the self-heal cannot fire on a
-   resolvable install, and a bare `npm install` can no-op on a corrupt tree — see
-   round-4 below). Both name the concrete npm remedy. This is the defensive backstop
-   for any caller that reaches `loadGoogleapis` without going through the self-heal
+   misleading string) branches on token presence and then on **physical presence**
+   of the deps tree (`depsPresent`): no token → the current connect-Google message
+   (unchanged); token present + **no deps tree** → "needs a one-time install … the
+   next `wienerdog gws` command will offer to install it"; token present + a **deps
+   tree present but not usable** (corrupt entry, missing/malformed main, no
+   `.google`, or symlink-out) → "broken (installed but not loadable) — delete the
+   folder `<depsDir>`, then reinstall it", with no offer claim (the self-heal cannot
+   fire on a present tree, and a bare `npm install` can no-op on a corrupt tree — see
+   round-4/round-6 below). Both name the concrete npm remedy. This is the defensive
+   backstop for any caller that reaches `loadGoogleapis` without going through the self-heal
    wrapper, and it mirrors WP-103's doctor split exactly.
 
 **Product invariants that bound this WP.** Wienerdog is just files (ADR-0004): the
@@ -207,9 +208,11 @@ cases — see "Do NOT modify these" below.
 
 | Action | Path | Notes |
 |--------|------|-------|
-| modify | src/gws/deps.js | (0) **rewrite `resolveFromDeps` to direct-path construction** (owner-approved guard change, contract §0 — cache-poisoning fix); (a) make `loadGoogleapis` token-aware + state-aware + shape-check per the Exact contract; (b) add + export `ensureGoogleReady(paths, opts)`; (c) add an internal `hasToken(paths)` helper (lazy `require('./client')`); (d) two one-line edits to `ensureGoogleapis` — quote the `--prefix` in its `cmd` string (P2-A) and pass `{defaultYes:true}` to the confirm call (P2-B), per contract §3b. |
-| modify | src/gws/index.js | import `ensureGoogleReady` from `./deps`; call `await ensureGoogleReady(paths)` for every non-`auth` command, before services are built. |
-| modify | tests/unit/gws-deps.test.js | add the `plantToken`/`plantCorruptDeps`/`plantShapelessDeps` helpers + the new cases below (incl. the §0 cache-regression case **(a4)**). Do NOT modify the existing no-token / containment assertions (they stay byte-identical — behavior is unchanged). |
+| modify | src/gws/deps.js | (0) **rewrite `resolveFromDeps` to direct-path construction** + add & export **`depsPresent`** (§0, cache-poisoning + presence-key); (a) `loadGoogleapis` token-aware + **presence-keyed** absent/broken split + shape-check (§2); (b) add + export `ensureGoogleReady`, **gated on `depsPresent`** (§3); (c) internal `hasToken` (lazy `require('./client')`) (§1); (d) `ensureGoogleapis` — quote `--prefix` (P2-A), `{defaultYes:true}` confirm (P2-B), notice+prompt → **stderr** (P1), + a present-but-broken **fail-to-print** guard (round-6 P2); (e) `defaultRunInstall` stdio → `['inherit', 2, 2]` (npm output → stderr, P1). Per contract §0/§2/§3/§3b. |
+| modify | src/gws/index.js | import `ensureGoogleReady` from `./deps`; call `await ensureGoogleReady(paths)` for every non-`auth` command, before services are built. (No P1/P2 change — chatter routing is entirely in deps.js/prompt.js.) |
+| modify | src/core/prompt.js | add `opts.output` to `confirm` (mode-1 prompt output stream; default `process.stdout`), per §3c. Backward-compatible; mode 2/3 unchanged. |
+| modify | tests/unit/gws-deps.test.js | add the `plantToken`/`plantCorruptDeps`/`plantShapelessDeps`/`plantMainlessDeps` helpers + the new cases below (incl. §0 cache-regression **(a4)**, §2 missing-main **(a5)**, ensureGoogleReady present-no-op **(h)**, ensureGoogleapis present-broken throw **(i)**, stdout-hygiene **(j)**). Do NOT modify the existing no-token / containment assertions (they stay byte-identical). |
+| modify | tests/unit/prompt.test.js | add one case: mode-1 `opts.output` routes the prompt to the given stream (keeps `process.stdout` clean); existing cases unchanged. |
 
 ### Exact contracts
 
@@ -233,15 +236,30 @@ exists for (a machine with a global/ancestor `googleapis`).
 resolve it absolutely:
 
 ```js
+/** Whether a googleapis tree is PHYSICALLY present in the deps dir (its own
+ *  package.json exists). This — NOT resolvability — is the absent/broken key and
+ *  the self-heal gate (see §2 and §3/§3b + round-6 P2): a present-but-unresolvable
+ *  tree (missing/malformed main, or a symlink pointing outside) must read BROKEN,
+ *  and self-heal must NOT `npm` over it (arborist can no-op). `existsSync` follows
+ *  symlinks, so a symlinked-inside copy counts as present and is then rejected as
+ *  broken by resolveFromDeps's containment check. Exported (doctor/WP-103 uses it). */
+function depsPresent(paths) {
+  return fs.existsSync(path.join(depsDir(paths), 'node_modules', 'googleapis', 'package.json'));
+}
+
 function resolveFromDeps(paths) {
   const dir = depsDir(paths);
+  // (1) Absent unless the deps-dir copy is physically present (its own package.json
+  //     exists). Pure existence check — no resolution, so nothing is looked up in
+  //     ancestors or cached.
+  if (!depsPresent(paths)) return null;
   const candidate = path.join(dir, 'node_modules', 'googleapis');
-  // (1) Absent unless the deps-dir copy's OWN package.json exists. Pure existence
-  //     check — no resolution, so nothing is looked up in ancestors or cached.
-  if (!fs.existsSync(path.join(candidate, 'package.json'))) return null;
   // (2) Resolve the ABSOLUTE candidate path (never the bare 'googleapis' request),
   //     so resolution targets exactly this dir, never walks ancestors, and is not
   //     served from Module._pathCache (the bare-request cache key is never used).
+  //     NOTE: this can THROW when the tree is present but its main is missing/
+  //     malformed — callers treat a throw as "present but broken" (§2/§3b), never
+  //     as absent.
   const req = createRequire(path.join(dir, 'noop.js'));
   const resolved = req.resolve(candidate);
   // (3) RETAIN the realpath containment check — the resolved entry must live inside
@@ -261,9 +279,12 @@ deps-dir copy's own `package.json`; step 2 resolves only the absolute in-dir pat
 The **symlink defense is unchanged**: step 3's realpath containment still rejects a
 symlinked-inside copy that points outside the deps dir. The walk had to go because
 it was the source of the `Module._pathCache` poisoning above; direct-path
-resolution is simpler and cache-immune. `isInstalled` and `loadGoogleapis` above
-the resolver are **unchanged** (they still call `resolveFromDeps` and branch on
-non-null / null).
+resolution is simpler and cache-immune. `isInstalled` is **unchanged** (still
+`resolveFromDeps(paths) !== null`); `loadGoogleapis`, `ensureGoogleReady`, and
+`ensureGoogleapis` are re-keyed onto `depsPresent` (physical presence) rather than
+resolvability — see §2 / §3 / §3b (round-6 P2): a present-but-unresolvable tree
+(missing/malformed main, or a symlink-out) must classify **broken**, and self-heal
+must never `npm`-install over a present tree.
 
 **1. `hasToken(paths)` — new internal helper in `deps.js`.** Lazy-require
 `./client` to avoid a load-time cycle (`client.js` requires `deps.js` at top
@@ -283,34 +304,34 @@ function hasToken(paths) {
 }
 ```
 
-**2. `loadGoogleapis(paths)` — branch on token presence, then on resolvability.**
-Keep the resolve attempt and the no-token message byte-for-byte; add the
-token-present branch, split into **absent** vs **broken** exactly as WP-103's
-doctor probe does (Codex round-3 Finding). Capture resolvability from the resolve
-attempt already made — `resolveFromDeps` returns non-null iff `googleapis` resolves
-from **inside** the deps dir (== `isInstalled`), and the require can still throw
-afterward for a corrupt install — so a single `resolvable` flag set **before** the
-require distinguishes the two failure modes without a second resolve:
+**2. `loadGoogleapis(paths)` — branch on token presence, then on PHYSICAL
+PRESENCE (`depsPresent`), not resolvability.** Keep the no-token message
+byte-for-byte; the token-present branch splits **absent** vs **broken** on
+`depsPresent(paths)` (round-6 P2). **Why presence, not resolvability:** a tree
+whose `package.json` exists but whose main is missing/malformed makes
+`resolveFromDeps` *throw* (→ `null`/absent under the old resolvable key), which
+would mis-classify it ABSENT → self-heal would `npm`-over-corrupt → arborist can
+no-op → permanent loop. Keying on physical presence makes **every** present-yet-
+unusable state — resolve-throw (bad main), require-throw (corrupt entry point),
+shape-fail (no `.google`), and symlink-out (containment reject) — classify BROKEN:
 
 ```js
 function loadGoogleapis(paths) {
-  let resolvable = false;
-  try {
-    const hit = resolveFromDeps(paths);
-    if (hit) {
-      resolvable = true;                 // resolves from inside the deps dir (== isInstalled)...
-      const mod = hit.req(hit.resolved); // ...but the require can throw (corrupt), or...
-      // ...load a SHAPE-BROKEN module: a zero-byte / stub `index.js` requires to
-      // `{}` (valid JS, no throw) but has no `.google`, so getServices would later
-      // crash with a raw TypeError at `new google.auth.OAuth2`. Validate the shape
-      // here and treat a missing `.google` object exactly as the BROKEN state
-      // (resolvable is already true), so both the read path and doctor get the
-      // friendly broken message instead of a TypeError (PR-gate P2).
-      if (mod && typeof mod.google === 'object' && mod.google) return mod;
-      // else: shape-broken — fall through to the BROKEN classification below.
+  const present = depsPresent(paths);   // physical presence — the classification key (round-6 P2)
+  if (present) {
+    try {
+      const hit = resolveFromDeps(paths);   // may THROW (bad main) or return null (symlink-out)
+      if (hit) {
+        const mod = hit.req(hit.resolved);   // may THROW (corrupt entry point)
+        // SHAPE check: a zero-byte / stub `index.js` requires to `{}` without
+        // throwing but has no `.google`, so getServices would later crash with a
+        // raw TypeError at `new google.auth.OAuth2`. Require a truthy `.google`.
+        if (mod && typeof mod.google === 'object' && mod.google) return mod;   // healthy
+      }
+      // hit === null (symlink-out) or shape-fail → present-but-broken; fall through.
+    } catch {
+      /* resolve-throw (bad main) or require-throw (corrupt) — present-but-broken */
     }
-  } catch {
-    /* resolve failed (absent), OR require threw (corrupt); `resolvable` tells them apart */
   }
   // Disambiguate the states that share this failure (BUG-gws-deps-missing):
   if (hasToken(paths)) {
@@ -319,23 +340,20 @@ function loadGoogleapis(paths) {
     // C:\Users\John Smith\...) would otherwise split the argument when the user
     // pastes the command. Double quotes work in POSIX shells, cmd, and PowerShell.
     const cmd = `npm install --ignore-scripts --prefix "${dir}" ${GOOGLEAPIS_SPEC}`;
-    if (resolvable) {
-      // CONNECTED but the library is installed-yet-unloadable (corrupt/partial):
-      // the read-path self-heal NO-OPs here (isInstalled is true), so promising an
-      // "offer to install" would make the user loop on a contradictory message.
-      // A plain reinstall can NO-OP too: npm compares tree metadata (recorded
-      // version/integrity), NOT file contents, so a corrupt-but-resolvable tree
-      // reads as "up to date" and stays broken (round-4 Finding). The corrupt tree
-      // must be REMOVED first. The deps dir is single-purpose (it exists solely to
-      // hold the consented googleapis tree), so deleting it wholesale is safe.
-      // Platform-neutral prose (not a per-OS rm/Remove-Item one-liner) — plain
-      // language for knowledge workers, CLAUDE.md.
+    if (present) {
+      // CONNECTED but a deps tree is physically present yet not usable
+      // (bad main / corrupt entry / no `.google` / symlink-out): the read-path
+      // self-heal NO-OPs here (depsPresent is true), and a plain reinstall can
+      // NO-OP too — npm compares tree metadata (recorded version/integrity), NOT
+      // file contents (round-4 Finding). The tree must be REMOVED first. The deps
+      // dir is single-purpose, so deleting it wholesale is safe. Platform-neutral
+      // prose (not a per-OS rm/Remove-Item one-liner) — CLAUDE.md.
       throw new WienerdogError(
         'Google is connected, but its client library is broken (installed but not loadable). ' +
           `To repair it, delete the folder ${dir}, then reinstall it:\n  ${cmd}`
       );
     }
-    // CONNECTED and the library is ABSENT: the next gws read WILL self-heal.
+    // CONNECTED and the library is ABSENT (no deps tree): the next gws read WILL self-heal.
     throw new WienerdogError(
       'Google is connected, but its client library needs a one-time install. ' +
         'The next `wienerdog gws` command will offer to install it, or run:\n  ' +
@@ -353,20 +371,22 @@ The exact npm command in every message is the **quoted-prefix** form
 below).
 
 Message contract (parity with WP-103's two warns):
-- **Absent** (token present, not resolvable): MUST contain `Google is connected,
-  but its client library needs a one-time install` AND `The next \`wienerdog gws\`
-  command will offer to install it` AND the exact quoted-prefix npm command.
-- **Broken** (token present, resolvable but the require threw **OR** the loaded
-  module is shape-invalid — no truthy `.google` object): MUST contain `Google is
-  connected, but its client library is broken (installed but not loadable)` AND
-  `delete the folder <depsDir>` AND the exact quoted-prefix npm command, and MUST
-  **NOT** contain `will offer to install` (the self-heal cannot fire — `isInstalled`
-  is true). The **delete-first** instruction is load-bearing: a bare `npm install`
-  over a corrupt-but-resolvable tree can no-op (npm compares tree metadata, not file
-  contents), leaving the user looping (round-4 Finding). The **shape check** (a
-  zero-byte / stub `index.js` requires to `{}` without throwing) routes here too,
-  so a shape-broken install yields this friendly message rather than a raw
-  TypeError from `getServices` (PR-gate P2).
+- **Absent** (token present, `depsPresent === false` — no deps tree): MUST contain
+  `Google is connected, but its client library needs a one-time install` AND `The
+  next \`wienerdog gws\` command will offer to install it` AND the exact
+  quoted-prefix npm command.
+- **Broken** (token present, `depsPresent === true` but the tree is not usable —
+  bad main resolve-throw, corrupt entry require-throw, shape-fail with no truthy
+  `.google`, or symlink-out): MUST contain `Google is connected, but its client
+  library is broken (installed but not loadable)` AND `delete the folder <depsDir>`
+  AND the exact quoted-prefix npm command, and MUST **NOT** contain `will offer to
+  install` (the self-heal cannot fire — `depsPresent` is true). The **delete-first**
+  instruction is load-bearing: a bare `npm install` over a present-but-corrupt tree
+  can no-op (npm compares tree metadata, not file contents), leaving the user
+  looping (round-4 Finding). Both the shape-broken (`{}`) and the missing-main
+  (resolve-throw) trees route here, so they yield this friendly message rather than
+  a raw TypeError (PR-gate) or a mis-classified "will offer to install" loop
+  (round-6 P2).
 - **Both** branches MUST NOT contain `/wienerdog-google-setup`, `gws auth`, or any
   "no browser" claim (Codex Finding 3: recommending `wienerdog gws auth` here is
   factually wrong — `auth.run` throws without `--client <path>` and always opens
@@ -375,63 +395,129 @@ Message contract (parity with WP-103's two warns):
 - The **no-token** branch is unchanged (byte-for-byte the same
   `/wienerdog-google-setup` message).
 
-`resolvable` is captured from the resolve attempt already performed (cheaper than
-and equivalent to a second `isInstalled(paths)` call, since both mean
-"`resolveFromDeps` returned non-null"); keep the predicate explicit as shown. A
-shape-broken module (loaded but no `.google`) implies `resolvable === true` by
-construction — it resolved and required — so it falls through to the **broken**
-classification automatically; no separate flag is needed.
+`present` is the single classification key. It is `depsPresent(paths)` — physical
+presence of the deps-dir `googleapis/package.json` — evaluated ONCE, before any
+resolve. Every present-yet-unusable sub-state (resolve-throw, require-throw,
+shape-fail, symlink-out) falls through to the **broken** classification; only a
+truly absent tree (`present === false`) is **absent**. Do NOT re-key this on
+`isInstalled`/resolvability (that reintroduces the round-6 mis-classification of a
+missing-main tree as absent → `npm`-over-corrupt loop).
 
 **3. `ensureGoogleReady(paths, opts)` — new, exported.** The read-path self-heal.
+**Gate on `depsPresent`, not `isInstalled`** (round-6 P2): if any deps tree is
+physically present — healthy OR broken — self-heal must NOT run (it must never
+`npm`-install over a present tree; `loadGoogleapis` surfaces broken-vs-healthy).
 
 ```js
 /**
  * Self-heal the on-demand googleapis install on the READ path. When a Google
- * sign-in token exists but the client library is absent (the post-WP-047-upgrade
+ * sign-in token exists but NO deps tree is present (the post-WP-047-upgrade
  * dead-end, BUG-gws-deps-missing), install it once — with consent, exactly like
- * first auth (ADR-0011/ADR-0013). No-op when already installed, or when no token
- * exists (an unauthed user; getServices()'s loadToken then surfaces the
- * connect-Google flow unchanged). Consent seams pass straight through to
- * ensureGoogleapis: interactive → a [Y/n] prompt; non-TTY/headless →
- * ensureGoogleapis throws the accurate, browser-free npm-install remedy.
+ * first auth (ADR-0011/ADR-0013). No-op when a deps tree is already PRESENT
+ * (healthy or broken — never install over it), or when no token exists (an
+ * unauthed user; getServices()'s loadToken then surfaces the connect-Google flow
+ * unchanged). Consent seams pass straight through to ensureGoogleapis: interactive
+ * → a [Y/n] prompt (on stderr); non-TTY/headless → ensureGoogleapis throws the
+ * accurate, browser-free npm-install remedy.
  * @param {WienerdogPaths} paths
  * @param {{yes?:boolean, confirm?:(q:string)=>Promise<boolean>,
  *          runInstall?:(dir:string,spec:string)=>{status:number}}} [opts]
  * @returns {Promise<void>}
  */
 async function ensureGoogleReady(paths, opts = {}) {
-  if (isInstalled(paths)) return;   // already present — nothing to do
+  if (depsPresent(paths)) return;   // a deps tree is present (healthy or broken) — never install over it
   if (!hasToken(paths)) return;     // unauthed — do not install; let loadToken surface the connect flow
   await ensureGoogleapis(paths, opts);
 }
 ```
 
-Add `ensureGoogleReady` to `module.exports` (keep the existing exports).
+Add `ensureGoogleReady` and `depsPresent` to `module.exports` (keep the existing
+exports).
 
-**3b. `ensureGoogleapis` — two one-line changes (PR-gate P2-A + P2-B).** The
-existing WP-047 installer body gets exactly two edits; nothing else in it changes:
+**3b. `ensureGoogleapis` + `defaultRunInstall` — changes (PR-gate P2-A/P2-B + the
+round-6 P1 stdout-hygiene + P2 present-but-broken fixes).** The target
+`ensureGoogleapis` body:
 
-- **P2-A — quote the prefix in its `cmd` template** (same reason and form as
-  `loadGoogleapis`; leaving it unquoted breaks parity — this `cmd` is what its
-  prompt line and its decline / install-failed messages show the user):
-  - OLD: `` const cmd = `npm install --ignore-scripts --prefix ${dir} ${GOOGLEAPIS_SPEC}`; ``
-  - NEW: `` const cmd = `npm install --ignore-scripts --prefix "${dir}" ${GOOGLEAPIS_SPEC}`; ``
-- **P2-B — pass `{ defaultYes: true }` to the production confirm** so pressing
-  Enter at the `[Y/n]` prompt ACCEPTS (the prompt, the function's own doc comment,
-  and ADR-0011's posture all advertise default-yes, but `src/core/prompt.js`
-  `confirm(question, opts)` defaults `defaultYes` **false**, so today Enter
-  *declines* — a latent WP-047 defect that WP-102's self-heal makes the primary
-  recovery path, so it is in-scope here):
-  - OLD: `const ok = opts.yes || (await ask('Install it now? [Y/n] '));`
-  - NEW: `const ok = opts.yes || (await ask('Install it now? [Y/n] ', { defaultYes: true }));`
-  - `ask = opts.confirm || confirm`; production `confirm` accepts `(question,
-    opts)`. Do **NOT** use `opts.yes` for this (that bypasses consent entirely).
-    The injected test seams have signature `(q) => Promise<boolean>`; passing a
-    second arg to them is harmless.
+```js
+async function ensureGoogleapis(paths, opts = {}) {
+  if (isInstalled(paths)) return { installed: false, already: true };   // healthy → no-op
+  const dir = depsDir(paths);
+  // P2-A: quote the prefix (space-safe home paths); same form as loadGoogleapis.
+  const cmd = `npm install --ignore-scripts --prefix "${dir}" ${GOOGLEAPIS_SPEC}`;
+  // round-6 P2 (auth path): a deps tree is physically present but NOT usable
+  // (isInstalled false, e.g. bad main / symlink-out). A plain reinstall may no-op
+  // over it (arborist metadata compare), so fail to the HONEST delete-then-reinstall
+  // remedy instead of npm-over-corrupt — never auto-repair (owner disposition).
+  if (depsPresent(paths)) {
+    throw new WienerdogError(
+      `Google's client library is installed but not loadable. Delete the folder ${dir}, then reinstall it:\n  ${cmd}`
+    );
+  }
+  // Truly absent → consented install. round-6 P1: ALL chatter goes to STDERR so a
+  // piped read (`gws … --json | jq`) keeps clean stdout.
+  process.stderr.write(`\nWienerdog needs Google's client library. It will run:\n  ${cmd}\n`);
+  const ask = opts.confirm || confirm;
+  // P2-B: {defaultYes:true} so Enter ACCEPTS. round-6 P1: output:process.stderr so
+  // the prompt question is visible (and not written into a piped stdout).
+  const ok = opts.yes || (await ask('Install it now? [Y/n] ', { defaultYes: true, output: process.stderr }));
+  if (!ok) throw new WienerdogError(`declined — run this yourself, then retry:\n  ${cmd}`);
+  fs.mkdirSync(dir, { recursive: true });
+  const run = opts.runInstall || defaultRunInstall;
+  const r = run(dir, GOOGLEAPIS_SPEC);
+  if (r.status !== 0) throw new WienerdogError(`install failed — run it yourself, then retry:\n  ${cmd}`);
+  return { installed: true };
+}
+```
 
-`defaultRunInstall`'s `spawnSync` arg array is **unchanged** — it invokes `npm`
-with an argv array (no shell), so the prefix needs no quoting there; only the
-human-facing command STRINGS are quoted.
+Change summary versus the WP-047 body:
+- **P2-A** — quote `--prefix "${dir}"` in `cmd` (space-safe home paths).
+- **P2-B** — `{ defaultYes: true }` on the confirm call so Enter ACCEPTS. Do **NOT**
+  use `opts.yes` (that bypasses consent). Injected `(q)=>Promise<boolean>` seams
+  ignore the 2nd arg harmlessly.
+- **round-6 P1 (stdout hygiene)** — the "Wienerdog needs Google's client library…"
+  notice moves from `process.stdout.write` to **`process.stderr.write`**, and the
+  confirm call passes **`output: process.stderr`** so the prompt renders on stderr.
+  Rationale: a connected user running `gws gmail search --json | jq` (stdout piped,
+  stdin a TTY) must NOT get the notice/prompt/npm output mixed into the JSON on
+  stdout — today it corrupts every piped consumer, and the prompt question is even
+  written *into the pipe* (invisible) while it waits.
+- **round-6 P2 (auth path)** — the new `if (depsPresent(paths)) throw …` guard: for
+  a present-but-broken tree, fail to the honest delete-then-reinstall remedy instead
+  of `npm`-installing over it. Only reachable via `auth.js` (ensureGoogleReady gates
+  on `depsPresent` and returns before calling here); healthy trees still no-op via
+  `isInstalled`. auth's own meaningful stdout (the authorization URL) is written by
+  `auth.js`, not here, and is unchanged.
+
+**`defaultRunInstall` — route npm's output to stderr (round-6 P1).**
+- OLD: `spawnSync('npm', [...], { stdio: 'inherit' })`
+- NEW: `spawnSync('npm', [...], { stdio: ['inherit', 2, 2] })` — child stdin inherits
+  from the parent; child stdout AND stderr both go to the parent's **stderr** (fd 2),
+  so npm's progress never lands on the piped stdout. The argv array is otherwise
+  unchanged (no shell — the prefix needs no quoting here; only the human-facing
+  command STRINGS are quoted).
+
+**If any existing test pins the `ensureGoogleapis` notice/prompt on stdout**, move
+that assertion to stderr. (None do today — the current gws-deps ensureGoogleapis
+tests assert on return values / thrown messages, not captured stdout.)
+
+**3c. `src/core/prompt.js` — add `opts.output` to `confirm` (round-6 P1;
+backward-compatible).** Today the mode-1 (stdin-is-a-TTY) branch renders the
+prompt to a hardcoded `process.stdout`; the mode-2 (`/dev/tty`) branch already
+uses `process.stderr`. Add an `opts.output` that overrides the **mode-1** output
+stream (default stays `process.stdout`), so `ensureGoogleapis` can route the
+consent prompt to stderr:
+
+- OLD (mode-1 branch): `ask(process.stdin, process.stdout, question, () => {}, () => resolve(false), defaultYes)`
+- NEW: `const output = (opts && opts.output) || process.stdout;` then
+  `ask(process.stdin, output, question, () => {}, () => resolve(false), defaultYes)`
+
+Constraints:
+- **Mode 2 and mode 3 are unchanged** (mode 2 already prompts on `process.stderr`;
+  mode 3 aborts). `opts.output` affects only the mode-1 default-stdout path.
+- **Backward-compatible**: every existing caller (no `opts.output`) still renders
+  on `process.stdout` in mode 1. `defaultYes` handling is unchanged.
+- Update `confirm`'s JSDoc `@param opts` to document `output?: NodeJS.WritableStream`
+  ("mode-1 prompt output stream; default process.stdout").
 
 **4. `src/gws/index.js` wiring.** Add the import near the existing requires:
 
@@ -460,8 +546,8 @@ against `ensureGoogleReady` (§5); the index wiring is this thin call.
 build services. If a future gws verb is added that needs no services, it must be
 excluded from this gate too (note it then).
 
-**5. Tests (`tests/unit/gws-deps.test.js`).** Add three helpers and ten cases
-(a, a2, a3, a4, b–g). Reuse the existing `tempPaths()`, `fakeInstall`,
+**5. Tests (`tests/unit/gws-deps.test.js`).** Add four helpers and fourteen cases
+(a, a2, a3, a4, a5, b–j). Reuse the existing `tempPaths()`, `fakeInstall`,
 `plantGoogleapis(base, which)` (already in the file — used by (a4) for the ancestor
 copy), `deps`, `WienerdogError`, `path`, `fs`.
 
@@ -493,6 +579,16 @@ function plantShapelessDeps(paths) {
   fs.writeFileSync(path.join(pkgDir, 'package.json'),
     JSON.stringify({ name: 'googleapis', version: '173.0.0', main: 'index.js' }));
   fs.writeFileSync(path.join(pkgDir, 'index.js'), 'module.exports = {};\n');
+}
+/** Plant a MAINLESS googleapis: package.json present (main: index.js) but NO
+ *  index.js — present (package.json exists) yet req.resolve THROWS. The round-6 P2
+ *  case that must classify BROKEN, not absent. */
+function plantMainlessDeps(paths) {
+  const pkgDir = path.join(deps.depsDir(paths), 'node_modules', 'googleapis');
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(path.join(pkgDir, 'package.json'),
+    JSON.stringify({ name: 'googleapis', version: '173.0.0', main: 'index.js' }));
+  // deliberately NO index.js — req.resolve(candidate) throws (main missing)
 }
 ```
 
@@ -553,6 +649,14 @@ function plantShapelessDeps(paths) {
   `loadGoogleapis` cache-hits the ancestor and throws "needs a one-time install")
   **and passes on the §0 direct-path guard.** Run **in-process** (the whole point is
   the intra-process cache) — do NOT use `probeInChild` here.
+- **(a5) loadGoogleapis — token present + MAINLESS tree (package.json but no main)
+  → BROKEN, not absent (round-6 P2).** `plantToken(paths)` **and**
+  `plantMainlessDeps(paths)` on a fresh `tempPaths()`; assert `loadGoogleapis`
+  throws a `WienerdogError` matching `/broken \(installed but not loadable\)/` and
+  `/delete the folder/`, and does **NOT** match `/needs a one-time install/`, NOT
+  `/will offer to install/`, NOT `/\/wienerdog-google-setup/`. Also assert
+  `deps.depsPresent(paths) === true` and `deps.isInstalled(paths) === false` (the
+  exact state that mis-classified as absent under the old resolvable key).
 - **(b) ensureGoogleReady — token present + deps absent + consent-yes →
   installs.** `plantToken`; `await ensureGoogleReady(paths, {confirm: async () =>
   true, runInstall: (dir, spec) => fakeInstall(dir, spec)})`; assert the injected
@@ -573,22 +677,46 @@ function plantShapelessDeps(paths) {
   true, runInstall: () => {ran = true; return {status:0};}})`. Assert `res ===
   undefined`, `ran === false` (the consent seam was never consulted), and
   `deps.isInstalled(paths) === false`.
-- **(e) ensureGoogleReady — already installed → no-op.** `plantToken` **and**
+- **(e) ensureGoogleReady — a PRESENT (healthy) tree → no-op.** `plantToken` **and**
   `fakeInstall(deps.depsDir(paths))`; `await ensureGoogleReady(paths, {confirm:
   async () => true, runInstall: () => {ran = true; return {status:0};}})`; assert
-  `ran === false` (installer must not run when already present).
+  `ran === false` (installer must not run when a tree is present; now via the
+  `depsPresent` gate).
 - **(f) ensureGoogleReady with opts.yes — token present + deps absent → installs
   without prompting.** `plantToken`; `await ensureGoogleReady(paths, {yes: true,
   confirm: async () => {asked = true; return false;}, runInstall: fakeInstall})`;
   assert `asked === false` and `deps.isInstalled(paths) === true`.
-- **(g) ensureGoogleapis passes `{ defaultYes: true }` to confirm (P2-B — locks
-  the default against regression).** On a fresh `tempPaths()` (deps absent, so the
-  prompt/install path runs), `let seenQ, seenOpts; await deps.ensureGoogleapis(
-  paths, {confirm: async (q, opts) => { seenQ = q; seenOpts = opts; return true; },
-  runInstall: fakeInstall});` then `assert.equal(seenQ, 'Install it now? [Y/n] ');
-  assert.deepEqual(seenOpts, { defaultYes: true });`. (Tested directly on
-  `ensureGoogleapis`, the sole consent site; `ensureGoogleReady` passes the same
-  seam straight through.)
+- **(g) ensureGoogleapis passes `{ defaultYes: true, output: process.stderr }` to
+  confirm (P2-B + P1 — locks the default-yes AND the stderr routing).** On a fresh
+  `tempPaths()` (deps absent, so the prompt/install path runs), `let seenQ,
+  seenOpts; await deps.ensureGoogleapis(paths, {confirm: async (q, opts) => { seenQ
+  = q; seenOpts = opts; return true; }, runInstall: fakeInstall});` then
+  `assert.equal(seenQ, 'Install it now? [Y/n] '); assert.equal(seenOpts.defaultYes,
+  true); assert.equal(seenOpts.output, process.stderr);` (identity check on the
+  stream, not `deepEqual` — a stream is not structurally comparable).
+- **(h) ensureGoogleReady — a PRESENT-but-BROKEN tree → NO-OP, seams never
+  consulted (round-6 P2).** `plantToken(paths)` **and** `plantMainlessDeps(paths)`;
+  `let ran = false; const res = await deps.ensureGoogleReady(paths, {confirm: async
+  () => { ran = true; return true; }, runInstall: () => { ran = true; return
+  {status:0}; }});` assert `res === undefined` and `ran === false` (self-heal must
+  NOT `npm` over a present-but-broken tree — it returns via the `depsPresent` gate).
+- **(i) ensureGoogleapis — a PRESENT-but-BROKEN tree → throws the delete-then-
+  reinstall remedy, no install (round-6 P2, auth path).** `plantMainlessDeps(paths)`
+  on a fresh `tempPaths()`; `let ran = false; await assert.rejects(() =>
+  deps.ensureGoogleapis(paths, {confirm: async () => true, runInstall: () => { ran =
+  true; return {status:0}; }}), (e) => e instanceof WienerdogError && /Delete the
+  folder/.test(e.message) && e.message.includes(\`npm install --ignore-scripts
+  --prefix "${deps.depsDir(paths)}" ${deps.GOOGLEAPIS_SPEC}\`)); assert.equal(ran,
+  false);` (never `npm`-over-corrupt; fail to the honest remedy).
+- **(j) ensureGoogleapis writes NOTHING to stdout on the yes-path; the notice goes
+  to stderr (round-6 P1).** On a fresh `tempPaths()` (deps absent), capture
+  `process.stdout.write` and `process.stderr.write` around `await
+  deps.ensureGoogleapis(paths, {confirm: async () => true, runInstall:
+  fakeInstall})`; assert the captured **stdout is empty** and the captured
+  **stderr contains** `Wienerdog needs Google's client library`. (The injected
+  `confirm` seam does not touch streams, so this asserts the notice routing; the
+  prompt-stream routing is covered by the prompt.test.js case. Restore both
+  `write`s in a `finally`.)
 
 ### Update these existing `ensureGoogleapis` assertions to the quoted command (P2-A)
 
@@ -619,6 +747,27 @@ handled exactly as before (loaded if inside `realpath(depsDir)`, rejected if the
 symlink points outside). So the `probeInChild` ancestor-decoy cases (:205–230)
 still pass verbatim; only the NEW in-process case (a4) distinguishes old from new.
 
+**5b. Test (`tests/unit/prompt.test.js`) — mode-1 `opts.output` routes the prompt
+(round-6 P1).** Reuse the file's existing `withFakeTTYStdin` helper (it installs a
+fake TTY `PassThrough` as `process.stdin`). Add:
+
+```js
+test('mode 1: opts.output routes the prompt to the given stream (keeps stdout clean)', async () => {
+  await withFakeTTYStdin(async (fake) => {
+    const out = new PassThrough();          // PassThrough is already imported in this file
+    let written = '';
+    out.on('data', (c) => { written += c.toString(); });
+    const p = confirm('Install it now? [Y/n] ', { defaultYes: true, output: out });
+    fake.write('\n');                        // bare Enter → true (defaultYes)
+    assert.equal(await p, true);
+    assert.match(written, /Install it now\?/);   // the prompt went to opts.output, not stdout
+  });
+});
+```
+
+Do NOT change the existing prompt cases — they pass no `opts.output`, so mode 1
+still renders on `process.stdout` (backward-compat).
+
 ## Implementation notes & constraints
 
 - **Zero new dependencies.** No new require beyond the lazy `require('./client')`
@@ -633,25 +782,20 @@ still pass verbatim; only the NEW in-process case (a4) distinguishes old from ne
   cache-immune while preserving the symlink defense. Self-heal still populates the
   deps dir *through* the guard's install path and never bypasses it. Do not
   reintroduce the bare-`googleapis` ancestor walk.
-- **Accepted residual — self-heal SKIPS the corrupt state (Codex Finding 1b;
-  narrowed in round-3).** `ensureGoogleReady` gates on `isInstalled`, which only
-  *resolves* `googleapis` (via `resolveFromDeps`), it does not *load* it. So a
-  **corrupt/partial** install (interrupted `npm`, missing transitive dep, broken
-  entry point) that still resolves reads as installed → self-heal no-ops. Keeping
-  the resolve-only check on the read path is deliberate (loading the heavy
-  `googleapis` on every read to detect corruption is not worth it). **The residual
-  is now ONLY that self-heal does not auto-repair a corrupt install — the MESSAGE
-  is no longer misleading:** since round-3, `loadGoogleapis` detects this exact
-  state (resolvable + require threw) and emits the **broken** message, which makes
-  no self-heal promise and points to the repair that actually fixes it. Since
-  round-4 that repair is **delete the folder `<depsDir>`, then reinstall** — a bare
-  `npm install` can no-op over a corrupt-but-resolvable tree (npm compares tree
-  metadata, not file contents), so the corrupt tree must be removed first (the deps
-  dir is single-purpose). So a user in this state gets an accurate, actionable
-  message and never loops. The `doctor` probe (WP-103) surfaces the same state with
-  the same delete-then-reinstall remedy. Do NOT change the read-path `isInstalled`
-  check to a load probe here — the accurate message, not auto-repair, is what
-  closes the loop.
+- **Accepted residual — self-heal SKIPS the present-but-broken state (Codex
+  Finding 1b; narrowed round-3; re-keyed round-6).** `ensureGoogleReady` gates on
+  `depsPresent` — physical presence of the deps tree — and no-ops whenever a tree is
+  present, healthy OR broken. So a **corrupt/partial** install (interrupted `npm`,
+  missing transitive dep, missing/malformed main, broken entry point, symlink-out)
+  is never auto-repaired. Keeping self-heal to the truly-absent case is deliberate
+  (owner disposition: no auto-repair of a present tree; a plain reinstall can no-op
+  anyway). **The residual is ONLY that self-heal does not auto-repair — the MESSAGE
+  is accurate:** `loadGoogleapis` keys the same `depsPresent` split, so a
+  present-but-broken tree emits the **broken** message (delete the folder
+  `<depsDir>`, then reinstall — round-4), never a "will offer to install" loop
+  (round-6 P2 closed the missing-main mis-classification). The `doctor` probe
+  (WP-103) surfaces the same state with the same remedy. Do NOT re-key the read gate
+  onto `isInstalled`/resolvability — that reopens the missing-main-tree loop.
 - **The shape check is minimal (PR-gate P2).** `loadGoogleapis` validates only that
   the required module exposes a truthy `.google` object — enough to catch the
   canonical shape-broken case (a zero-byte / stub `index.js` → `{}`) and convert it
@@ -689,6 +833,13 @@ still pass verbatim; only the NEW in-process case (a4) distinguishes old from ne
   `defaultYes` and returns false), so headless installs are never silently
   performed. Every user-facing command string is quoted (`--prefix "<dir>"`, P2-A);
   `defaultRunInstall`'s argv array is untouched (no shell).
+- **stdout hygiene (round-6 P1).** ALL self-heal chatter goes to **stderr**: the
+  "Wienerdog needs Google's client library…" notice (`process.stderr.write`), the
+  consent prompt (confirm `output: process.stderr`, via the mode-1 `opts.output`
+  seam in `prompt.js`), and npm's own output (`defaultRunInstall` `stdio:
+  ['inherit', 2, 2]`). So a connected user's `gws … --json | jq` keeps a clean
+  stdout even when the first read triggers a consented install. `index.js` needs no
+  change — the routing lives entirely in `deps.js` + `prompt.js`.
 - When uncertain: choose the simpler option and record it under "Decisions made".
   Do NOT expand scope (no update-time backfill — see Out of scope; no keyring; no
   changes to token/client persistence, scopes, or the containment guard).
@@ -721,12 +872,12 @@ still pass verbatim; only the NEW in-process case (a4) distinguishes old from ne
 - [ ] `loadGoogleapis` with a token present + deps **absent** throws the "Google is
       connected, but its client library needs a one-time install … will offer to
       install it" message with the npm command, not `/wienerdog-google-setup`.
-- [ ] `loadGoogleapis` with a token present + a **resolvable-but-unloadable**
-      (corrupt) install throws the "broken (installed but not loadable) — delete the
-      folder `<depsDir>`, then reinstall it" message naming the deps folder and the
-      npm command, with **no** "will offer to install" claim; and the prescribed
-      delete-then-reinstall flow makes the library loadable again (verified with the
-      test seams).
+- [ ] `loadGoogleapis` with a token present + a **present-but-unusable** deps tree
+      (corrupt entry, or missing-main) throws the "broken (installed but not
+      loadable) — delete the folder `<depsDir>`, then reinstall it" message naming the
+      deps folder and the npm command, with **no** "will offer to install" claim; and
+      the prescribed delete-then-reinstall flow makes the library loadable again
+      (verified with the test seams, case a2).
 - [ ] An **unauthed** user (no token) is unaffected: `ensureGoogleReady` is a
       no-op and the existing "no Google sign-in found — run `wienerdog gws auth`
       first" / connect flow is unchanged.
@@ -739,15 +890,24 @@ still pass verbatim; only the NEW in-process case (a4) distinguishes old from ne
       [Y/n]` ACCEPTS (`{ defaultYes: true }` on the production confirm), while a
       non-TTY still aborts and installs nothing (P2-B).
 - [ ] Running a read twice after a successful self-heal is idempotent (second run:
-      `isInstalled` true → no install attempted).
+      `depsPresent` true → `ensureGoogleReady` no-ops, no install attempted).
 - [ ] `resolveFromDeps` uses direct-path construction (no ancestor walk): on a
       machine with an ancestor/global `googleapis`, a consented self-heal in the
       **same process** succeeds — the post-install read loads the deps-dir copy, not
       the cached ancestor (§0; case (a4)). Ancestor-only stays classified absent;
       a symlinked-inside copy pointing outside the deps dir stays rejected.
+- [ ] A **present-but-broken** deps tree (package.json but missing/malformed main)
+      classifies **broken**, not absent: `loadGoogleapis` throws the delete-then-
+      reinstall message (case a5), `ensureGoogleReady` no-ops (case h), and
+      `ensureGoogleapis` fails to the honest remedy instead of `npm`-over-corrupt
+      (case i) — no permanent loop (round-6 P2).
+- [ ] Self-heal chatter never lands on stdout: `ensureGoogleapis`'s notice + prompt
+      go to stderr and npm's output is routed to stderr, so `gws … --json | jq`
+      keeps clean stdout after a consented install (round-6 P1; cases g, j, and the
+      prompt.test.js `opts.output` case).
 - [ ] The existing no-token AND containment (:205–230) assertions in
-      `gws-deps.test.js` are byte-unchanged and still pass. `npm test` and
-      `npm run lint` are green.
+      `gws-deps.test.js` are byte-unchanged and still pass; existing `prompt.test.js`
+      cases are unchanged. `npm test` and `npm run lint` are green.
 
 ## Verification steps (run these; paste output in the PR)
 
@@ -900,3 +1060,30 @@ npm run lint
   same-process `loadGoogleapis` loads the deps copy — FAILS on the old walk, passes
   on the rewrite. Documented the preserved-or-strengthened threat posture and why
   the walk had to go.
+- **2026-07-13 — closing Codex PR pass, round-6 (two findings; deps.js + prompt.js
+  + doctor.js/WP-103).**
+  - **P1 (high user-visibility — stdout hygiene).** The self-heal wrote its notice,
+    consent prompt, and npm output to STDOUT, so a connected user's `gws … --json |
+    jq` got invalid JSON (and, with stdout piped + a TTY stdin, the prompt question
+    was written into the pipe, invisible, while it waited). Routed ALL chatter to
+    stderr: the notice → `process.stderr.write`; npm → `defaultRunInstall` `stdio:
+    ['inherit', 2, 2]`; the prompt → a new backward-compatible `opts.output` on
+    `confirm` (mode-1 output stream, default `process.stdout`) that `ensureGoogleapis`
+    sets to `process.stderr`. Grew Deliverables by `src/core/prompt.js` + its test.
+    `index.js` unchanged. auth's meaningful stdout (the authorization URL) is
+    separate and unchanged.
+  - **P2 (classification gap the §0 rewrite opened).** A tree whose `package.json`
+    exists but is unresolvable (missing/malformed main) made `resolveFromDeps` throw
+    → `isInstalled` false → classified ABSENT → self-heal `npm`-over-corrupt →
+    arborist no-op → permanent loop. Re-keyed the absent/broken split AND the
+    self-heal gate onto **physical presence** (`depsPresent`, the §0 step-1 existence
+    check, now extracted + exported): `loadGoogleapis` sets `present` before any
+    resolve so resolve-throw/require-throw/shape-fail/symlink-out all classify
+    BROKEN; `ensureGoogleReady` gates on `depsPresent` (never install over a present
+    tree); and `ensureGoogleapis` gained a `if (depsPresent(paths)) throw <delete-
+    then-reinstall remedy>` guard so the **auth** path fails honestly instead of
+    `npm`-over-corrupt (owner's no-auto-repair disposition). WP-103's doctor probe
+    swaps its broken-vs-missing key from `isInstalled` to `depsPresent`. New tests:
+    a5 (missing-main → broken), h (ensureGoogleReady no-op on present), i
+    (ensureGoogleapis present-broken throw), j (no stdout on yes-path); a2/a3/a4 and
+    the containment probes stay green.

--- a/docs/specs/WP-102-gws-deps-self-heal.md
+++ b/docs/specs/WP-102-gws-deps-self-heal.md
@@ -1,0 +1,448 @@
+---
+id: WP-102
+title: gws read-path self-heal + disambiguated deps error (fix the post-upgrade dead-end)
+status: Ready
+model: sonnet
+size: S
+depends_on: []
+adrs: [ADR-0004, ADR-0011, ADR-0013]
+branch: wp/102-gws-deps-self-heal
+---
+
+# WP-102: gws read-path self-heal + disambiguated deps error
+
+## Context (read this, nothing else)
+
+**gws** is the `wienerdog gws` Google Workspace CLI (gmail / cal / drive). It is
+read-first and draft-first. To talk to Google it needs Google's heavy
+`googleapis` client library, which Wienerdog does **not** bundle: per ADR-0013,
+the vendored app copy carries no `node_modules`, so `googleapis` is installed
+**on demand, once, with consent** into a per-install deps dir
+`~/.wienerdog/app/deps/` (NOT under `app/<version>/`, so version bumps never
+remove it). This was WP-047. A **containment guard** (`resolveFromDeps` in
+`src/gws/deps.js`) then resolves `googleapis` strictly from inside that deps dir
+and treats any copy resolving outside it as absent — a deliberate supply-chain
+guard. **Keep that guard exactly as-is.**
+
+**The bug this WP fixes (`userreports/BUG-gws-deps-missing-after-upgrade.md`).**
+The library-presence check and the installer live on **different code paths, and
+only `auth` installs**:
+
+- Read commands reach `loadGoogleapis(paths)` (`src/gws/deps.js`), which
+  **throws** a setup error when `googleapis` can't be resolved from the deps dir
+  — it **never installs**.
+- The installer `ensureGoogleapis(paths, opts)` is called from **exactly one
+  place**: `src/gws/auth.js` (during `gws auth`). So the deps dir is only ever
+  populated by running `gws auth`.
+
+Consequence: a user who connected Google **before** the WP-047 deps-dir scheme
+existed (before 2026-07-04) has a **complete, valid token** in
+`~/.wienerdog/secrets/google-token.json` but an **absent** `app/deps`. After they
+`wienerdog update` across that boundary, **every** gws read command fails with:
+
+> `Google isn't set up yet — run /wienerdog-google-setup to connect Gmail, Calendar, and Drive.`
+
+The message is **wrong** (Google *is* connected) and the only remedy that works
+is re-running `gws auth` (a needless OAuth round-trip that reinstalls deps as a
+side effect). Nothing on the read path ever backfills `app/deps`, so the state is
+a **permanent dead-end**. Headless routines (morning digest, inbox triage) hit
+the same misleading error and cannot self-heal (they can't run interactive
+`gws auth`). This must be fixed before the next npm publish.
+
+**This WP does two things** (the report's fixes 1 + 2 + 5):
+
+1. **Self-heal on read.** When a read command finds the deps dir absent **and** a
+   valid token exists, lazily run the same **consented** `ensureGoogleapis`
+   install — exactly like first auth. Interactive: a consent prompt. Headless /
+   non-TTY: fail with the accurate, browser-free `npm install` remedy (no worse
+   than today). An **unauthed** user (no token) is untouched — they still get the
+   existing "connect Google" flow.
+2. **Disambiguate the error.** `loadGoogleapis` (the sole emit site of the
+   misleading string) branches on token presence: no token → the current
+   connect-Google message (unchanged); token present → an accurate "Google is
+   connected, but its client library needs a one-time install" message naming the
+   concrete remedy. This is the defensive backstop for any caller that reaches
+   `loadGoogleapis` without going through the self-heal wrapper.
+
+**Product invariants that bound this WP.** Wienerdog is just files (ADR-0004): the
+self-heal runs `npm install` synchronously and returns; it starts nothing that
+outlives the command. The on-demand install is **consented** (ADR-0011/0013):
+show the exact command, prompt (default yes), fail-to-print on decline. Zero new
+runtime dependencies; plain Node ≥ 18; JSDoc types only (CLAUDE.md).
+
+**Out of scope by explicit decision:** an `update`-time migration/backfill
+(report fix 3). Once self-heal-on-read exists it is redundant, and adding a
+consent/network dependency to the `update` path buys no extra coverage. Recorded
+under "Out of scope" below. The `doctor` probe (report fix 4) is a **separate**
+WP (WP-103) because it touches a different surface (`src/cli/doctor.js`).
+
+## Current state
+
+**`src/gws/deps.js`** — the pieces you extend (verified against main @ d8ef87c):
+
+```js
+const GOOGLEAPIS_SPEC = 'googleapis@^173';
+
+/** <core>/app/deps */
+function depsDir(paths) { return path.join(paths.core, 'app', 'deps'); }
+
+/** Resolve googleapis strictly from within the deps dir (containment-guarded);
+ *  a copy resolving outside the deps dir is treated as absent. Returns
+ *  {req, resolved} | null. DO NOT CHANGE. */
+function resolveFromDeps(paths) { /* ... */ }
+
+/** Whether googleapis resolves from within the deps dir. */
+function isInstalled(paths) {
+  try { return resolveFromDeps(paths) !== null; } catch { return false; }
+}
+
+/** Resolve googleapis from the deps dir; throws a plain setup error when absent.
+ *  THIS is the sole emit site of the misleading "isn't set up yet" string. */
+function loadGoogleapis(paths) {
+  try {
+    const hit = resolveFromDeps(paths);
+    if (hit) return hit.req(hit.resolved);
+  } catch { /* treated as absent */ }
+  throw new WienerdogError(
+    "Google isn't set up yet — run /wienerdog-google-setup to connect Gmail, Calendar, and Drive."
+  );
+}
+
+/** Ensure googleapis is installed in the deps dir, once, with consent (ADR-0011:
+ *  show the exact command, default yes, fail-to-print on decline/failure).
+ *  No-op when already present. Seams: opts.confirm, opts.runInstall, opts.yes.
+ *  On decline: throws `declined — run this yourself, then retry:\n  <cmd>`
+ *  where <cmd> = `npm install --ignore-scripts --prefix <deps> googleapis@^173`.
+ *  On install failure (status !== 0): throws `install failed — run it yourself,
+ *  then retry:\n  <cmd>`. */
+async function ensureGoogleapis(paths, opts = {}) { /* ... */ }
+
+module.exports = {
+  GOOGLEAPIS_SPEC, depsDir, isInstalled, loadGoogleapis, ensureGoogleapis,
+  defaultRunInstall,
+};
+```
+
+`deps.js` already `require`s `node:fs` at the top. It does **not** require
+`./client` at load time (important — see the load-order note below).
+
+**`src/gws/client.js`** — `getServices(paths, opts)` (the read entry) loads the
+token and client JSON **before** googleapis, in this order:
+
+```js
+function getServices(paths, opts = {}) {
+  const token = loadToken(paths);      // throws "no Google sign-in found — run `wienerdog gws auth` first" if absent
+  const client = loadClientJson(paths);
+  if (opts.factory) return opts.factory(token);   // unit-test seam
+  const { google } = opts.googleapis || loadGoogleapis(paths);  // throws the misleading msg in case B
+  // ... builds gmail/calendar/drive ...
+}
+```
+
+`tokenPath(paths)` in `client.js` returns
+`path.join(paths.secrets, 'google-token.json')` — the canonical token path.
+Because `getServices` calls `loadToken` **first**, on the read path
+`loadGoogleapis` is only ever reached when a **token already exists** — i.e.
+`loadGoogleapis`'s failure on the read path is **always** the token-present case
+(B). That is precisely why its unconditional message is wrong there.
+
+**`src/gws/index.js`** — `run(argv)` dispatches `<group> <verb>`. It builds a
+`key` (`'auth'`, `'gmail search'`, `'cal'`, `'drive'`, `'_alert'`, …), looks up a
+handler, then builds a **lazy** services accessor so `auth` (which needs no
+token) never loads one:
+
+```js
+async function run(argv) {
+  const group = argv[0];
+  let key; let rest;
+  if (group === 'gmail') { key = `gmail ${argv[1]}`; rest = argv.slice(2); }
+  else { key = group; rest = argv.slice(1); }
+
+  const handler = DISPATCH[key];
+  if (!handler) throw new WienerdogError(`unknown gws command: ${argv.slice(0, 2).join(' ').trim()}`);
+
+  const flags = parseFlags(rest);
+  const paths = getPaths();
+  // Build services lazily so `auth` (which needs no token) never loads one.
+  let cached;
+  const services = () => (cached || (cached = getServices(paths)));
+
+  const result = await handler({ paths, flags, services });
+  render(key, result, flags.json);
+}
+```
+
+Every non-`auth` handler (`gmail *`, `cal`, `drive`, `_alert`) calls `services()`
+and thus needs `googleapis`; only `auth` does not. `run` is already `async`.
+
+**`tests/unit/gws-deps.test.js`** already has the fixtures you reuse:
+`tempPaths()` (fresh isolated temp core, no `app/deps`), `fakeInstall(dir)`
+(plants a fake `<dir>/node_modules/googleapis` and returns `{status:0}` — a
+stand-in for the real `npm install`), `plantGoogleapis(base, which)`. The
+existing tests at lines ~101–110 (loadGoogleapis throws the setup error when
+absent) and ~205–230 (containment-guard child-process probes) are **no-token**
+cases — see "Do NOT modify these" below.
+
+## Deliverables (permission boundary — touch ONLY these)
+
+<!-- Always allowed without listing: this spec file, docs/specs/ROADMAP.md, package-lock.json. -->
+
+| Action | Path | Notes |
+|--------|------|-------|
+| modify | src/gws/deps.js | (a) make `loadGoogleapis` token-aware per the Exact contract; (b) add + export `ensureGoogleReady(paths, opts)`; (c) add an internal `hasToken(paths)` helper (lazy `require('./client')`). |
+| modify | src/gws/index.js | import `ensureGoogleReady` from `./deps`; call `await ensureGoogleReady(paths)` for every non-`auth` command, before services are built. |
+| modify | tests/unit/gws-deps.test.js | add a `plantToken(paths)` helper + the six new cases below. Do NOT modify the existing no-token assertions. |
+
+### Exact contracts
+
+**1. `hasToken(paths)` — new internal helper in `deps.js`.** Lazy-require
+`./client` to avoid a load-time cycle (`client.js` requires `deps.js` at top
+level; `deps.js` must NOT top-level-require `client.js`). At call time both
+modules are fully loaded, so a lazy require inside the function body is safe.
+
+```js
+/**
+ * Whether a Google sign-in token exists on disk. Lazy require avoids a
+ * load-time cycle with client.js (which requires this module at top level).
+ * @param {WienerdogPaths} paths
+ * @returns {boolean}
+ */
+function hasToken(paths) {
+  const { tokenPath } = require('./client');
+  return fs.existsSync(tokenPath(paths));
+}
+```
+
+**2. `loadGoogleapis(paths)` — branch on token presence.** Keep the resolve
+attempt and the no-token message byte-for-byte; add the token-present branch:
+
+```js
+function loadGoogleapis(paths) {
+  try {
+    const hit = resolveFromDeps(paths);
+    if (hit) return hit.req(hit.resolved);
+  } catch {
+    /* treated as absent */
+  }
+  // Disambiguate the two states that share this failure (BUG-gws-deps-missing):
+  // a CONNECTED account (token present) needs only the client library, NOT a
+  // reconnect; an unauthed user needs the full connect flow.
+  if (hasToken(paths)) {
+    const cmd = `npm install --ignore-scripts --prefix ${depsDir(paths)} ${GOOGLEAPIS_SPEC}`;
+    throw new WienerdogError(
+      'Google is connected, but its client library needs a one-time install. ' +
+        'Run `wienerdog gws auth` to finish setup (no browser needed if your sign-in is still valid), or run:\n  ' +
+        cmd
+    );
+  }
+  throw new WienerdogError(
+    "Google isn't set up yet — run /wienerdog-google-setup to connect Gmail, Calendar, and Drive."
+  );
+}
+```
+
+The token-present message MUST contain the literal substring `Google is
+connected, but its client library needs a one-time install` AND the exact
+`npm install --ignore-scripts --prefix <deps> googleapis@^173` command, and MUST
+NOT contain `/wienerdog-google-setup`. The no-token branch is unchanged.
+
+**3. `ensureGoogleReady(paths, opts)` — new, exported.** The read-path self-heal.
+
+```js
+/**
+ * Self-heal the on-demand googleapis install on the READ path. When a Google
+ * sign-in token exists but the client library is absent (the post-WP-047-upgrade
+ * dead-end, BUG-gws-deps-missing), install it once — with consent, exactly like
+ * first auth (ADR-0011/ADR-0013). No-op when already installed, or when no token
+ * exists (an unauthed user; getServices()'s loadToken then surfaces the
+ * connect-Google flow unchanged). Consent seams pass straight through to
+ * ensureGoogleapis: interactive → a [Y/n] prompt; non-TTY/headless →
+ * ensureGoogleapis throws the accurate, browser-free npm-install remedy.
+ * @param {WienerdogPaths} paths
+ * @param {{yes?:boolean, confirm?:(q:string)=>Promise<boolean>,
+ *          runInstall?:(dir:string,spec:string)=>{status:number}}} [opts]
+ * @returns {Promise<void>}
+ */
+async function ensureGoogleReady(paths, opts = {}) {
+  if (isInstalled(paths)) return;   // already present — nothing to do
+  if (!hasToken(paths)) return;     // unauthed — do not install; let loadToken surface the connect flow
+  await ensureGoogleapis(paths, opts);
+}
+```
+
+Add `ensureGoogleReady` to `module.exports` (keep the existing exports).
+
+**4. `src/gws/index.js` wiring.** Add the import near the existing requires:
+
+```js
+const { ensureGoogleReady } = require('./deps');
+```
+
+In `run`, immediately **after** `const paths = getPaths();` (after the
+handler-exists check, before the `services` accessor), add:
+
+```js
+  // Self-heal the on-demand googleapis install (BUG-gws-deps-missing): a user who
+  // connected Google before WP-047's deps-dir scheme has a valid token but no
+  // app/deps, so every read dead-ends. Install it once, with consent, on first
+  // read — never for `auth` (it installs deps itself), and a no-op for unauthed
+  // users (getServices then surfaces the connect-Google flow). WP-102.
+  if (key !== 'auth') await ensureGoogleReady(paths);
+```
+
+Pass **no** `opts` — production defaults apply (`ensureGoogleapis` falls back to
+the real `confirm` from `src/core/prompt.js` and the real npm installer, exactly
+as `auth.js` already wires it). The self-heal **logic** is unit-tested directly
+against `ensureGoogleReady` (§5); the index wiring is this thin call.
+
+`key !== 'auth'` is the exact gate: `auth` is the only gws command that does not
+build services. If a future gws verb is added that needs no services, it must be
+excluded from this gate too (note it then).
+
+**5. Tests (`tests/unit/gws-deps.test.js`).** Add a helper and six cases. Reuse
+the existing `tempPaths()`, `fakeInstall`, `WienerdogError`, `path`, `fs`.
+
+```js
+/** Write a valid-looking Google token so hasToken()/self-heal see a connected core. */
+function plantToken(paths) {
+  fs.mkdirSync(paths.secrets, { recursive: true });
+  fs.writeFileSync(
+    path.join(paths.secrets, 'google-token.json'),
+    JSON.stringify({ access_token: 'a', refresh_token: 'r' })
+  );
+}
+```
+
+- **(a) loadGoogleapis — token present + deps absent → the "client library"
+  message.** `plantToken(paths)` on a fresh `tempPaths()`; assert `loadGoogleapis`
+  throws a `WienerdogError` whose message matches `/Google is connected, but its
+  client library needs a one-time install/`, **includes** `npm install
+  --ignore-scripts --prefix ${deps.depsDir(paths)} ${deps.GOOGLEAPIS_SPEC}`, does
+  **not** match `/\/wienerdog-google-setup/`, and does **not** match
+  `/MODULE_NOT_FOUND/`.
+- **(b) ensureGoogleReady — token present + deps absent + consent-yes →
+  installs.** `plantToken`; `await ensureGoogleReady(paths, {confirm: async () =>
+  true, runInstall: (dir, spec) => fakeInstall(dir, spec)})`; assert the injected
+  `runInstall` ran (spy a boolean) and `deps.isInstalled(paths) === true`
+  afterward.
+- **(c) ensureGoogleReady — token present + deps absent + consent-no → throws the
+  npm command, no install.** `plantToken`; call `ensureGoogleReady(paths, ...)`
+  with `confirm: async () => false` and a spying `runInstall` (sets `ran = true`).
+  Assert via `assert.rejects` that it throws a `WienerdogError` whose message
+  includes the exact `npm install --ignore-scripts --prefix <depsDir>
+  googleapis@^173` command (build the expectation from `deps.depsDir(paths)` and
+  `deps.GOOGLEAPIS_SPEC`); then assert `ran === false` and
+  `deps.isInstalled(paths) === false`. (This is the headless-equivalent: the real
+  `confirm` returns false on a non-TTY, so the same throw fires.)
+- **(d) ensureGoogleReady — NO token → no-op (unauthed path unchanged).** No
+  `plantToken`. `const res = await ensureGoogleReady(paths, {confirm: async () =>
+  true, runInstall: () => {ran = true; return {status:0};}})`. Assert `res ===
+  undefined`, `ran === false` (the consent seam was never consulted), and
+  `deps.isInstalled(paths) === false`.
+- **(e) ensureGoogleReady — already installed → no-op.** `plantToken` **and**
+  `fakeInstall(deps.depsDir(paths))`; `await ensureGoogleReady(paths, {confirm:
+  async () => true, runInstall: () => {ran = true; return {status:0};}})`; assert
+  `ran === false` (installer must not run when already present).
+- **(f) ensureGoogleReady with opts.yes — token present + deps absent → installs
+  without prompting.** `plantToken`; `await ensureGoogleReady(paths, {yes: true,
+  confirm: async () => {asked = true; return false;}, runInstall: fakeInstall})`;
+  assert `asked === false` and `deps.isInstalled(paths) === true`.
+
+### Do NOT modify these existing tests (answer to the report's fix-5 question)
+
+The existing assertions at `tests/unit/gws-deps.test.js` ~lines **101–110**
+(`loadGoogleapis` throws the setup error when absent) and ~lines **205–230** (the
+containment-guard child-process probes) are all **no-token** cases. With this WP,
+the no-token branch of `loadGoogleapis` still emits the identical
+`/wienerdog-google-setup` message, so those tests remain valid and **must stay
+unchanged**. Do not touch them.
+
+## Implementation notes & constraints
+
+- **Zero new dependencies.** No new require beyond the lazy `require('./client')`
+  inside `hasToken`. `node:fs` is already required in `deps.js`.
+- **Load-order / cycle safety.** `client.js` top-level-requires `deps.js`;
+  `deps.js` must reference `./client` **only** lazily (inside `hasToken`, at call
+  time). Do not add a top-level `require('./client')` to `deps.js` — it would
+  create a load-time cycle and `tokenPath` could be `undefined`.
+- **Keep the containment guard (`resolveFromDeps`) unchanged** — it is a
+  deliberate supply-chain control locked by the existing tests. Self-heal
+  populates the deps dir *through* the guard's install path; it never bypasses
+  the guard.
+- **`_alert` is included in the self-heal gate** (`key !== 'auth'` covers it).
+  `_alert` is internal and headless-only in practice: with deps absent it fails
+  today too (via `loadGoogleapis`), and run-job's fail-loud already falls back to
+  `state/alerts.jsonl` (ADR-0012). Self-heal here is no worse — on a non-TTY it
+  aborts to the accurate npm remedy without attempting an install. This is an
+  accepted, deliberate behavior; do not add special-casing for it.
+- **Headless framing.** On a non-TTY, `ensureGoogleapis` (via the shared
+  `confirm`) prints the no-terminal notice and throws the `declined — run this
+  yourself, then retry:\n  <npm cmd>` message. That message is accurate and
+  browser-free — strictly better than today's misleading "isn't set up yet". The
+  fix-2 "Google is connected, but…" wording is delivered by `loadGoogleapis` for
+  any caller that reaches it directly (the defensive backstop); the two messages
+  are consistent (both name the connected-account remedy).
+- When uncertain: choose the simpler option and record it under "Decisions made".
+  Do NOT expand scope (no update-time backfill — see Out of scope; no keyring; no
+  changes to token/client persistence, scopes, or the containment guard).
+
+## Security checklist
+
+- [ ] No untrusted input flows into a path or shell command. `hasToken` builds
+      the token path via `client.tokenPath(paths)` (env-derived core, already
+      trusted) and only `fs.existsSync`es it. The self-heal install command is the
+      pre-existing, pinned `ensureGoogleapis` command (`--ignore-scripts`,
+      constant `GOOGLEAPIS_SPEC`) — no user value is interpolated into it.
+- [ ] Consent is preserved (ADR-0011): the self-heal install still shows the
+      exact command and prompts (default yes); a decline or a non-TTY fails to a
+      printed remedy and installs nothing.
+- [ ] No process outlives the command (ADR-0004): `ensureGoogleapis` runs
+      `npm install` synchronously and returns.
+
+## Acceptance criteria
+
+- [ ] A read command run interactively with a valid token but no `app/deps`
+      prompts to install `googleapis` and, on consent, succeeds using the existing
+      token — no re-auth, no browser (self-heal).
+- [ ] The same on a non-TTY fails with the accurate npm-install remedy (naming the
+      exact command), never the misleading "isn't set up yet".
+- [ ] `loadGoogleapis` with a token present + deps absent throws the "Google is
+      connected, but its client library needs a one-time install" message with the
+      npm command, not `/wienerdog-google-setup`.
+- [ ] An **unauthed** user (no token) is unaffected: `ensureGoogleReady` is a
+      no-op and the existing "no Google sign-in found — run `wienerdog gws auth`
+      first" / connect flow is unchanged.
+- [ ] `ensureGoogleReady` is a no-op when `googleapis` is already installed.
+- [ ] Running a read twice after a successful self-heal is idempotent (second run:
+      `isInstalled` true → no install attempted).
+- [ ] The existing no-token assertions in `gws-deps.test.js` are unchanged and
+      still pass. `npm test` and `npm run lint` are green.
+
+## Verification steps (run these; paste output in the PR)
+
+```bash
+npm test -- --test-name-pattern "gws-deps|ensureGoogleReady|loadGoogleapis|dispatch"
+npm test
+npm run lint
+```
+
+## Out of scope (do NOT do these)
+
+- **Update-time migration/backfill (report fix 3) — deliberately skipped.** Once
+  self-heal-on-read exists, an install during `wienerdog update` adds a
+  consent/network dependency to the update path for **no extra coverage** (the
+  first read heals it anyway). Do not add any `app/deps` creation to
+  `src/cli/update.js` or `src/core/vendor.js`.
+- **The `doctor` probe (report fix 4)** — that is **WP-103**
+  (`src/cli/doctor.js` plus its test), a separate surface.
+- Any change to the containment guard `resolveFromDeps`, to `GOOGLEAPIS_SPEC`, or
+  to token/client persistence, scopes, or the OAuth flow.
+- The `gws drive search` bare-term query papercut — separate backlog WP-104.
+
+## Definition of done
+
+1. All verification steps pass locally; output pasted into the PR body.
+2. Branch `wp/102-gws-deps-self-heal`; conventional commits; PR titled
+   `fix(gws): self-heal googleapis on read + disambiguate the deps error (WP-102)`.
+3. PR template filled, including "Decisions made" (or "none") and `Generated-by:`.
+4. This spec's `status:` flipped to `In-Review` in the same PR.

--- a/docs/specs/WP-103-doctor-gws-deps-probe.md
+++ b/docs/specs/WP-103-doctor-gws-deps-probe.md
@@ -161,7 +161,9 @@ function googleReadinessChecks(paths) {
   //                        (WP-102's isInstalled gate is true), so promising an
   //                        offer would be false — require a manual reinstall.
   const dir = deps.depsDir(paths);
-  const cmd = `npm install --ignore-scripts --prefix ${dir} ${deps.GOOGLEAPIS_SPEC}`;
+  // Quote the prefix (P2-A): a home path with spaces would split the argument when
+  // the user pastes the command. Double quotes work in POSIX shells, cmd, PowerShell.
+  const cmd = `npm install --ignore-scripts --prefix "${dir}" ${deps.GOOGLEAPIS_SPEC}`;
   if (deps.isInstalled(paths)) {
     // Round-4 Finding — a bare `npm install` can NO-OP over a corrupt-but-
     // resolvable tree (npm compares tree metadata, not file contents), so the
@@ -400,3 +402,10 @@ npm run lint
   prose in parity with WP-102's `loadGoogleapis` broken message. The
   `plantCorruptDeps` case now asserts the `delete the folder …` wording. Absent-state
   message, token validation, and load probe unchanged.
+- **2026-07-13 — PR-gate review (Codex PR review; P2-A, WP-102 + WP-103 mirror).**
+  The npm command in both warn messages interpolated the deps dir **unquoted**
+  (`--prefix ${dir}`), so a home path with spaces splits the argument when pasted.
+  Quoted the prefix in the helper's `cmd` template (`--prefix "${dir}"`), matching
+  WP-102. Existing test assertions are unaffected (they pin the message text and the
+  `delete the folder <path>` fragment, not the `--prefix` portion); no test change
+  required here.

--- a/docs/specs/WP-103-doctor-gws-deps-probe.md
+++ b/docs/specs/WP-103-doctor-gws-deps-probe.md
@@ -160,14 +160,18 @@ function googleReadinessChecks(paths) {
   //   isInstalled true  → BROKEN (resolves but won't load): self-heal NO-OPs
   //                        (WP-102's isInstalled gate is true), so promising an
   //                        offer would be false — require a manual reinstall.
-  // Same npm command repairs both (install over the corrupt dir overwrites it).
-  const cmd = `npm install --ignore-scripts --prefix ${deps.depsDir(paths)} ${deps.GOOGLEAPIS_SPEC}`;
+  const dir = deps.depsDir(paths);
+  const cmd = `npm install --ignore-scripts --prefix ${dir} ${deps.GOOGLEAPIS_SPEC}`;
   if (deps.isInstalled(paths)) {
+    // Round-4 Finding — a bare `npm install` can NO-OP over a corrupt-but-
+    // resolvable tree (npm compares tree metadata, not file contents), so the
+    // corrupt tree must be DELETED first. Deps dir is single-purpose → safe to
+    // remove wholesale. Platform-neutral prose (parity with WP-102).
     return [
       {
         status: 'warn',
         msg:
-          'Google is connected but its client library is broken (installed but not loadable) — reinstall it: ' + cmd,
+          `Google is connected but its client library is broken (installed but not loadable) — delete the folder ${dir}, then reinstall it: ` + cmd,
       },
     ];
   }
@@ -187,11 +191,13 @@ token read. Both warn branches drop the `wienerdog gws auth` suggestion (Codex
 Finding 3). Two distinct messages (round-2 Finding 2): the **absent** message
 keeps the self-heal promise + npm command; the **broken** (resolvable-but-
 un-loadable) message must NOT claim the next-command offer — WP-102's self-heal
-no-ops on a resolvable install — and points only to the npm reinstall (the same
-command repairs it). Consistent with WP-102's `loadGoogleapis` message, whose
-single string is an error (not a status) and always carries the npm one-liner. The
-`npm install` one-liner is the universal remedy
-for both.
+no-ops on a resolvable install — and prescribes **delete-the-folder-then-reinstall**
+(round-4 Finding: a bare `npm install` can no-op over a corrupt-but-resolvable
+tree). Same **delete-then-reinstall** remedy as WP-102's `loadGoogleapis` broken
+message (worded for the single-line doctor warn — no newline; WP-102's is a thrown
+error), so the two surfaces prescribe an identical repair. The `npm install`
+one-liner is the remedy the delete precedes for the broken state, and the direct
+remedy for the absent state.
 
 **2. Wire into `run`.** Immediately **after** the `codexSkillChecks` loop and
 **before** the update-notice block, add:
@@ -258,13 +264,15 @@ function plantDamagedToken(core, content) {
   `/\[warn\] Google is connected but its client library is missing — the next .?wienerdog gws.? command will offer to install it/`,
   does **not** match `/gws auth/` (Finding 3), and `r.status === 0` (warn, not fail).
 - **Connected + library BROKEN (resolvable but throws on load) → `[warn]`
-  "broken", exit 0 (Finding 1a + round-2 Finding 2).** `init`; `plantToken(core)`;
-  `plantCorruptDeps(core)`; `doctor`. Assert `r.stdout` matches `/\[warn\] Google
-  is connected but its client library is broken \(installed but not loadable\)/`,
-  **does NOT match** `/will offer to install/` (the broken state does not
-  self-heal — round-2 Finding 2), does **not** match `/\[ok\] Google connected/`,
-  and `r.status === 0`. (This is the case a resolve-only check would falsely pass,
-  and the case whose remedy must not promise the next-command offer.)
+  "broken" with the delete-then-reinstall remedy, exit 0 (Finding 1a + round-2
+  Finding 2 + round-4 Finding).** `init`; `plantToken(core)`; `plantCorruptDeps(core)`;
+  `doctor`. Assert `r.stdout` matches `/\[warn\] Google is connected but its client
+  library is broken \(installed but not loadable\) — delete the folder /`, contains
+  the `<core>/app/deps` path, **does NOT match** `/will offer to install/` (the
+  broken state does not self-heal — round-2 Finding 2), does **not** match `/\[ok\]
+  Google connected/`, and `r.status === 0`. (This is the case a resolve-only check
+  would falsely pass; its remedy must delete the tree first, since a bare `npm
+  install` can no-op over it — round-4 Finding.)
 - **Connected + library present and loadable → `[ok]`.** `init`;
   `plantToken(core)`; `plantDeps(core)`; `doctor`. Assert `r.stdout` matches
   `/\[ok\] Google connected and its client library is installed/` and
@@ -313,8 +321,10 @@ it to the plant helpers. Read the helper at the top of the file.)
       gws\` command will offer to install it …` line and exits 0.
 - [ ] When Google is connected but `googleapis` is **resolvable-but-un-loadable**
       (corrupt), `doctor` prints one `[warn] … client library is broken (installed
-      but not loadable) — reinstall it: <npm>` line that does **NOT** claim the
-      next-command offer, and exits 0. Neither warn suggests `gws auth`.
+      but not loadable) — delete the folder <depsDir>, then reinstall it: <npm>`
+      line (naming the deps folder, delete-first because a bare `npm install` can
+      no-op over a corrupt tree) that does **NOT** claim the next-command offer, and
+      exits 0. Neither warn suggests `gws auth`.
 - [ ] When the token file is present but damaged (zero-byte / malformed JSON /
       missing / wrong-type / whitespace-only `refresh_token`), `doctor` prints one
       `[warn] Google sign-in file looks damaged …` line and never `[ok]`; exit 0.
@@ -382,3 +392,11 @@ npm run lint
     so `{"refresh_token":true}` or a whitespace value passed → possible false
     `[ok]`. Tightened to `typeof … === 'string' && .trim() !== ''`; added
     wrong-type and whitespace-only damaged-token fixtures.
+- **2026-07-13 — Codex round-4 review (WP-102 + WP-103 mirror).** The broken-state
+  remedy `npm install --prefix <deps> …` can **no-op** on a corrupt install (npm
+  compares tree metadata, not file contents), leaving the user looping. The broken
+  warn now prescribes **delete the folder `<depsDir>`, then reinstall it: <npm>**
+  (the deps dir is single-purpose → safe to remove wholesale), platform-neutral
+  prose in parity with WP-102's `loadGoogleapis` broken message. The
+  `plantCorruptDeps` case now asserts the `delete the folder …` wording. Absent-state
+  message, token validation, and load probe unchanged.

--- a/docs/specs/WP-103-doctor-gws-deps-probe.md
+++ b/docs/specs/WP-103-doctor-gws-deps-probe.md
@@ -42,9 +42,9 @@ its tests; it changes no adapter, no `sync`, no `gws` code, no manifest.
 outlives its job (ADR-0004). This WP only reads the filesystem and prints lines.
 
 **Dependency on WP-102.** WP-103 depends on WP-102 for **coherence of the remedy
-wording**, not for code: the warn line tells the user the next `gws` read will
+wording**, not for code: the warn line tells the user the next `gws` command will
 offer to install the library (WP-102's self-heal), so WP-102 must land first for
-that sentence to be true. The APIs this probe calls (`deps.isInstalled`,
+that sentence to be true. The APIs this probe calls (`deps.loadGoogleapis`,
 `deps.depsDir`, `deps.GOOGLEAPIS_SPEC`, `client.tokenPath`) all exist on main
 today.
 
@@ -76,12 +76,19 @@ if (failed) process.exitCode = 1;
 lazily inside `run` already exists (`require('../scheduler/status')`).
 
 **gws helpers this probe uses (all exported on main today):**
-- `require('../gws/deps').isInstalled(paths)` → `boolean` — whether `googleapis`
-  resolves from inside `<core>/app/deps` (containment-guarded).
-- `require('../gws/deps').depsDir(paths)` → `<core>/app/deps`.
-- `require('../gws/deps').GOOGLEAPIS_SPEC` → `'googleapis@^173'`.
+- `require('../gws/deps').loadGoogleapis(paths)` → the loaded `googleapis` module,
+  or **throws** a `WienerdogError`. It resolves via the containment guard AND
+  `require`s the module inside its own `try/catch`, so it is a full **LOAD** probe
+  — a corrupt/partial install that resolves but fails to `require` throws here.
+  Use this (in a `try/catch`), **not** `isInstalled` (which only resolves), so the
+  probe warns on a corrupt-but-resolvable install instead of falsely reading
+  `[ok]` (Codex Finding 1a).
+- `require('../gws/deps').depsDir(paths)` → `<core>/app/deps` (for the remedy).
+- `require('../gws/deps').GOOGLEAPIS_SPEC` → `'googleapis@^173'` (for the remedy).
 - `require('../gws/client').tokenPath(paths)` → `path.join(paths.secrets,
-  'google-token.json')` — the canonical token path.
+  'google-token.json')` — the canonical token path. The probe reads + JSON-parses
+  it (read-only) and requires a `refresh_token`, so a zero-byte/malformed/
+  incomplete token warns as "damaged" and never reads `[ok]` (Codex Finding 4).
 
 **`tests/unit/doctor.test.js`** drives `doctor` as a subprocess
 (`node bin/wienerdog.js doctor`) against an isolated temp `HOME`/`WIENERDOG_HOME`
@@ -110,15 +117,35 @@ pattern), so `doctor` doesn't load gws for a run that never reaches this check.
 
 ```js
 /** Report Google client-library readiness for a CONNECTED account. Read-only;
- *  never fails (a missing library is actionable, so a WARN). Emits NOTHING when
- *  Google is not connected (no token) — the normal state. WP-103 / BUG-gws-deps-missing.
+ *  never fails (WARN, not fail). Emits NOTHING when Google is not connected (no
+ *  token). A damaged token warns separately (never [ok]). Uses a containment-
+ *  guarded LOAD probe (not just resolve) so a corrupt/partial install warns.
+ *  WP-103 / BUG-gws-deps-missing.
  *  @param {import('../core/paths').WienerdogPaths} paths
  *  @returns {{status:'ok'|'warn', msg:string}[]} */
 function googleReadinessChecks(paths) {
   const { tokenPath } = require('../gws/client');
   const deps = require('../gws/deps');
-  if (!fileExists(tokenPath(paths))) return []; // Google not connected — nothing to check (normal)
-  if (deps.isInstalled(paths)) {
+  const tp = tokenPath(paths);
+  if (!fileExists(tp)) return []; // Google not connected — nothing to check (normal)
+
+  // Finding 4 — minimal, read-only token validation: a zero-byte / malformed /
+  // incomplete token must never read as a healthy [ok]. Require valid JSON with a
+  // refresh_token; anything else is a separate "damaged" warn.
+  let token = null;
+  try { token = JSON.parse(fs.readFileSync(tp, 'utf8')); } catch { token = null; }
+  if (!token || typeof token !== 'object' || !token.refresh_token) {
+    return [{ status: 'warn', msg: 'Google sign-in file looks damaged — reconnect with /wienerdog-google-setup' }];
+  }
+
+  // Finding 1(a) — containment-guarded LOAD probe: actually require the resolved
+  // module so a resolvable-but-unloadable (corrupt/partial) install warns instead
+  // of falsely reading [ok]. loadGoogleapis resolves via the containment guard
+  // AND requires the module inside its try/catch, so a broken entry point throws a
+  // WienerdogError we catch here. doctor runs rarely, so the load cost is fine.
+  let usable = false;
+  try { deps.loadGoogleapis(paths); usable = true; } catch { usable = false; }
+  if (usable) {
     return [{ status: 'ok', msg: 'Google connected and its client library is installed' }];
   }
   const cmd = `npm install --ignore-scripts --prefix ${deps.depsDir(paths)} ${deps.GOOGLEAPIS_SPEC}`;
@@ -126,16 +153,21 @@ function googleReadinessChecks(paths) {
     {
       status: 'warn',
       msg:
-        'Google is connected but its client library is missing — the next `wienerdog gws` ' +
-        'command will offer to install it, or run `wienerdog gws auth`, or: ' + cmd,
+        'Google is connected but its client library is missing or broken — the next `wienerdog gws` ' +
+        'command will offer to install it, or run: ' + cmd,
     },
   ];
 }
 ```
 
-Use the file's existing `fileExists(p)` helper (already defined in `doctor.js`)
-for the token check. Return **one** line (not one per state); keep `doctor`
-output compact and consistent with the scheduler/Codex checks.
+Use the file's existing `fileExists(p)` helper and its top-level `fs` for the
+token read. Return **one** line (not one per state); keep `doctor` output compact.
+The warn message drops the `wienerdog gws auth` suggestion (Codex Finding 3 —
+`gws auth` cannot fix this without re-opening browser consent), and stays worded
+consistently with WP-102's `loadGoogleapis` message. It says "missing **or
+broken**" because the LOAD probe warns on both the absent and the
+corrupt-but-resolvable case; the `npm install` one-liner is the universal remedy
+for both.
 
 **2. Wire into `run`.** Immediately **after** the `codexSkillChecks` loop and
 **before** the update-notice block, add:
@@ -146,13 +178,13 @@ for (const c of googleReadinessChecks(paths)) check(c.status, c.msg);
 
 `paths` is already in scope. No other change to `run`.
 
-**3. Tests (`tests/unit/doctor.test.js`).** Add a small plant helper and three
-cases using the existing `run`/`tempEnv` helpers. Plant a token by writing
-`<core>/secrets/google-token.json`; plant the library the same way
-`gws-deps.test.js` does:
+**3. Tests (`tests/unit/doctor.test.js`).** Add the plant helpers and the cases
+below using the existing `run`/`tempEnv` helpers. Plant a token by writing
+`<core>/secrets/google-token.json`; plant the library under `<core>/app/deps`
+(the containment-guarded location — do NOT plant it elsewhere):
 
 ```js
-/** Plant a fake googleapis under <core>/app/deps so isInstalled() is true (no network). */
+/** Plant a WORKING fake googleapis under <core>/app/deps (resolves AND loads). */
 function plantDeps(core) {
   const pkgDir = path.join(core, 'app', 'deps', 'node_modules', 'googleapis');
   fs.mkdirSync(pkgDir, { recursive: true });
@@ -160,41 +192,69 @@ function plantDeps(core) {
     JSON.stringify({ name: 'googleapis', version: '173.0.0', main: 'index.js' }));
   fs.writeFileSync(path.join(pkgDir, 'index.js'), 'module.exports = { google: {} };\n');
 }
-/** Plant a valid-looking token so the core reads as "connected". */
+/** Plant a CORRUPT fake googleapis: resolves fine, but its entry point throws on require. */
+function plantCorruptDeps(core) {
+  const pkgDir = path.join(core, 'app', 'deps', 'node_modules', 'googleapis');
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(path.join(pkgDir, 'package.json'),
+    JSON.stringify({ name: 'googleapis', version: '173.0.0', main: 'index.js' }));
+  fs.writeFileSync(path.join(pkgDir, 'index.js'), "throw new Error('corrupt googleapis entry point');\n");
+}
+/** Plant a VALID token (JSON + refresh_token) so the core reads as "connected". */
 function plantToken(core) {
   const secrets = path.join(core, 'secrets');
   fs.mkdirSync(secrets, { recursive: true });
   fs.writeFileSync(path.join(secrets, 'google-token.json'),
     JSON.stringify({ access_token: 'a', refresh_token: 'r' }));
 }
+/** Plant a DAMAGED token file (malformed / missing refresh_token). */
+function plantDamagedToken(core, content) {
+  const secrets = path.join(core, 'secrets');
+  fs.mkdirSync(secrets, { recursive: true });
+  fs.writeFileSync(path.join(secrets, 'google-token.json'), content);
+}
 ```
 
 - **Google not connected → no Google-readiness line.** Default `tempEnv()`;
-  `run(['init','--yes'], env)` then `run(['doctor'], env)`. Assert
-  `r.stdout` does **not** match `/Google connected|Google is connected but/` and
-  `r.status === 0`.
+  `run(['init','--yes'], env)` then `run(['doctor'], env)`. Assert `r.stdout` does
+  **not** match `/Google connected|Google is connected but|Google sign-in file/`
+  and `r.status === 0`.
+- **Damaged token → `[warn]` "looks damaged", never `[ok]` (Finding 4).** `init`;
+  `plantDamagedToken(core, 'not json')`; `doctor`. Assert `r.stdout` matches
+  `/\[warn\] Google sign-in file looks damaged/`, does **not** match
+  `/\[ok\] Google connected/`, and `r.status === 0`. Add a second variant with a
+  well-formed but incomplete token: `plantDamagedToken(core,
+  JSON.stringify({access_token:'a'}))` (no `refresh_token`) → same `[warn]`.
 - **Connected + library missing → `[warn]`, exit 0.** `init`; `plantToken(core)`
-  (no `plantDeps`); `doctor`. Assert `r.stdout` matches `/\[warn\] Google is
-  connected but its client library is missing/` and `r.status === 0` (warn, not
-  fail).
-- **Connected + library present → `[ok]`.** `init`; `plantToken(core)`;
-  `plantDeps(core)`; `doctor`. Assert `r.stdout` matches `/\[ok\] Google connected
-  and its client library is installed/` and `r.status === 0`.
+  (no deps planted); `doctor`. Assert `r.stdout` matches `/\[warn\] Google is
+  connected but its client library is missing or broken/`, does **not** match
+  `/gws auth/` (Finding 3), and `r.status === 0` (warn, not fail).
+- **Connected + library corrupt (resolvable but throws on load) → `[warn]`, exit 0
+  (Finding 1a).** `init`; `plantToken(core)`; `plantCorruptDeps(core)`; `doctor`.
+  Assert `r.stdout` matches `/\[warn\] Google is connected but its client library
+  is missing or broken/`, does **not** match `/\[ok\] Google connected/`, and
+  `r.status === 0`. (This is the case a resolve-only check would falsely pass.)
+- **Connected + library present and loadable → `[ok]`.** `init`;
+  `plantToken(core)`; `plantDeps(core)`; `doctor`. Assert `r.stdout` matches
+  `/\[ok\] Google connected and its client library is installed/` and
+  `r.status === 0`.
 
 (Whichever of `tempEnv`'s return fields exposes the core dir — e.g. `core` — pass
-it to `plantToken`/`plantDeps`. Read the helper at the top of the file.)
+it to the plant helpers. Read the helper at the top of the file.)
 
 ## Implementation notes & constraints
 
 - **Read-only, warn-not-fail.** `doctor` must never create, install, or repair
-  anything. A missing library is a `warn`; the printed remedies are the WP-102
-  self-heal (next `gws` command), `wienerdog gws auth`, or the exact npm command.
+  anything. A missing/broken library is a `warn`; the printed remedies are the
+  WP-102 self-heal (the next `gws` command) and the exact npm one-liner. Do **not**
+  print a `wienerdog gws auth` suggestion (Codex Finding 3 — it cannot fix this
+  without re-opening browser consent).
 - **Silent when unconnected.** Drive the check off token presence: no token →
   empty array → no line. This keeps `doctor` clean for the majority of users.
-- **The `isInstalled` probe respects the containment guard** — it returns true
-  only when `googleapis` resolves from **inside** `<core>/app/deps` (WP-047), so a
-  stray `googleapis` elsewhere on the machine does not read as installed. The
-  planted-under-`app/deps` test fixture satisfies the guard; do not plant it
+- **The LOAD probe respects the containment guard** — `loadGoogleapis` resolves
+  `googleapis` only from **inside** `<core>/app/deps` (WP-047) and then requires
+  it, so a stray or corrupt copy does not read as usable. The
+  planted-under-`app/deps` test fixtures satisfy the guard; do not plant them
   anywhere else.
 - Zero new dependencies; no build step. Do not touch `gws`, adapters, `sync`,
   `detect`, or the manifest.
@@ -203,19 +263,27 @@ it to `plantToken`/`plantDeps`. Read the helper at the top of the file.)
 ## Security checklist
 
 - [ ] No untrusted input. The token path comes from `client.tokenPath(paths)`
-      (env-derived core, already trusted); the check only `stat`s it and prints
-      strings. The npm command in the warn message is the pre-existing pinned
-      `deps.depsDir`/`deps.GOOGLEAPIS_SPEC` constant — no user value is
-      interpolated. No value flows into a shell command or a mutation.
+      (env-derived core, already trusted); the check reads + JSON-parses it and
+      prints strings. The **load probe** `require`s `googleapis` only from inside
+      the containment-guarded `<core>/app/deps` (via `loadGoogleapis`) — the same
+      copy, from the same guarded location, that every `gws` command already loads,
+      so it introduces no new code-execution surface. The npm command in the warn
+      message is the pre-existing pinned `deps.depsDir`/`deps.GOOGLEAPIS_SPEC`
+      constant — no user value is interpolated. No value flows into a shell command
+      or a mutation.
 
 ## Acceptance criteria
 
-- [ ] When Google is connected (token present) and `googleapis` resolves from
+- [ ] When Google is connected (valid token) and `googleapis` **loads** from
       `<core>/app/deps`, `doctor` prints one `[ok] Google connected and its client
       library is installed` line and exits 0.
-- [ ] When Google is connected but `googleapis` does not resolve from
-      `<core>/app/deps`, `doctor` prints one `[warn] Google is connected but its
-      client library is missing …` line with the remedy and **still exits 0**.
+- [ ] When Google is connected but `googleapis` is **absent OR resolvable-but-
+      un-loadable** (corrupt), `doctor` prints one `[warn] Google is connected but
+      its client library is missing or broken …` line with the npm remedy (no
+      `gws auth` suggestion) and **still exits 0**.
+- [ ] When the token file is present but damaged (zero-byte / malformed JSON /
+      missing `refresh_token`), `doctor` prints one `[warn] Google sign-in file
+      looks damaged …` line and never `[ok]`; exit 0.
 - [ ] When Google is not connected (no token), `doctor` prints **no** Google line.
 - [ ] `doctor` performs no filesystem mutation in any of these paths.
 - [ ] `npm test` and `npm run lint` pass.
@@ -233,7 +301,7 @@ npm run lint
 - The read-path self-heal + disambiguated error — that is **WP-102** (this WP
   depends on it for the remedy wording).
 - Any auto-repair from `doctor` (remediation is the next `gws` command's
-  self-heal, or `gws auth`).
+  self-heal, or the printed npm one-liner).
 - Surfacing this in the session digest — a separate concern (the digest's
   cache-then-render split), not scoped here.
 
@@ -244,3 +312,24 @@ npm run lint
    `feat(doctor): flag a connected Google account with a missing client library (WP-103)`.
 3. PR template filled, including "Decisions made" (or "none") and `Generated-by:`.
 4. This spec's `status:` flipped to `In-Review` in the same PR.
+
+## Revision log
+
+- **2026-07-13 — Codex round-1 review + owner dispositions.** Applied after the
+  implementer had already coded this spec verbatim (PR #104); the deltas below are
+  surgical patches to the same branch.
+  - **Finding 1 (owner: TARGETED).** The probe now uses a containment-guarded
+    **LOAD** probe (`deps.loadGoogleapis` in a `try/catch`) instead of the
+    resolve-only `deps.isInstalled`, so a corrupt/partial install that resolves but
+    fails to `require` warns (not `[ok]`). Warn wording became "missing **or
+    broken**"; a `plantCorruptDeps` fixture (entry point throws on require) was
+    added.
+  - **Finding 3 (MUST FIX).** The warn message dropped the `wienerdog gws auth`
+    suggestion (it cannot fix this without re-opening browser consent), leaving the
+    self-heal + the exact npm one-liner — kept consistent with WP-102's message. A
+    `!/gws auth/` negative assertion was added to the missing-library test.
+  - **Finding 4 (owner: MINIMAL VALIDATION).** The probe now JSON-parses the token
+    (read-only) and requires a `refresh_token`; a zero-byte / malformed / incomplete
+    token yields a separate `[warn] Google sign-in file looks damaged …` and never
+    `[ok]`. Damaged-token fixtures/cases were added. (WP-102's `hasToken` stays
+    existence-only by design — the documented asymmetry.)

--- a/docs/specs/WP-103-doctor-gws-deps-probe.md
+++ b/docs/specs/WP-103-doctor-gws-deps-probe.md
@@ -232,6 +232,16 @@ function plantCorruptDeps(core) {
     JSON.stringify({ name: 'googleapis', version: '173.0.0', main: 'index.js' }));
   fs.writeFileSync(path.join(pkgDir, 'index.js'), "throw new Error('corrupt googleapis entry point');\n");
 }
+/** Plant a SHAPE-BROKEN fake googleapis: resolves AND requires cleanly, but exports
+ *  no `.google` (zero-byte / stub index.js → {}). The false-[ok] case the WP-102
+ *  load-probe shape check must catch (PR-gate P2). */
+function plantShapelessDeps(core) {
+  const pkgDir = path.join(core, 'app', 'deps', 'node_modules', 'googleapis');
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(path.join(pkgDir, 'package.json'),
+    JSON.stringify({ name: 'googleapis', version: '173.0.0', main: 'index.js' }));
+  fs.writeFileSync(path.join(pkgDir, 'index.js'), 'module.exports = {};\n');
+}
 /** Plant a VALID token (JSON + refresh_token) so the core reads as "connected". */
 function plantToken(core) {
   const secrets = path.join(core, 'secrets');
@@ -275,6 +285,14 @@ function plantDamagedToken(core, content) {
   Google connected/`, and `r.status === 0`. (This is the case a resolve-only check
   would falsely pass; its remedy must delete the tree first, since a bare `npm
   install` can no-op over it — round-4 Finding.)
+- **Connected + library SHAPE-BROKEN (loads to `{}`, no `.google`) → `[warn]`
+  "broken", exit 0 (PR-gate P2).** `init`; `plantToken(core)`;
+  `plantShapelessDeps(core)`; `doctor`. Assert `r.stdout` matches `/\[warn\] Google
+  is connected but its client library is broken \(installed but not loadable\)/`,
+  **does NOT match** `/\[ok\] Google connected/`, and `r.status === 0`. This proves
+  the false-`[ok]` is closed end-to-end: the load probe (`deps.loadGoogleapis`) now
+  shape-checks (WP-102), so a stub module that requires cleanly no longer reads as
+  usable. (No `doctor.js` change — the probe inherits WP-102's fix.)
 - **Connected + library present and loadable → `[ok]`.** `init`;
   `plantToken(core)`; `plantDeps(core)`; `doctor`. Assert `r.stdout` matches
   `/\[ok\] Google connected and its client library is installed/` and
@@ -409,3 +427,12 @@ npm run lint
   WP-102. Existing test assertions are unaffected (they pin the message text and the
   `delete the folder <path>` fragment, not the `--prefix` portion); no test change
   required here.
+- **2026-07-13 — closing PR-gate (Codex PR review; P2 fixed in WP-102's `deps.js`,
+  verified here).** The load probe treated any successfully-required module as
+  usable, so a shape-broken install (`index.js` → `{}`, canonically a zero-byte
+  entry point) passed → `doctor` falsely reported `[ok]` and the next gws read
+  crashed with a raw `TypeError`. WP-102's `loadGoogleapis` now shape-checks
+  (rejects a module with no truthy `.google`), and this probe **inherits** the fix
+  (it calls `loadGoogleapis`) — **no `doctor.js` code change**. Added a doctor test
+  case: `plantToken` + `plantShapelessDeps` (`module.exports = {}`) → `[warn]`
+  broken, never `[ok]`, proving the false-`[ok]` is closed end-to-end.

--- a/docs/specs/WP-103-doctor-gws-deps-probe.md
+++ b/docs/specs/WP-103-doctor-gws-deps-probe.md
@@ -80,15 +80,18 @@ lazily inside `run` already exists (`require('../scheduler/status')`).
   or **throws** a `WienerdogError`. It resolves via the containment guard AND
   `require`s the module inside its own `try/catch`, so it is a full **LOAD** probe
   — a corrupt/partial install that resolves but fails to `require` throws here.
-  Use this (in a `try/catch`), **not** `isInstalled` (which only resolves), so the
-  probe warns on a corrupt-but-resolvable install instead of falsely reading
-  `[ok]` (Codex Finding 1a).
+  Use this (in a `try/catch`) as the primary usability check (Codex Finding 1a).
+- `require('../gws/deps').isInstalled(paths)` → `boolean` (resolve-only). Used
+  **only after a failed load** to distinguish ABSENT (`false` → self-heal will
+  fire) from BROKEN (`true` → resolvable-but-un-loadable, self-heal no-ops), so the
+  two get distinct remedies (round-2 Finding 2).
 - `require('../gws/deps').depsDir(paths)` → `<core>/app/deps` (for the remedy).
 - `require('../gws/deps').GOOGLEAPIS_SPEC` → `'googleapis@^173'` (for the remedy).
 - `require('../gws/client').tokenPath(paths)` → `path.join(paths.secrets,
   'google-token.json')` — the canonical token path. The probe reads + JSON-parses
-  it (read-only) and requires a `refresh_token`, so a zero-byte/malformed/
-  incomplete token warns as "damaged" and never reads `[ok]` (Codex Finding 4).
+  it (read-only) and requires a **non-empty string** `refresh_token`, so a
+  zero-byte / malformed / incomplete / wrong-type / whitespace-only token warns as
+  "damaged" and never reads `[ok]` (Codex Finding 4 + round-2 Finding 3).
 
 **`tests/unit/doctor.test.js`** drives `doctor` as a subprocess
 (`node bin/wienerdog.js doctor`) against an isolated temp `HOME`/`WIENERDOG_HOME`
@@ -129,12 +132,15 @@ function googleReadinessChecks(paths) {
   const tp = tokenPath(paths);
   if (!fileExists(tp)) return []; // Google not connected — nothing to check (normal)
 
-  // Finding 4 — minimal, read-only token validation: a zero-byte / malformed /
-  // incomplete token must never read as a healthy [ok]. Require valid JSON with a
-  // refresh_token; anything else is a separate "damaged" warn.
+  // Finding 4 + round-2 Finding 3 — minimal, read-only token validation: a
+  // zero-byte / malformed / incomplete token must never read as a healthy [ok].
+  // Require valid JSON with a NON-EMPTY STRING refresh_token (a truthiness-only
+  // check would let {"refresh_token":true} or a whitespace value pass). Anything
+  // else is a separate "damaged" warn.
   let token = null;
   try { token = JSON.parse(fs.readFileSync(tp, 'utf8')); } catch { token = null; }
-  if (!token || typeof token !== 'object' || !token.refresh_token) {
+  if (!token || typeof token !== 'object' ||
+      typeof token.refresh_token !== 'string' || token.refresh_token.trim() === '') {
     return [{ status: 'warn', msg: 'Google sign-in file looks damaged — reconnect with /wienerdog-google-setup' }];
   }
 
@@ -148,12 +154,28 @@ function googleReadinessChecks(paths) {
   if (usable) {
     return [{ status: 'ok', msg: 'Google connected and its client library is installed' }];
   }
+  // Round-2 Finding 2 — DISTINGUISH the two failed-load states, because the
+  // self-heal promise is only true for one of them:
+  //   isInstalled false → ABSENT: the next read WILL self-heal (WP-102).
+  //   isInstalled true  → BROKEN (resolves but won't load): self-heal NO-OPs
+  //                        (WP-102's isInstalled gate is true), so promising an
+  //                        offer would be false — require a manual reinstall.
+  // Same npm command repairs both (install over the corrupt dir overwrites it).
   const cmd = `npm install --ignore-scripts --prefix ${deps.depsDir(paths)} ${deps.GOOGLEAPIS_SPEC}`;
+  if (deps.isInstalled(paths)) {
+    return [
+      {
+        status: 'warn',
+        msg:
+          'Google is connected but its client library is broken (installed but not loadable) — reinstall it: ' + cmd,
+      },
+    ];
+  }
   return [
     {
       status: 'warn',
       msg:
-        'Google is connected but its client library is missing or broken — the next `wienerdog gws` ' +
+        'Google is connected but its client library is missing — the next `wienerdog gws` ' +
         'command will offer to install it, or run: ' + cmd,
     },
   ];
@@ -161,12 +183,14 @@ function googleReadinessChecks(paths) {
 ```
 
 Use the file's existing `fileExists(p)` helper and its top-level `fs` for the
-token read. Return **one** line (not one per state); keep `doctor` output compact.
-The warn message drops the `wienerdog gws auth` suggestion (Codex Finding 3 —
-`gws auth` cannot fix this without re-opening browser consent), and stays worded
-consistently with WP-102's `loadGoogleapis` message. It says "missing **or
-broken**" because the LOAD probe warns on both the absent and the
-corrupt-but-resolvable case; the `npm install` one-liner is the universal remedy
+token read. Both warn branches drop the `wienerdog gws auth` suggestion (Codex
+Finding 3). Two distinct messages (round-2 Finding 2): the **absent** message
+keeps the self-heal promise + npm command; the **broken** (resolvable-but-
+un-loadable) message must NOT claim the next-command offer — WP-102's self-heal
+no-ops on a resolvable install — and points only to the npm reinstall (the same
+command repairs it). Consistent with WP-102's `loadGoogleapis` message, whose
+single string is an error (not a status) and always carries the npm one-liner. The
+`npm install` one-liner is the universal remedy
 for both.
 
 **2. Wire into `run`.** Immediately **after** the `codexSkillChecks` loop and
@@ -219,21 +243,28 @@ function plantDamagedToken(core, content) {
   `run(['init','--yes'], env)` then `run(['doctor'], env)`. Assert `r.stdout` does
   **not** match `/Google connected|Google is connected but|Google sign-in file/`
   and `r.status === 0`.
-- **Damaged token → `[warn]` "looks damaged", never `[ok]` (Finding 4).** `init`;
-  `plantDamagedToken(core, 'not json')`; `doctor`. Assert `r.stdout` matches
-  `/\[warn\] Google sign-in file looks damaged/`, does **not** match
-  `/\[ok\] Google connected/`, and `r.status === 0`. Add a second variant with a
-  well-formed but incomplete token: `plantDamagedToken(core,
-  JSON.stringify({access_token:'a'}))` (no `refresh_token`) → same `[warn]`.
-- **Connected + library missing → `[warn]`, exit 0.** `init`; `plantToken(core)`
-  (no deps planted); `doctor`. Assert `r.stdout` matches `/\[warn\] Google is
-  connected but its client library is missing or broken/`, does **not** match
-  `/gws auth/` (Finding 3), and `r.status === 0` (warn, not fail).
-- **Connected + library corrupt (resolvable but throws on load) → `[warn]`, exit 0
-  (Finding 1a).** `init`; `plantToken(core)`; `plantCorruptDeps(core)`; `doctor`.
-  Assert `r.stdout` matches `/\[warn\] Google is connected but its client library
-  is missing or broken/`, does **not** match `/\[ok\] Google connected/`, and
-  `r.status === 0`. (This is the case a resolve-only check would falsely pass.)
+- **Damaged token → `[warn]` "looks damaged", never `[ok]` (Finding 4 + round-2
+  Finding 3).** For **each** of these damaged variants, `init`;
+  `plantDamagedToken(core, <content>)`; `doctor`; assert `r.stdout` matches
+  `/\[warn\] Google sign-in file looks damaged/`, does **not** match `/\[ok\]
+  Google connected/`, and `r.status === 0`:
+  - malformed JSON: `'not json'`
+  - missing `refresh_token`: `JSON.stringify({access_token:'a'})`
+  - **wrong-type** `refresh_token` (round-2 Finding 3): `JSON.stringify({refresh_token:true})`
+  - **whitespace-only** `refresh_token` (round-2 Finding 3): `JSON.stringify({refresh_token:'   '})`
+  - zero-byte: `''`
+- **Connected + library ABSENT → `[warn]` "missing", exit 0.** `init`;
+  `plantToken(core)` (no deps planted); `doctor`. Assert `r.stdout` matches
+  `/\[warn\] Google is connected but its client library is missing — the next .?wienerdog gws.? command will offer to install it/`,
+  does **not** match `/gws auth/` (Finding 3), and `r.status === 0` (warn, not fail).
+- **Connected + library BROKEN (resolvable but throws on load) → `[warn]`
+  "broken", exit 0 (Finding 1a + round-2 Finding 2).** `init`; `plantToken(core)`;
+  `plantCorruptDeps(core)`; `doctor`. Assert `r.stdout` matches `/\[warn\] Google
+  is connected but its client library is broken \(installed but not loadable\)/`,
+  **does NOT match** `/will offer to install/` (the broken state does not
+  self-heal — round-2 Finding 2), does **not** match `/\[ok\] Google connected/`,
+  and `r.status === 0`. (This is the case a resolve-only check would falsely pass,
+  and the case whose remedy must not promise the next-command offer.)
 - **Connected + library present and loadable → `[ok]`.** `init`;
   `plantToken(core)`; `plantDeps(core)`; `doctor`. Assert `r.stdout` matches
   `/\[ok\] Google connected and its client library is installed/` and
@@ -277,13 +308,16 @@ it to the plant helpers. Read the helper at the top of the file.)
 - [ ] When Google is connected (valid token) and `googleapis` **loads** from
       `<core>/app/deps`, `doctor` prints one `[ok] Google connected and its client
       library is installed` line and exits 0.
-- [ ] When Google is connected but `googleapis` is **absent OR resolvable-but-
-      un-loadable** (corrupt), `doctor` prints one `[warn] Google is connected but
-      its client library is missing or broken …` line with the npm remedy (no
-      `gws auth` suggestion) and **still exits 0**.
+- [ ] When Google is connected but `googleapis` is **absent** (not resolvable),
+      `doctor` prints one `[warn] … client library is missing — the next \`wienerdog
+      gws\` command will offer to install it …` line and exits 0.
+- [ ] When Google is connected but `googleapis` is **resolvable-but-un-loadable**
+      (corrupt), `doctor` prints one `[warn] … client library is broken (installed
+      but not loadable) — reinstall it: <npm>` line that does **NOT** claim the
+      next-command offer, and exits 0. Neither warn suggests `gws auth`.
 - [ ] When the token file is present but damaged (zero-byte / malformed JSON /
-      missing `refresh_token`), `doctor` prints one `[warn] Google sign-in file
-      looks damaged …` line and never `[ok]`; exit 0.
+      missing / wrong-type / whitespace-only `refresh_token`), `doctor` prints one
+      `[warn] Google sign-in file looks damaged …` line and never `[ok]`; exit 0.
 - [ ] When Google is not connected (no token), `doctor` prints **no** Google line.
 - [ ] `doctor` performs no filesystem mutation in any of these paths.
 - [ ] `npm test` and `npm run lint` pass.
@@ -333,3 +367,18 @@ npm run lint
     token yields a separate `[warn] Google sign-in file looks damaged …` and never
     `[ok]`. Damaged-token fixtures/cases were added. (WP-102's `hasToken` stays
     existence-only by design — the documented asymmetry.)
+- **2026-07-13 — Codex round-2 review.** Two correctness deltas on the round-1
+  material:
+  - **Round-2 Finding 2 (medium).** The single "missing **or** broken" warn falsely
+    promised the next `wienerdog gws` command "will offer to install it" for the
+    **broken** (resolvable-but-un-loadable) case — WP-102's self-heal no-ops there
+    (`isInstalled` true). The probe now splits the two failed-load states via
+    `deps.isInstalled`: **absent** (`false`) keeps the self-heal promise; **broken**
+    (`true`) gets a distinct message ("broken (installed but not loadable) —
+    reinstall it: <npm>") that makes no offer claim. Same npm command repairs both.
+    The `plantCorruptDeps` case now asserts the broken message and `!/will offer to
+    install/`.
+  - **Round-2 Finding 3 (medium).** `refresh_token` validation was truthiness-only,
+    so `{"refresh_token":true}` or a whitespace value passed → possible false
+    `[ok]`. Tightened to `typeof … === 'string' && .trim() !== ''`; added
+    wrong-type and whitespace-only damaged-token fixtures.

--- a/docs/specs/WP-103-doctor-gws-deps-probe.md
+++ b/docs/specs/WP-103-doctor-gws-deps-probe.md
@@ -1,0 +1,246 @@
+---
+id: WP-103
+title: doctor probe — connected Google account with a missing client library
+status: Ready
+model: sonnet
+size: S
+depends_on: [WP-102]
+adrs: [ADR-0004]
+branch: wp/103-doctor-gws-deps-probe
+---
+
+# WP-103: doctor probe — connected Google account with a missing client library
+
+## Context (read this, nothing else)
+
+`wienerdog doctor` (`src/cli/doctor.js`) prints one `[ok]`/`[warn]`/`[fail]` line
+per health check and exits 1 (via `process.exitCode`) only if some check
+**fails**; warnings never fail. It already checks the core dir, manifest parse,
+config, vault, secrets permissions, a harness-detection summary, scheduler-load
+health, and Codex skill links.
+
+**Why this WP exists.** `userreports/BUG-gws-deps-missing-after-upgrade.md`
+documents a dead-end: a user who connected Google **before** the on-demand
+`googleapis` deps-dir scheme (WP-047) has a **valid token** in
+`~/.wienerdog/secrets/google-token.json` but an **absent**
+`~/.wienerdog/app/deps/`, so every `gws` read fails. `doctor` today has **no
+probe** for this state — it reports all-green while every gws read is broken.
+WP-102 makes reads **self-heal** (install on first read, with consent) and fixes
+the misleading error; this WP adds the matching **visibility**: `doctor` reports
+the connected-but-library-missing state and its one-line remedy, so a user (or an
+operator debugging a headless routine that can't prompt) sees it explicitly
+instead of discovering it only when a routine fails.
+
+**Scope discipline.** This is a **read-only** check — `doctor` never mutates. The
+connected-but-missing state is a **warn** (actionable), never a fail. When Google
+is **not** connected (no token), the check emits **nothing** — that is the normal
+state for the majority who never connected Google (mirrors how the existing Codex
+skill check stays silent when Codex is absent). This WP adds one focused check and
+its tests; it changes no adapter, no `sync`, no `gws` code, no manifest.
+
+**Product invariant.** Wienerdog is just files; it never starts a process that
+outlives its job (ADR-0004). This WP only reads the filesystem and prints lines.
+
+**Dependency on WP-102.** WP-103 depends on WP-102 for **coherence of the remedy
+wording**, not for code: the warn line tells the user the next `gws` read will
+offer to install the library (WP-102's self-heal), so WP-102 must land first for
+that sentence to be true. The APIs this probe calls (`deps.isInstalled`,
+`deps.depsDir`, `deps.GOOGLEAPIS_SPEC`, `client.tokenPath`) all exist on main
+today.
+
+## Current state
+
+**`src/cli/doctor.js`** — `run(_argv)` builds a `check(status, msg)` closure and,
+near the end, runs the scheduler and Codex checks in loops, then a trailing
+update-notice block:
+
+```js
+const harnesses = detectHarnesses();
+check('ok', `AI tools — Claude Code: ${...}, Codex CLI: ${...}`);
+
+const { doctorSchedulerChecks } = require('../scheduler/status');
+for (const c of doctorSchedulerChecks(paths)) check(c.status, c.msg);
+
+// Codex skill-link health ...
+for (const c of codexSkillChecks(paths, harnesses)) check(c.status, c.msg);
+
+// Cache-only update notice (no network; does not affect pass/fail). ADR-0015.
+const upd = getUpdateNotice(paths);
+if (upd.available) { console.log(`[info] ...`); }
+
+if (failed) process.exitCode = 1;
+```
+
+`doctor.js` already imports `fs` and `path` at the top. It does **not** import
+`../gws/deps` or `../gws/client` yet; the pattern for pulling in a helper module
+lazily inside `run` already exists (`require('../scheduler/status')`).
+
+**gws helpers this probe uses (all exported on main today):**
+- `require('../gws/deps').isInstalled(paths)` → `boolean` — whether `googleapis`
+  resolves from inside `<core>/app/deps` (containment-guarded).
+- `require('../gws/deps').depsDir(paths)` → `<core>/app/deps`.
+- `require('../gws/deps').GOOGLEAPIS_SPEC` → `'googleapis@^173'`.
+- `require('../gws/client').tokenPath(paths)` → `path.join(paths.secrets,
+  'google-token.json')` — the canonical token path.
+
+**`tests/unit/doctor.test.js`** drives `doctor` as a subprocess
+(`node bin/wienerdog.js doctor`) against an isolated temp `HOME`/`WIENERDOG_HOME`
+(helper `tempEnv()`), then asserts on stdout / exit code. It runs `init --yes`
+first to create the core (which creates `secrets/` but no token and no
+`app/deps`). To exercise a "connected" core a test writes a token file into
+`<core>/secrets/google-token.json`; to exercise "library installed" a test plants
+a fake `googleapis` under `<core>/app/deps/node_modules/googleapis` (same shape as
+`tests/unit/gws-deps.test.js`'s `fakeInstall`/`plantGoogleapis`).
+
+## Deliverables (permission boundary — touch ONLY these)
+
+<!-- Always allowed without listing: this spec file, docs/specs/ROADMAP.md, package-lock.json. -->
+
+| Action | Path | Notes |
+|--------|------|-------|
+| modify | src/cli/doctor.js | add a read-only `googleReadinessChecks(paths)` helper returning `{status,msg}[]`; call it in `run`, one `check(...)` per line, after the Codex-skill loop and before the update-notice block. |
+| modify | tests/unit/doctor.test.js | add three cases: not-connected → no Google line; connected + library missing → `[warn]`, exit 0; connected + library present → `[ok]`. |
+
+### Exact contracts
+
+**1. `googleReadinessChecks(paths)` — new helper in `doctor.js`.** Pure and
+read-only; returns `{status:'ok'|'warn', msg:string}[]` (never `'fail'`). Lazy-
+require the gws helpers inside the function (mirrors the scheduler-status require
+pattern), so `doctor` doesn't load gws for a run that never reaches this check.
+
+```js
+/** Report Google client-library readiness for a CONNECTED account. Read-only;
+ *  never fails (a missing library is actionable, so a WARN). Emits NOTHING when
+ *  Google is not connected (no token) — the normal state. WP-103 / BUG-gws-deps-missing.
+ *  @param {import('../core/paths').WienerdogPaths} paths
+ *  @returns {{status:'ok'|'warn', msg:string}[]} */
+function googleReadinessChecks(paths) {
+  const { tokenPath } = require('../gws/client');
+  const deps = require('../gws/deps');
+  if (!fileExists(tokenPath(paths))) return []; // Google not connected — nothing to check (normal)
+  if (deps.isInstalled(paths)) {
+    return [{ status: 'ok', msg: 'Google connected and its client library is installed' }];
+  }
+  const cmd = `npm install --ignore-scripts --prefix ${deps.depsDir(paths)} ${deps.GOOGLEAPIS_SPEC}`;
+  return [
+    {
+      status: 'warn',
+      msg:
+        'Google is connected but its client library is missing — the next `wienerdog gws` ' +
+        'command will offer to install it, or run `wienerdog gws auth`, or: ' + cmd,
+    },
+  ];
+}
+```
+
+Use the file's existing `fileExists(p)` helper (already defined in `doctor.js`)
+for the token check. Return **one** line (not one per state); keep `doctor`
+output compact and consistent with the scheduler/Codex checks.
+
+**2. Wire into `run`.** Immediately **after** the `codexSkillChecks` loop and
+**before** the update-notice block, add:
+
+```js
+for (const c of googleReadinessChecks(paths)) check(c.status, c.msg);
+```
+
+`paths` is already in scope. No other change to `run`.
+
+**3. Tests (`tests/unit/doctor.test.js`).** Add a small plant helper and three
+cases using the existing `run`/`tempEnv` helpers. Plant a token by writing
+`<core>/secrets/google-token.json`; plant the library the same way
+`gws-deps.test.js` does:
+
+```js
+/** Plant a fake googleapis under <core>/app/deps so isInstalled() is true (no network). */
+function plantDeps(core) {
+  const pkgDir = path.join(core, 'app', 'deps', 'node_modules', 'googleapis');
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(path.join(pkgDir, 'package.json'),
+    JSON.stringify({ name: 'googleapis', version: '173.0.0', main: 'index.js' }));
+  fs.writeFileSync(path.join(pkgDir, 'index.js'), 'module.exports = { google: {} };\n');
+}
+/** Plant a valid-looking token so the core reads as "connected". */
+function plantToken(core) {
+  const secrets = path.join(core, 'secrets');
+  fs.mkdirSync(secrets, { recursive: true });
+  fs.writeFileSync(path.join(secrets, 'google-token.json'),
+    JSON.stringify({ access_token: 'a', refresh_token: 'r' }));
+}
+```
+
+- **Google not connected → no Google-readiness line.** Default `tempEnv()`;
+  `run(['init','--yes'], env)` then `run(['doctor'], env)`. Assert
+  `r.stdout` does **not** match `/Google connected|Google is connected but/` and
+  `r.status === 0`.
+- **Connected + library missing → `[warn]`, exit 0.** `init`; `plantToken(core)`
+  (no `plantDeps`); `doctor`. Assert `r.stdout` matches `/\[warn\] Google is
+  connected but its client library is missing/` and `r.status === 0` (warn, not
+  fail).
+- **Connected + library present → `[ok]`.** `init`; `plantToken(core)`;
+  `plantDeps(core)`; `doctor`. Assert `r.stdout` matches `/\[ok\] Google connected
+  and its client library is installed/` and `r.status === 0`.
+
+(Whichever of `tempEnv`'s return fields exposes the core dir — e.g. `core` — pass
+it to `plantToken`/`plantDeps`. Read the helper at the top of the file.)
+
+## Implementation notes & constraints
+
+- **Read-only, warn-not-fail.** `doctor` must never create, install, or repair
+  anything. A missing library is a `warn`; the printed remedies are the WP-102
+  self-heal (next `gws` command), `wienerdog gws auth`, or the exact npm command.
+- **Silent when unconnected.** Drive the check off token presence: no token →
+  empty array → no line. This keeps `doctor` clean for the majority of users.
+- **The `isInstalled` probe respects the containment guard** — it returns true
+  only when `googleapis` resolves from **inside** `<core>/app/deps` (WP-047), so a
+  stray `googleapis` elsewhere on the machine does not read as installed. The
+  planted-under-`app/deps` test fixture satisfies the guard; do not plant it
+  anywhere else.
+- Zero new dependencies; no build step. Do not touch `gws`, adapters, `sync`,
+  `detect`, or the manifest.
+- When uncertain, choose the simpler option and record it under "Decisions made".
+
+## Security checklist
+
+- [ ] No untrusted input. The token path comes from `client.tokenPath(paths)`
+      (env-derived core, already trusted); the check only `stat`s it and prints
+      strings. The npm command in the warn message is the pre-existing pinned
+      `deps.depsDir`/`deps.GOOGLEAPIS_SPEC` constant — no user value is
+      interpolated. No value flows into a shell command or a mutation.
+
+## Acceptance criteria
+
+- [ ] When Google is connected (token present) and `googleapis` resolves from
+      `<core>/app/deps`, `doctor` prints one `[ok] Google connected and its client
+      library is installed` line and exits 0.
+- [ ] When Google is connected but `googleapis` does not resolve from
+      `<core>/app/deps`, `doctor` prints one `[warn] Google is connected but its
+      client library is missing …` line with the remedy and **still exits 0**.
+- [ ] When Google is not connected (no token), `doctor` prints **no** Google line.
+- [ ] `doctor` performs no filesystem mutation in any of these paths.
+- [ ] `npm test` and `npm run lint` pass.
+
+## Verification steps (run these; paste output in the PR)
+
+```bash
+npm test -- --test-name-pattern doctor
+npm test
+npm run lint
+```
+
+## Out of scope (do NOT do these)
+
+- The read-path self-heal + disambiguated error — that is **WP-102** (this WP
+  depends on it for the remedy wording).
+- Any auto-repair from `doctor` (remediation is the next `gws` command's
+  self-heal, or `gws auth`).
+- Surfacing this in the session digest — a separate concern (the digest's
+  cache-then-render split), not scoped here.
+
+## Definition of done
+
+1. All verification steps pass locally; output pasted into the PR body.
+2. Branch `wp/103-doctor-gws-deps-probe`; conventional commits; PR titled
+   `feat(doctor): flag a connected Google account with a missing client library (WP-103)`.
+3. PR template filled, including "Decisions made" (or "none") and `Generated-by:`.
+4. This spec's `status:` flipped to `In-Review` in the same PR.

--- a/docs/specs/WP-103-doctor-gws-deps-probe.md
+++ b/docs/specs/WP-103-doctor-gws-deps-probe.md
@@ -81,10 +81,13 @@ lazily inside `run` already exists (`require('../scheduler/status')`).
   `require`s the module inside its own `try/catch`, so it is a full **LOAD** probe
   — a corrupt/partial install that resolves but fails to `require` throws here.
   Use this (in a `try/catch`) as the primary usability check (Codex Finding 1a).
-- `require('../gws/deps').isInstalled(paths)` → `boolean` (resolve-only). Used
-  **only after a failed load** to distinguish ABSENT (`false` → self-heal will
-  fire) from BROKEN (`true` → resolvable-but-un-loadable, self-heal no-ops), so the
-  two get distinct remedies (round-2 Finding 2).
+- `require('../gws/deps').depsPresent(paths)` → `boolean` (physical presence — the
+  deps-dir `googleapis/package.json` exists). Used **only after a failed load** to
+  distinguish ABSENT (`false` → self-heal will fire) from BROKEN (`true` → a deps
+  tree exists but isn't usable, self-heal no-ops), so the two get distinct remedies
+  (round-2 Finding 2, re-keyed round-6 P2). Do NOT use `isInstalled` here — it is
+  `false` for a package.json-present-but-unresolvable (missing-main) tree, which
+  would mis-label that BROKEN state as "missing".
 - `require('../gws/deps').depsDir(paths)` → `<core>/app/deps` (for the remedy).
 - `require('../gws/deps').GOOGLEAPIS_SPEC` → `'googleapis@^173'` (for the remedy).
 - `require('../gws/client').tokenPath(paths)` → `path.join(paths.secrets,
@@ -154,17 +157,20 @@ function googleReadinessChecks(paths) {
   if (usable) {
     return [{ status: 'ok', msg: 'Google connected and its client library is installed' }];
   }
-  // Round-2 Finding 2 — DISTINGUISH the two failed-load states, because the
-  // self-heal promise is only true for one of them:
-  //   isInstalled false → ABSENT: the next read WILL self-heal (WP-102).
-  //   isInstalled true  → BROKEN (resolves but won't load): self-heal NO-OPs
-  //                        (WP-102's isInstalled gate is true), so promising an
-  //                        offer would be false — require a manual reinstall.
+  // Round-2 Finding 2 — DISTINGUISH the two failed-load states, keyed on PHYSICAL
+  // PRESENCE (round-6 P2), NOT isInstalled/resolvability:
+  //   depsPresent false → ABSENT: the next read WILL self-heal (WP-102).
+  //   depsPresent true  → BROKEN (a deps tree exists but won't load — bad main /
+  //                       corrupt entry / no .google / symlink-out): self-heal
+  //                       NO-OPs (WP-102 gates on depsPresent), so promising an
+  //                       offer would be false — require a manual delete+reinstall.
+  // NOTE: `deps.isInstalled` is FALSE for a package.json-present-but-unresolvable
+  // (missing-main) tree, so keying on it would mis-label that state "missing".
   const dir = deps.depsDir(paths);
   // Quote the prefix (P2-A): a home path with spaces would split the argument when
   // the user pastes the command. Double quotes work in POSIX shells, cmd, PowerShell.
   const cmd = `npm install --ignore-scripts --prefix "${dir}" ${deps.GOOGLEAPIS_SPEC}`;
-  if (deps.isInstalled(paths)) {
+  if (deps.depsPresent(paths)) {
     // Round-4 Finding — a bare `npm install` can NO-OP over a corrupt-but-
     // resolvable tree (npm compares tree metadata, not file contents), so the
     // corrupt tree must be DELETED first. Deps dir is single-purpose → safe to
@@ -190,11 +196,12 @@ function googleReadinessChecks(paths) {
 
 Use the file's existing `fileExists(p)` helper and its top-level `fs` for the
 token read. Both warn branches drop the `wienerdog gws auth` suggestion (Codex
-Finding 3). Two distinct messages (round-2 Finding 2): the **absent** message
-keeps the self-heal promise + npm command; the **broken** (resolvable-but-
-un-loadable) message must NOT claim the next-command offer — WP-102's self-heal
-no-ops on a resolvable install — and prescribes **delete-the-folder-then-reinstall**
-(round-4 Finding: a bare `npm install` can no-op over a corrupt-but-resolvable
+Finding 3). Two distinct messages (round-2 Finding 2), keyed on
+`deps.depsPresent` (round-6 P2): the **absent** message (`depsPresent === false`)
+keeps the self-heal promise + npm command; the **broken** message (`depsPresent ===
+true` but not usable) must NOT claim the next-command offer — WP-102's self-heal
+no-ops on any present tree — and prescribes **delete-the-folder-then-reinstall**
+(round-4 Finding: a bare `npm install` can no-op over a present-but-corrupt
 tree). Same **delete-then-reinstall** remedy as WP-102's `loadGoogleapis` broken
 message (worded for the single-line doctor warn — no newline; WP-102's is a thrown
 error), so the two surfaces prescribe an identical repair. The `npm install`
@@ -241,6 +248,16 @@ function plantShapelessDeps(core) {
   fs.writeFileSync(path.join(pkgDir, 'package.json'),
     JSON.stringify({ name: 'googleapis', version: '173.0.0', main: 'index.js' }));
   fs.writeFileSync(path.join(pkgDir, 'index.js'), 'module.exports = {};\n');
+}
+/** Plant a MAINLESS fake googleapis: package.json present but NO index.js —
+ *  depsPresent true, but req.resolve throws. isInstalled would read FALSE here;
+ *  the probe must still label it BROKEN, not missing (round-6 P2). */
+function plantMainlessDeps(core) {
+  const pkgDir = path.join(core, 'app', 'deps', 'node_modules', 'googleapis');
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(path.join(pkgDir, 'package.json'),
+    JSON.stringify({ name: 'googleapis', version: '173.0.0', main: 'index.js' }));
+  // deliberately NO index.js
 }
 /** Plant a VALID token (JSON + refresh_token) so the core reads as "connected". */
 function plantToken(core) {
@@ -293,6 +310,13 @@ function plantDamagedToken(core, content) {
   the false-`[ok]` is closed end-to-end: the load probe (`deps.loadGoogleapis`) now
   shape-checks (WP-102), so a stub module that requires cleanly no longer reads as
   usable. (No `doctor.js` change — the probe inherits WP-102's fix.)
+- **Connected + library MAINLESS (package.json but no main; `isInstalled` FALSE)
+  → `[warn]` "broken", not "missing" (round-6 P2).** `init`; `plantToken(core)`;
+  `plantMainlessDeps(core)`; `doctor`. Assert `r.stdout` matches `/\[warn\] Google
+  is connected but its client library is broken \(installed but not loadable\)/`,
+  **does NOT match** `/is missing/`, does **not** match `/\[ok\] Google connected/`,
+  and `r.status === 0`. This is the state whose `deps.isInstalled` is `false`: keying
+  the split on `depsPresent` (not `isInstalled`) is what labels it broken.
 - **Connected + library present and loadable → `[ok]`.** `init`;
   `plantToken(core)`; `plantDeps(core)`; `doctor`. Assert `r.stdout` matches
   `/\[ok\] Google connected and its client library is installed/` and
@@ -339,12 +363,15 @@ it to the plant helpers. Read the helper at the top of the file.)
 - [ ] When Google is connected but `googleapis` is **absent** (not resolvable),
       `doctor` prints one `[warn] … client library is missing — the next \`wienerdog
       gws\` command will offer to install it …` line and exits 0.
-- [ ] When Google is connected but `googleapis` is **resolvable-but-un-loadable**
-      (corrupt), `doctor` prints one `[warn] … client library is broken (installed
-      but not loadable) — delete the folder <depsDir>, then reinstall it: <npm>`
-      line (naming the deps folder, delete-first because a bare `npm install` can
-      no-op over a corrupt tree) that does **NOT** claim the next-command offer, and
-      exits 0. Neither warn suggests `gws auth`.
+- [ ] When Google is connected but a deps tree is **present yet not usable**
+      (`depsPresent` true — corrupt entry, shape-broken, symlink-out, OR
+      package.json-present-but-unresolvable/missing-main), `doctor` prints one
+      `[warn] … client library is broken (installed but not loadable) — delete the
+      folder <depsDir>, then reinstall it: <npm>` line (naming the deps folder,
+      delete-first because a bare `npm install` can no-op over it) that does **NOT**
+      claim the next-command offer, and exits 0. The split keys on `depsPresent`, so
+      the missing-main tree (where `isInstalled` is false) still reads broken, not
+      missing. Neither warn suggests `gws auth`.
 - [ ] When the token file is present but damaged (zero-byte / malformed JSON /
       missing / wrong-type / whitespace-only `refresh_token`), `doctor` prints one
       `[warn] Google sign-in file looks damaged …` line and never `[ok]`; exit 0.
@@ -436,3 +463,14 @@ npm run lint
   (it calls `loadGoogleapis`) — **no `doctor.js` code change**. Added a doctor test
   case: `plantToken` + `plantShapelessDeps` (`module.exports = {}`) → `[warn]`
   broken, never `[ok]`, proving the false-`[ok]` is closed end-to-end.
+- **2026-07-13 — closing Codex PR pass, round-6 (P2 reconciliation; one-word
+  doctor code change).** WP-102 re-keyed its absent/broken split onto physical
+  presence (`depsPresent`) rather than resolvability, because a
+  package.json-present-but-unresolvable (missing-main) tree makes `resolveFromDeps`
+  throw → `isInstalled` false. This probe keyed broken-vs-missing on
+  `deps.isInstalled` after a failed load, which would mis-label that state
+  "missing". Swapped the key to **`deps.depsPresent`** (newly exported from
+  `deps.js`), so a missing-main tree reads BROKEN. Added a doctor test case:
+  `plantToken` + `plantMainlessDeps` (package.json, no `index.js`) → `[warn]`
+  broken, NOT `/is missing/`. The load probe, token validation, and all message
+  strings are otherwise unchanged.

--- a/docs/specs/WP-104-gws-drive-search-friendly-query.md
+++ b/docs/specs/WP-104-gws-drive-search-friendly-query.md
@@ -1,0 +1,215 @@
+---
+id: WP-104
+title: gws drive search — friendly term search by default, --raw for Drive query language
+status: Ready
+model: sonnet
+size: S
+depends_on: []
+adrs: []
+branch: wp/104-gws-drive-search-friendly-query
+---
+
+# WP-104: gws drive search — friendly term search by default
+
+> **Owner signed off 2026-07-13: option (B), friendly-by-default + `--raw`.**
+> This changes the **default behavior** of `gws drive search` (see the resolved
+> decision below). Captured from the appendix of
+> `userreports/BUG-gws-deps-missing-after-upgrade.md`.
+
+## Context (read this, nothing else)
+
+**gws** is the `wienerdog gws` Google Workspace CLI, aimed at knowledge workers,
+not developers (CLAUDE.md: user-facing text is plain language). `gws drive search
+<query>` passes its argument **verbatim** as the Google Drive `q` parameter
+(`src/gws/drive.js`, `search()` → `files.list({ q: opts.query, … })`).
+
+Google Drive's `q` is a **query language**, not a free-text search: it requires
+`<field> <operator> <value>`, e.g. `name contains 'report'` or `fullText contains
+'budget'`. A bare word — the intuitive thing a knowledge worker types, e.g.
+`wienerdog gws drive search budget` — is sent as `q=budget`, which the Drive API
+rejects with `GaxiosError: Invalid Value` (a **query-syntax** error, surfaced as
+an opaque failure — not an auth problem). So the most natural invocation fails
+confusingly.
+
+This WP makes a bare term **just work** by wrapping it as a full-text search,
+while giving power users an explicit escape hatch (`--raw`) to pass Drive query
+language unchanged. Read-only Drive access is unchanged (scope
+`drive.readonly`); no write path is touched.
+
+## Decision (resolved — owner chose (B), 2026-07-13)
+
+The bug report offered two directions; they are mutually exclusive as the default:
+
+- **(A) Document only.** Leave `q` verbatim; add the Drive query syntax to
+  `--help`/error text. Zero behavior change, lowest value — the natural bare-word
+  invocation still fails.
+- **(B) Friendly-by-default + `--raw` (recommended).** Treat the argument as a
+  plain search term by default and wrap it as `fullText contains '<term>'`; add a
+  `--raw` flag that passes the argument as literal Drive `q`. Best UX for the
+  target audience; **changes the default** for anyone currently relying on passing
+  raw `q` (they must add `--raw`).
+
+The architect recommends **(B)**: it matches the plain-language product voice and
+fixes the reported papercut, and `--raw` fully preserves power-user queries. A
+non-heuristic flag (rather than "guess whether the arg looks like a query") keeps
+behavior predictable. The rest of this spec assumes (B). **If the owner picks
+(A), this spec must be rewritten to a docs/help-only change.**
+
+## Current state
+
+**`src/gws/drive.js`** (verified against main @ d8ef87c):
+
+```js
+async function search(services, opts) {
+  const res = await services.drive.files.list({
+    q: opts.query,
+    pageSize: opts.max || 20,
+    fields: 'files(id,name,mimeType,modifiedTime)',
+  });
+  return (res.data && res.data.files) || [];
+}
+
+/** index.js leaves drive's own verb flags (e.g. --id) as plain tokens here. */
+function parseVerbFlags(tokens) {
+  const out = {};
+  for (let i = 0; i < tokens.length; i++) {
+    if (tokens[i] === '--id') out.id = tokens[++i];
+  }
+  return out;
+}
+
+async function run(services, flags) {
+  const [verb, ...rest] = flags.positionals;
+  switch (verb) {
+    case 'search':
+      return search(services, { query: require_(rest[0], '<query>'), max: flags.max });
+    case 'read': { /* ... uses parseVerbFlags(rest).id ... */ }
+    default: throw new WienerdogError(`unknown drive verb: ${verb || '<none>'}`);
+  }
+}
+```
+
+`index.js`'s generic flag parser (`src/gws/index.js` `parseFlags`) leaves any
+token it does not recognize in `flags.positionals`, so a new `--raw` token arrives
+in `rest` here untouched (no change needed in `index.js`). `--max` **is** consumed
+by `index.js` and arrives as `flags.max`.
+
+**`tests/unit/gws-drive.test.js`** calls `drive.search(services, {query, max})`
+directly with a stub `services.drive.files.list` that records the `args` it
+receives (`seen.q`, `seen.pageSize`, `seen.fields`), and calls `drive.run(services,
+{positionals:[...]})` for the verb-routing/`require_` cases. One existing case
+asserts `seen.q === "name contains 'Q3'"` for `search(services, {query: "name
+contains 'Q3'", max: 1})` — i.e. `search()` itself must keep passing `opts.query`
+through verbatim; the **wrapping happens in `run()`**, not in `search()`. Keep it
+that way so that existing test stays valid.
+
+## Deliverables (permission boundary — touch ONLY these)
+
+<!-- Always allowed without listing: this spec file, docs/specs/ROADMAP.md, package-lock.json. -->
+
+| Action | Path | Notes |
+|--------|------|-------|
+| modify | src/gws/drive.js | add `buildDriveQuery(term, {raw})`; parse a boolean `--raw` in the `search` path; build `opts.query` from it. `search()`'s own `q: opts.query` pass-through stays unchanged. |
+| modify | tests/unit/gws-drive.test.js | add cases: bare term → `fullText contains`, `--raw` → verbatim, quote-escaping. |
+
+### Exact contracts
+
+**1. `buildDriveQuery(term, opts)` — new pure helper in `drive.js`.**
+
+```js
+/**
+ * Build the Drive `q` from a user argument. By default a plain term is wrapped
+ * as a full-text search; --raw passes the argument as literal Drive query
+ * language. Drive string literals are single-quoted with `\` and `'` escaped.
+ * @param {string} term
+ * @param {{raw?:boolean}} [opts]
+ * @returns {string}
+ */
+function buildDriveQuery(term, opts = {}) {
+  if (opts.raw) return term;
+  const escaped = term.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+  return `fullText contains '${escaped}'`;
+}
+```
+
+**2. Parse `--raw` and the term in the `search` path of `run()`.** `--raw` is a
+boolean flag that may appear before or after the term, so extract flags first,
+then take the first remaining token as the term:
+
+```js
+case 'search': {
+  const raw = rest.includes('--raw');
+  const term = require_(rest.find((t) => t !== '--raw'), '<query>');
+  return search(services, { query: buildDriveQuery(term, { raw }), max: flags.max });
+}
+```
+
+(`--max` is already consumed upstream into `flags.max`, so it is not among
+`rest`. `--raw` is the only new drive-local token to skip when picking the term.)
+
+`search()` is unchanged — it still does `q: opts.query`.
+
+**3. Tests (`tests/unit/gws-drive.test.js`).** Add cases driving `drive.run` with
+a `list`-spy stub (assert `seen.q`):
+- `run(services, {positionals: ['search', 'budget']})` → `seen.q === "fullText
+  contains 'budget'"`.
+- `run(services, {positionals: ['search', "name contains 'Q3'", '--raw']})` →
+  `seen.q === "name contains 'Q3'"` (verbatim).
+- `run(services, {positionals: ['search', "o'brien"]})` → `seen.q === "fullText
+  contains 'o\\'brien'"` (single-quote escaped) — assert the exact string.
+- `run(services, {positionals: ['search']})` still rejects with `/<query>/`
+  (unchanged require).
+- Keep the existing `drive.search(services, {query: "name contains 'Q3'"})`
+  pass-through test unchanged (proves `search()` did not start wrapping).
+
+## Implementation notes & constraints
+
+- Zero new dependencies; pure string building. No change to `index.js`, to the
+  `read` verb, or to Drive scopes (still `drive.readonly`).
+- Escaping order matters: escape `\` **before** `'` (the code above does).
+- Keep wrapping in `run()`, not `search()`, so `search()` stays a thin pass-through
+  and the existing `search()` unit test stays valid.
+- When uncertain, choose the simpler option and record it under "Decisions made".
+  Do NOT add heuristic "does this look like a query?" detection — the `--raw`
+  flag is the explicit, predictable escape hatch (that is the whole point of
+  choosing (B) over a heuristic).
+
+## Security checklist
+
+- [ ] The user term is interpolated into a Drive **API query string**, not a
+      shell command or a filesystem path. It is single-quote-escaped per Drive
+      query rules (`\` and `'`), so a crafted term cannot break out of the string
+      literal. No `path.join`, no `spawn`, no filesystem write is involved.
+
+## Acceptance criteria
+
+- [ ] `gws drive search <bare term>` searches file contents and returns results
+      instead of an `Invalid Value` error.
+- [ ] `gws drive search --raw '<drive query>'` passes the query to Drive verbatim.
+- [ ] A term containing a single quote is escaped and does not break the query.
+- [ ] The existing `search()` pass-through test is unchanged and passes.
+- [ ] `npm test` and `npm run lint` pass.
+
+## Verification steps (run these; paste output in the PR)
+
+```bash
+npm test -- --test-name-pattern "drive"
+npm test
+npm run lint
+```
+
+## Out of scope (do NOT do these)
+
+- Any change to `gws drive read`, to Drive scopes, or to the write path (there is
+  none — Drive access is read-only).
+- The deps self-heal / doctor probe — WP-102 / WP-103.
+- Heuristic query detection (explicitly rejected in favor of `--raw`).
+
+## Definition of done
+
+1. Owner confirmed the default-behavior change to (B) (2026-07-13).
+2. All verification steps pass locally; output pasted into the PR body.
+3. Branch `wp/104-gws-drive-search-friendly-query`; conventional commits; PR
+   titled `feat(gws): friendly drive search term + --raw escape hatch (WP-104)`.
+4. PR template filled, including "Decisions made" (or "none") and `Generated-by:`.
+5. This spec's `status:` flipped to `In-Review` in the same PR.

--- a/docs/specs/WP-105-sync-interactive-gws-backfill.md
+++ b/docs/specs/WP-105-sync-interactive-gws-backfill.md
@@ -1,0 +1,267 @@
+---
+id: WP-105
+title: sync interactive backfill of the on-demand googleapis install (headless-only users)
+status: Draft
+model: sonnet
+size: S
+depends_on: [WP-102]
+adrs: [ADR-0004, ADR-0011, ADR-0013]
+branch: wp/105-sync-interactive-gws-backfill
+---
+
+# WP-105: sync interactive backfill of the on-demand googleapis install
+
+## Context (read this, nothing else)
+
+`googleapis` (Google's client library) is not bundled: per ADR-0013 the vendored
+app copy carries no `node_modules`, so `googleapis` is installed **on demand,
+once, with consent** into a per-install deps dir `~/.wienerdog/app/deps/`
+(WP-047). `userreports/BUG-gws-deps-missing-after-upgrade.md` documents a
+dead-end: a user who connected Google **before** that scheme has a **valid token**
+but an **absent** `app/deps`, so every `gws` read fails.
+
+**WP-102** fixed the interactive read path: a `gws` read with a valid token but
+absent deps now **self-heals** — `ensureGoogleReady(paths)` runs the same
+consented `ensureGoogleapis` install on first read (interactive: a consent prompt;
+non-TTY: fails with the accurate npm remedy, no worse than today).
+
+**Why this WP exists (Codex Finding 2, owner disposition: ADD BACKFILL).** WP-102
+alone does not help a **headless-only (routines-only) user** — exactly the profile
+this bug hits. Their Google access is used only by scheduled routines (morning
+digest, inbox triage), which run **non-TTY**, where the self-heal **declines the
+consented install by design** (a scheduled job must never block on a prompt). So
+those users never reach an interactive read and their `app/deps` is **never
+populated** — the routines fail indefinitely. The original WP-102 "update-time
+backfill is redundant" rationale was therefore wrong for them.
+
+This WP reinstates a **consented, interactive-only backfill** on the `sync` flow.
+When `sync` runs **with a terminal** (a person typed `wienerdog sync`, or
+`wienerdog init` / `wienerdog update` handed off with the terminal attached) and
+a valid token exists but `app/deps` is absent, it offers the same consented
+install — so a headless-only user's *interactive* maintenance command
+(`sync`/`update`) populates the deps dir that their non-interactive routines then
+use. A **non-TTY** `sync` (CI, a scripted invocation) stays **mutation-free**: no
+prompt, no install.
+
+**Where `sync` sits in the flows.** `wienerdog update` (`src/cli/update.js`)
+downloads + unpacks the new version, then **hands off to the NEW version's `sync`**
+via `spawnSync(node, [newBin, 'sync'], { stdio: 'inherit' })` — so the child
+`sync` inherits the parent's terminal, and an interactive `update` reaches this
+backfill. `wienerdog init` also runs `sync` at the end. `sync` is **never** run by
+the OS scheduler or `run-job` (those run `run-job <name>`), so the interactive gate
+cleanly separates "a person is maintaining the install" (backfill) from "a routine
+is running" (never).
+
+**Product invariants.** Wienerdog is just files (ADR-0004): the backfill runs
+`npm install` synchronously and returns; it starts nothing that outlives the
+command. The install is **consented** (ADR-0011/0013): `ensureGoogleapis` shows
+the exact command and prompts (default yes); a decline fails to a printed remedy.
+The backfill is **best-effort**: a decline or install failure must **never** fail
+`sync`. Zero new runtime dependencies; plain Node ≥ 18; JSDoc types only.
+
+## Current state
+
+**`src/cli/sync.js`** — `run(argv, opts = {})` is the compiler pass. It already
+takes an `opts.loader` scheduler seam. Early on it computes `dryRun` and `paths`,
+then does all writes inside a single `if (!dryRun) { … }` block: vendor the app +
+write the shim, repoint schedules, heal missing scheduler entries, and
+`status.refreshSchedulerStatus(paths)`. The **end** of that block (right after
+`status.refreshSchedulerStatus(paths);`) is the insertion point — `paths` and the
+vendored `app/` already exist by then.
+
+```js
+async function run(argv, opts = {}) {
+  const dryRun = argv.includes('--dry-run');
+  const paths = getPaths();
+  // ... vault check, manifest load ...
+  if (!dryRun) {
+    const { vendorSelf, writeShim } = require('../core/vendor');
+    const v = vendorSelf(paths, { manifest });
+    const shim = writeShim(paths, { manifest });
+    // ... repointSchedules, reloadMissing ...
+    status.refreshSchedulerStatus(paths);
+    // <<< INSERT THE BACKFILL HERE (still inside `if (!dryRun)`) >>>
+  }
+  // ... digest, stageSkills, adapters, manifest save ...
+}
+```
+
+**`ensureGoogleReady(paths, opts)`** (added by WP-102, exported from
+`src/gws/deps.js`): `if (isInstalled(paths)) return; if (!hasToken(paths)) return;
+await ensureGoogleapis(paths, opts);`. It is a **no-op** when already installed or
+when no token exists, and only acts on the exact bug state (valid-token-present +
+deps-absent). With no `opts`, `ensureGoogleapis` uses the real `confirm`
+(`src/core/prompt.js`) and the real npm installer. On a decline / non-TTY it
+throws a `WienerdogError` whose message names the exact `npm install` command.
+
+**`tests/unit/sync-repoint.test.js`** shows the sync test harness: an isolated
+temp core (`mkdirSync` core/state/logs, write `config.yaml`, save a manifest),
+`WIENERDOG_LOADER_NOOP=1` so the default scheduler loaders never spawn, harness
+dirs pointed at absent paths, vault **unset** (so the digest/managed-block steps
+are skipped), and `sync.run(argv)` invoked with `process.env` pointed at the temp
+core (stdout silenced). Reuse this exact setup.
+
+## Deliverables (permission boundary — touch ONLY these)
+
+<!-- Always allowed without listing: this spec file, docs/specs/ROADMAP.md, package-lock.json. -->
+
+| Action | Path | Notes |
+|--------|------|-------|
+| modify | src/cli/sync.js | add two `opts` seams (`interactive`, `ensureGoogleReady`) and the interactive, best-effort backfill call at the end of the `if (!dryRun)` block. |
+| create | tests/unit/sync-gws-backfill.test.js | new test file covering: non-TTY → not called; interactive → called with paths; throw → sync still resolves; dry-run → not called. |
+
+### Exact contracts
+
+**1. Two new `opts` seams on `sync.run(argv, opts)`.** Keep the existing
+`opts.loader`. Add:
+- `opts.interactive` — when provided, overrides the terminal detection (for
+  tests); default is `!!process.stdin.isTTY`.
+- `opts.ensureGoogleReady` — inject the self-heal fn (for tests); default is the
+  real `require('../gws/deps').ensureGoogleReady`.
+
+Update the `run` JSDoc `@param opts` to document both alongside `loader`.
+
+**2. The backfill, at the end of the `if (!dryRun)` block** (immediately after
+`status.refreshSchedulerStatus(paths);`, still inside the block):
+
+```js
+    // Interactive backfill of the on-demand googleapis install (BUG-gws-deps-missing).
+    // A routines-only (headless) user who connected Google before WP-047 never
+    // reaches an interactive read to self-heal — their non-TTY routines decline the
+    // consented install by design, so app/deps is never populated. When a PERSON
+    // runs sync (or update/init hands off with the terminal attached) and a token
+    // exists but the deps dir is absent, offer the same consented install here so
+    // their routines then work. No-op when already installed or unauthed
+    // (ensureGoogleReady handles both). Best-effort: a decline/failure prints a
+    // note and NEVER fails sync. A non-TTY sync stays mutation-free (no prompt, no
+    // install). WP-105.
+    const interactive = opts.interactive !== undefined ? opts.interactive : !!process.stdin.isTTY;
+    if (interactive) {
+      const ensureGoogleReady = opts.ensureGoogleReady || require('../gws/deps').ensureGoogleReady;
+      try {
+        await ensureGoogleReady(paths);
+      } catch (e) {
+        console.log(`wienerdog: Google's client library was not installed — ${e.message}`);
+      }
+    }
+```
+
+Behavior:
+- Non-TTY (`interactive` false) → the whole block is skipped: no prompt, no
+  install, no `ensureGoogleReady` call. `sync` is mutation-free w.r.t. `app/deps`.
+- Interactive + already installed, or interactive + no token → `ensureGoogleReady`
+  is called but no-ops silently (its own guards).
+- Interactive + valid token + deps absent → `ensureGoogleapis` shows the exact
+  command and prompts (default yes). On yes it installs; on decline/failure it
+  throws, which is **caught** and printed as a note — `sync` continues to a normal
+  exit 0.
+- `--dry-run` never reaches this code (it is inside `if (!dryRun)`), so a dry-run
+  makes no prompt and no install.
+
+Do NOT pass any consent `opts` to `ensureGoogleReady` in production — the real
+`confirm` reads the terminal (we already gated on `process.stdin.isTTY`, so
+`confirm`'s `process.stdin.isTTY` branch reads from stdin).
+
+**3. Tests (`tests/unit/sync-gws-backfill.test.js`).** Mirror
+`sync-repoint.test.js`'s hermetic setup (temp core + `config.yaml` with vault
+unset + saved manifest + `WIENERDOG_LOADER_NOOP=1` + absent harness dirs +
+stdout silenced + `process.env` pointed at the temp core and restored in
+`finally`). Drive `sync.run` with the new seams:
+
+- **non-TTY → backfill not called.** `let called = false; await runSync(env,
+  ['sync'], { interactive: false, ensureGoogleReady: async () => { called = true;
+  } }); assert.equal(called, false);`
+- **interactive → backfill called once with `paths`.** `let seen; await
+  runSync(env, ['sync'], { interactive: true, ensureGoogleReady: async (p) => {
+  seen = p; } }); assert.equal(seen.core, paths.core);` (assert on a stable field
+  like `core`).
+- **interactive + backfill throws → `sync` still resolves (exit 0).** `await
+  assert.doesNotReject(() => runSync(env, ['sync'], { interactive: true,
+  ensureGoogleReady: async () => { throw new WienerdogError('declined — run this
+  yourself'); } }));` (a decline must not fail sync). Import `WienerdogError` from
+  `../../src/core/errors`.
+- **dry-run → backfill not called even when interactive.** `let called = false;
+  await runSync(env, ['sync', '--dry-run'], { interactive: true, ensureGoogleReady:
+  async () => { called = true; } }); assert.equal(called, false);`
+
+Extend the local `runSync` helper (copied from `sync-repoint.test.js`) to forward
+an `opts` argument to `sync.run(argv, opts)` (merge in `WIENERDOG_LOADER_NOOP`
+env, silence stdout, restore env in `finally`).
+
+## Implementation notes & constraints
+
+- **Best-effort, never fails sync.** The `try/catch` around `ensureGoogleReady` is
+  load-bearing: a user who declines the install, or a transient npm failure, must
+  still get a successful `sync` (the rest of sync already ran). Print a note; do
+  not rethrow.
+- **Interactive-only is the whole point.** Gate strictly on `process.stdin.isTTY`
+  (overridable by `opts.interactive` for tests). Never prompt or install in a
+  non-TTY `sync`. Do not try to make routines self-heal — they are the consumers
+  of the deps dir this backfill populates, not the installers.
+- **No change to `update.js` or `vendor.js`.** `update` already hands off to the
+  new version's `sync` with `stdio: 'inherit'`, so the terminal reaches this code
+  through `sync`. Do not add a second install site.
+- **Reuse `ensureGoogleReady` (WP-102) as-is.** Do not re-implement the
+  token/installed checks — they live in `ensureGoogleReady`. This WP only decides
+  *when* (interactive) to call it and swallows its throw.
+- Zero new dependencies; no build step. `require('../gws/deps')` lazily inside the
+  block (do not add a top-level gws require to `sync.js`).
+- When uncertain, choose the simpler option and record it under "Decisions made".
+
+## Security checklist
+
+- [ ] No untrusted input. The backfill calls the pre-existing, consented
+      `ensureGoogleReady`/`ensureGoogleapis` (pinned `GOOGLEAPIS_SPEC`,
+      `--ignore-scripts`); no user value is interpolated into the install command.
+      Consent (ADR-0011) is preserved — the terminal prompt still gates the
+      install, and a non-TTY `sync` installs nothing. No process outlives the
+      command (ADR-0004).
+
+## Acceptance criteria
+
+- [ ] An interactive `wienerdog sync` (or `update`/`init` handoff with a terminal)
+      with a valid token but absent `app/deps` prompts to install `googleapis` and,
+      on consent, populates the deps dir — so the user's headless routines then
+      work.
+- [ ] A non-TTY `sync` makes no prompt and no install (mutation-free w.r.t.
+      `app/deps`).
+- [ ] A decline or install failure prints a note and `sync` still exits 0.
+- [ ] `--dry-run` never prompts or installs.
+- [ ] Running `sync` twice after a successful backfill is idempotent (second run:
+      `ensureGoogleReady` no-ops because `isInstalled` is true).
+- [ ] `npm test` and `npm run lint` pass.
+
+## Verification steps (run these; paste output in the PR)
+
+```bash
+npm test -- --test-name-pattern "sync-gws-backfill|sync"
+npm test
+npm run lint
+```
+
+## Out of scope (do NOT do these)
+
+- Any `app/deps` install in `src/cli/update.js` or `src/core/vendor.js` — the
+  handoff to `sync` covers `update`.
+- Making non-TTY routines self-heal (they decline the consented install by design;
+  this backfill is what populates the deps dir for them).
+- The read-path self-heal / disambiguated error (WP-102) and the `doctor` probe
+  (WP-103) — separate WPs.
+
+## Definition of done
+
+1. All verification steps pass locally; output pasted into the PR body.
+2. Branch `wp/105-sync-interactive-gws-backfill`; conventional commits; PR titled
+   `feat(sync): interactive consented backfill of the googleapis deps dir (WP-105)`.
+3. PR template filled, including "Decisions made" (or "none") and `Generated-by:`.
+4. This spec's `status:` flipped to `In-Review` in the same PR.
+
+## Revision log
+
+- **2026-07-13 — created** from Codex round-1 Finding 2 (owner disposition: ADD
+  BACKFILL) on the WP-102/103/104 spec set. Reverses WP-102's original fix-3 "skip":
+  a headless-only user's routines run non-TTY and decline the consented install, so
+  the read-path self-heal never populates their deps dir — an *interactive*
+  `sync`/`update` backfill is the missing piece. Split as its own WP (not folded
+  into WP-102) because it touches `src/cli/sync.js`, a file outside WP-102's
+  already-implemented Deliverables.

--- a/docs/specs/WP-105-sync-interactive-gws-backfill.md
+++ b/docs/specs/WP-105-sync-interactive-gws-backfill.md
@@ -63,26 +63,30 @@ The backfill is **best-effort**: a decline or install failure must **never** fai
 
 **`src/cli/sync.js`** — `run(argv, opts = {})` is the compiler pass. It already
 takes an `opts.loader` scheduler seam. Early on it computes `dryRun` and `paths`,
-then does all writes inside a single `if (!dryRun) { … }` block: vendor the app +
-write the shim, repoint schedules, heal missing scheduler entries, and
-`status.refreshSchedulerStatus(paths)`. The **end** of that block (right after
-`status.refreshSchedulerStatus(paths);`) is the insertion point — `paths` and the
-vendored `app/` already exist by then.
+does all disk mutations (vendor + shim + schedules), renders the digest, stages
+skills, applies adapters, and **finally persists the manifest** as the last
+statement (`if (!dryRun) manifestMod.save(paths, manifest);`) followed by the
+summary `console.log`s.
+
+The backfill MUST go **after** `manifestMod.save` — the very last thing `run()`
+does (Codex round-2 Finding 1). The backfill awaits a consent prompt + `npm
+install`; if it sat between the disk mutations and `manifestMod.save`, a Ctrl-C at
+the prompt or a kill during npm would leave vendor/shim/schedule changes applied
+with their newly recorded manifest entries **unpersisted** — breaking uninstall
+reversibility at a long interactive boundary. The googleapis install is **not**
+manifest-tracked (`app/` is a single `vendored-tree` entry recorded by
+`vendorSelf`), so running it last has zero manifest interaction: an interruption
+then leaves a fully persisted, consistent sync.
 
 ```js
 async function run(argv, opts = {}) {
   const dryRun = argv.includes('--dry-run');
   const paths = getPaths();
-  // ... vault check, manifest load ...
-  if (!dryRun) {
-    const { vendorSelf, writeShim } = require('../core/vendor');
-    const v = vendorSelf(paths, { manifest });
-    const shim = writeShim(paths, { manifest });
-    // ... repointSchedules, reloadMissing ...
-    status.refreshSchedulerStatus(paths);
-    // <<< INSERT THE BACKFILL HERE (still inside `if (!dryRun)`) >>>
-  }
-  // ... digest, stageSkills, adapters, manifest save ...
+  // ... vault check, manifest load, vendor+shim+schedules, digest, skills, adapters ...
+  if (!dryRun) manifestMod.save(paths, manifest);      // <-- manifest persisted here
+  console.log(`wienerdog: ${summary.changed.length} changed, ${summary.unchanged.length} unchanged.`);
+  for (const n of summary.notices) console.log(`  note: ${n}`);
+  // <<< INSERT THE BACKFILL HERE — the FINAL statement of run(), AFTER manifestMod.save >>>
 }
 ```
 
@@ -107,7 +111,7 @@ core (stdout silenced). Reuse this exact setup.
 
 | Action | Path | Notes |
 |--------|------|-------|
-| modify | src/cli/sync.js | add two `opts` seams (`interactive`, `ensureGoogleReady`) and the interactive, best-effort backfill call at the end of the `if (!dryRun)` block. |
+| modify | src/cli/sync.js | add two `opts` seams (`interactive`, `ensureGoogleReady`) and the interactive, best-effort backfill call as the **final statement of `run()`, after `manifestMod.save`**. |
 | create | tests/unit/sync-gws-backfill.test.js | new test file covering: non-TTY → not called; interactive → called with paths; throw → sync still resolves; dry-run → not called. |
 
 ### Exact contracts
@@ -121,42 +125,48 @@ core (stdout silenced). Reuse this exact setup.
 
 Update the `run` JSDoc `@param opts` to document both alongside `loader`.
 
-**2. The backfill, at the end of the `if (!dryRun)` block** (immediately after
-`status.refreshSchedulerStatus(paths);`, still inside the block):
+**2. The backfill — the FINAL statement of `run()`, after `manifestMod.save`**
+(after the summary `console.log`s; gate on `!dryRun` explicitly, since this is no
+longer inside the earlier `if (!dryRun)` block):
 
 ```js
-    // Interactive backfill of the on-demand googleapis install (BUG-gws-deps-missing).
-    // A routines-only (headless) user who connected Google before WP-047 never
-    // reaches an interactive read to self-heal — their non-TTY routines decline the
-    // consented install by design, so app/deps is never populated. When a PERSON
-    // runs sync (or update/init hands off with the terminal attached) and a token
-    // exists but the deps dir is absent, offer the same consented install here so
-    // their routines then work. No-op when already installed or unauthed
-    // (ensureGoogleReady handles both). Best-effort: a decline/failure prints a
-    // note and NEVER fails sync. A non-TTY sync stays mutation-free (no prompt, no
-    // install). WP-105.
-    const interactive = opts.interactive !== undefined ? opts.interactive : !!process.stdin.isTTY;
-    if (interactive) {
-      const ensureGoogleReady = opts.ensureGoogleReady || require('../gws/deps').ensureGoogleReady;
-      try {
-        await ensureGoogleReady(paths);
-      } catch (e) {
-        console.log(`wienerdog: Google's client library was not installed — ${e.message}`);
-      }
+  // Interactive backfill of the on-demand googleapis install (BUG-gws-deps-missing).
+  // A routines-only (headless) user who connected Google before WP-047 never
+  // reaches an interactive read to self-heal — their non-TTY routines decline the
+  // consented install by design, so app/deps is never populated. When a PERSON runs
+  // sync (or update/init hands off with the terminal attached) and a token exists
+  // but the deps dir is absent, offer the same consented install here so their
+  // routines then work. No-op when already installed or unauthed (ensureGoogleReady
+  // handles both). RUN LAST — after manifestMod.save — so a Ctrl-C at the prompt or
+  // a kill during npm leaves a fully persisted, consistent sync (the install is not
+  // manifest-tracked). Best-effort: a decline/failure prints a note and NEVER fails
+  // sync. A non-TTY (or dry-run) sync stays mutation-free (no prompt, no install). WP-105.
+  const interactive = opts.interactive !== undefined ? opts.interactive : !!process.stdin.isTTY;
+  if (!dryRun && interactive) {
+    const ensureGoogleReady = opts.ensureGoogleReady || require('../gws/deps').ensureGoogleReady;
+    try {
+      await ensureGoogleReady(paths);
+    } catch (e) {
+      console.log(`wienerdog: Google's client library was not installed — ${e.message}`);
     }
+  }
 ```
 
 Behavior:
-- Non-TTY (`interactive` false) → the whole block is skipped: no prompt, no
-  install, no `ensureGoogleReady` call. `sync` is mutation-free w.r.t. `app/deps`.
+- Non-TTY (`interactive` false) or `--dry-run` → the block is skipped: no prompt,
+  no install, no `ensureGoogleReady` call. `sync` is mutation-free w.r.t.
+  `app/deps`, and the manifest is already fully persisted regardless.
 - Interactive + already installed, or interactive + no token → `ensureGoogleReady`
   is called but no-ops silently (its own guards).
 - Interactive + valid token + deps absent → `ensureGoogleapis` shows the exact
   command and prompts (default yes). On yes it installs; on decline/failure it
   throws, which is **caught** and printed as a note — `sync` continues to a normal
   exit 0.
-- `--dry-run` never reaches this code (it is inside `if (!dryRun)`), so a dry-run
-  makes no prompt and no install.
+- **Crash-safety:** because the manifest was saved *before* this call, an
+  interruption at the consent prompt or during `npm install` leaves every
+  manifest-tracked mutation (vendor/shim/schedules/skills/hooks) already persisted
+  — uninstall stays reversible. The googleapis install itself is covered by the
+  single `vendored-tree` (`app/`) manifest entry, so nothing new needs recording.
 
 Do NOT pass any consent `opts` to `ensureGoogleReady` in production — the real
 `confirm` reads the terminal (we already gated on `process.stdin.isTTY`, so
@@ -175,11 +185,16 @@ stdout silenced + `process.env` pointed at the temp core and restored in
   runSync(env, ['sync'], { interactive: true, ensureGoogleReady: async (p) => {
   seen = p; } }); assert.equal(seen.core, paths.core);` (assert on a stable field
   like `core`).
-- **interactive + backfill throws → `sync` still resolves (exit 0).** `await
+- **interactive + backfill throws → `sync` still resolves (exit 0) AND the
+  manifest is fully persisted (Finding 1 crash-safety).** `await
   assert.doesNotReject(() => runSync(env, ['sync'], { interactive: true,
   ensureGoogleReady: async () => { throw new WienerdogError('declined — run this
   yourself'); } }));` (a decline must not fail sync). Import `WienerdogError` from
-  `../../src/core/errors`.
+  `../../src/core/errors`. Then assert the manifest was saved **before** the
+  throwing backfill: `assert.ok(fs.existsSync(paths.manifest));` and
+  `const m = manifestLib.load(paths); assert.ok(m.entries.some((e) => e.kind ===
+  'vendored-tree'));` (proves `manifestMod.save` ran, with the vendor mutation
+  recorded, ahead of the backfill). `manifestLib` = `require('../../src/core/manifest')`.
 - **dry-run → backfill not called even when interactive.** `let called = false;
   await runSync(env, ['sync', '--dry-run'], { interactive: true, ensureGoogleReady:
   async () => { called = true; } }); assert.equal(called, false);`
@@ -265,3 +280,13 @@ npm run lint
   `sync`/`update` backfill is the missing piece. Split as its own WP (not folded
   into WP-102) because it touches `src/cli/sync.js`, a file outside WP-102's
   already-implemented Deliverables.
+- **2026-07-13 — Codex round-2 Finding 1 (high).** Moved the backfill from the end
+  of the `if (!dryRun)` block (between the disk mutations and `manifestMod.save`)
+  to the **final statement of `run()`, after `manifestMod.save`**. Sitting before
+  the save meant a Ctrl-C at the consent prompt or a kill during `npm install`
+  would strand vendor/shim/schedule mutations with their manifest entries
+  unpersisted — breaking uninstall reversibility. Running last (the install is not
+  manifest-tracked) leaves a fully persisted, consistent sync on interruption.
+  Gate changed to an explicit `if (!dryRun && interactive)`; added a test asserting
+  the manifest is saved (with the `vendored-tree` entry) even when the backfill
+  throws.


### PR DESCRIPTION
Specs turning the gws post-upgrade dead-end bug (local report `userreports/BUG-gws-deps-missing-after-upgrade.md`, gitignored) into implementation-ready WPs.

- **WP-102** (Ready): read-path self-heal (`ensureGoogleReady`, consented install like first auth) + token-aware `loadGoogleapis` error + regression tests. Report fixes 1+2+5. Update-time backfill (fix 3) deliberately skipped — redundant once reads self-heal.
- **WP-103** (Ready, soft-dep WP-102 for wording only): read-only `doctor` probe — token present + googleapis unresolvable from `app/deps` → warn with the one-line remedy; silent when Google not connected.
- **WP-104** (Ready): `gws drive search` wraps bare terms as `fullText contains '…'`, `--raw` escape hatch. Owner confirmed the default-behavior change (option B, 2026-07-13).
- ROADMAP updated (table, prose block, mermaid).

Verification: `npm run lint` green (195 files, 0 errors; frontmatter check 3 specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MozsEQZ3G3H66VjJ3K8z7