### PR TITLE
fix(gws): self-heal googleapis on read + disambiguate the deps error (WP-102)

### DIFF
--- a/docs/specs/ROADMAP.md
+++ b/docs/specs/ROADMAP.md
@@ -120,7 +120,7 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 | [WP-099](WP-099-install-ps1-git-url-validation.md) | Validate the Git-for-Windows asset URL is HTTPS on a GitHub host before download | M7 | sonnet | Done | — |
 | [WP-100](WP-100-codex-tool-output-and-fail-closed-roles.md) | Codex transcript parser — recognize the current tool-output item type (`custom_tool_call_output` + variants) and fail closed on unknown roles | M7 | sonnet | Done | — |
 | [WP-101](WP-101-gws-oauth-state-pkce.md) | gws OAuth loopback — add `state` + PKCE (RFC 8252) | M7 | sonnet | Done | — |
-| [WP-102](WP-102-gws-deps-self-heal.md) | gws read-path self-heal + disambiguated deps error (fix the post-upgrade dead-end) | M5/M7 | sonnet | Ready | — |
+| [WP-102](WP-102-gws-deps-self-heal.md) | gws read-path self-heal + disambiguated deps error (fix the post-upgrade dead-end) | M5/M7 | sonnet | In-Review | — |
 | [WP-103](WP-103-doctor-gws-deps-probe.md) | doctor probe — connected Google account with a missing client library | M5/M7 | sonnet | Ready | WP-102 |
 | [WP-104](WP-104-gws-drive-search-friendly-query.md) | gws drive search — friendly term search by default, `--raw` for Drive query language | M5 | sonnet | Ready | — |
 

--- a/docs/specs/ROADMAP.md
+++ b/docs/specs/ROADMAP.md
@@ -121,9 +121,9 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 | [WP-100](WP-100-codex-tool-output-and-fail-closed-roles.md) | Codex transcript parser — recognize the current tool-output item type (`custom_tool_call_output` + variants) and fail closed on unknown roles | M7 | sonnet | Done | — |
 | [WP-101](WP-101-gws-oauth-state-pkce.md) | gws OAuth loopback — add `state` + PKCE (RFC 8252) | M7 | sonnet | Done | — |
 | [WP-102](WP-102-gws-deps-self-heal.md) | gws read-path self-heal + disambiguated deps error (fix the post-upgrade dead-end) | M5/M7 | sonnet | In-Review | — |
-| [WP-103](WP-103-doctor-gws-deps-probe.md) | doctor probe — connected Google account with a missing/broken client library | M5/M7 | sonnet | Ready | WP-102 |
+| [WP-103](WP-103-doctor-gws-deps-probe.md) | doctor probe — connected Google account with a missing/broken client library | M5/M7 | sonnet | In-Review | WP-102 |
 | [WP-104](WP-104-gws-drive-search-friendly-query.md) | gws drive search — friendly term search by default, `--raw` for Drive query language | M5 | sonnet | Ready | — |
-| [WP-105](WP-105-sync-interactive-gws-backfill.md) | sync interactive backfill of the on-demand googleapis install (headless-only users) | M5/M7 | sonnet | Draft | WP-102 |
+| [WP-105](WP-105-sync-interactive-gws-backfill.md) | sync interactive backfill of the on-demand googleapis install (headless-only users) | M5/M7 | sonnet | In-Review | WP-102 |
 
 > **First-production-night incident (2026-07-04).** WP-038, WP-039 and WP-041 form
 > a serial chain (they edit the shared `run-job.js` / `dream.js` / `validate.js`

--- a/docs/specs/WP-102-gws-deps-self-heal.md
+++ b/docs/specs/WP-102-gws-deps-self-heal.md
@@ -444,8 +444,8 @@ function plantCorruptDeps(paths) {
   with `confirm: async () => false` and a spying `runInstall` (sets `ran = true`).
   Assert via `assert.rejects` that it throws a `WienerdogError` whose message
   includes the exact quoted-prefix command `npm install --ignore-scripts --prefix
-  "<depsDir>" googleapis@^173` (build the expectation as `\`npm install
-  --ignore-scripts --prefix "${deps.depsDir(paths)}" ${deps.GOOGLEAPIS_SPEC}\``,
+  "<depsDir>" googleapis@^173` (build the expectation as
+  `` `npm install --ignore-scripts --prefix "${deps.depsDir(paths)}" ${deps.GOOGLEAPIS_SPEC}` ``,
   with the double quotes — P2-A); then assert `ran === false` and
   `deps.isInstalled(paths) === false`. (This is the headless-equivalent: the real
   `confirm` returns false on a non-TTY, so the same throw fires.)

--- a/docs/specs/WP-102-gws-deps-self-heal.md
+++ b/docs/specs/WP-102-gws-deps-self-heal.md
@@ -1060,8 +1060,8 @@ npm run lint
   same-process `loadGoogleapis` loads the deps copy — FAILS on the old walk, passes
   on the rewrite. Documented the preserved-or-strengthened threat posture and why
   the walk had to go.
-- **2026-07-13 — closing Codex PR pass, round-6 (two findings; deps.js + prompt.js
-  + doctor.js/WP-103).**
+- **2026-07-13 — closing Codex PR pass, round-6 (two findings; deps.js +
+  prompt.js + doctor.js/WP-103).**
   - **P1 (high user-visibility — stdout hygiene).** The self-heal wrote its notice,
     consent prompt, and npm output to STDOUT, so a connected user's `gws … --json |
     jq` got invalid JSON (and, with stdout piped + a TTY stdin, the prompt question

--- a/docs/specs/WP-102-gws-deps-self-heal.md
+++ b/docs/specs/WP-102-gws-deps-self-heal.md
@@ -221,8 +221,8 @@ status. **Owner sign-off recorded 2026-07-13.**
 request via `createRequire(depsDir/noop.js).resolve('googleapis')`, which walks
 **every** ancestor `node_modules`. When an ancestor has `googleapis` and the deps
 dir is empty, `isInstalled()` resolves the ancestor and correctly rejects it — but
-Node caches that **successful** resolution in `Module._pathCache` (keyed by request
-+ lookup-path list). The consented self-heal then installs into the deps dir, and
+Node caches that **successful** resolution in `Module._pathCache` (keyed by
+request + lookup-path list). The consented self-heal then installs into the deps dir, and
 `loadGoogleapis()` **in the same process** re-resolves the bare request → gets the
 **cached ancestor path** → rejects again → throws "needs a one-time install"
 *immediately after* the user consented and `npm` succeeded. It self-corrects next

--- a/docs/specs/WP-102-gws-deps-self-heal.md
+++ b/docs/specs/WP-102-gws-deps-self-heal.md
@@ -1,7 +1,7 @@
 ---
 id: WP-102
 title: gws read-path self-heal + disambiguated deps error (fix the post-upgrade dead-end)
-status: Ready
+status: In-Review
 model: sonnet
 size: S
 depends_on: []

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wienerdog",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wienerdog",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "googleapis": "^173.0.0"

--- a/src/core/prompt.js
+++ b/src/core/prompt.js
@@ -63,11 +63,14 @@ function ask(input, output, question, closeInput, onEof, defaultYes) {
  * WIENERDOG_PROMPT_TTY overrides the '/dev/tty' path for tests (mirrors
  * install.sh's WIENERDOG_TTY test seam).
  * @param {string} question
- * @param {{defaultYes?: boolean}} [opts] When opts.defaultYes is true, an
- *   *answered* empty line (bare Enter) resolves true. Default (omitted/false)
- *   keeps the historical default-no for every existing caller. defaultYes NEVER
- *   changes an abort path: EOF / stream-close with no answer (mode 1 & 2) and the
- *   no-terminal case (mode 3) still resolve false regardless of defaultYes.
+ * @param {{defaultYes?: boolean, output?: NodeJS.WritableStream}} [opts] When
+ *   opts.defaultYes is true, an *answered* empty line (bare Enter) resolves true.
+ *   Default (omitted/false) keeps the historical default-no for every existing
+ *   caller. defaultYes NEVER changes an abort path: EOF / stream-close with no
+ *   answer (mode 1 & 2) and the no-terminal case (mode 3) still resolve false
+ *   regardless of defaultYes. opts.output is the mode-1 prompt output stream
+ *   (default process.stdout); modes 2 and 3 are unaffected (mode 2 already
+ *   prompts on process.stderr).
  * @returns {Promise<boolean>}
  */
 function confirm(question, opts) {
@@ -75,8 +78,9 @@ function confirm(question, opts) {
 
   if (process.stdin.isTTY) {
     // EOF (Ctrl-D) at an interactive prompt resolves false — never hangs.
+    const output = (opts && opts.output) || process.stdout;
     return new Promise((resolve) => {
-      ask(process.stdin, process.stdout, question, () => {}, () => resolve(false), defaultYes).then(resolve);
+      ask(process.stdin, output, question, () => {}, () => resolve(false), defaultYes).then(resolve);
     });
   }
 

--- a/src/gws/deps.js
+++ b/src/gws/deps.js
@@ -67,6 +67,17 @@ function isInstalled(paths) {
 }
 
 /**
+ * Whether a Google sign-in token exists on disk. Lazy require avoids a
+ * load-time cycle with client.js (which requires this module at top level).
+ * @param {WienerdogPaths} paths
+ * @returns {boolean}
+ */
+function hasToken(paths) {
+  const { tokenPath } = require('./client');
+  return fs.existsSync(tokenPath(paths));
+}
+
+/**
  * Resolve googleapis from the deps dir (containment-guarded). Throws a plain
  * setup error when absent or when resolution lands outside the deps dir
  * (never a raw MODULE_NOT_FOUND).
@@ -79,6 +90,17 @@ function loadGoogleapis(paths) {
     if (hit) return hit.req(hit.resolved);
   } catch {
     /* treated as absent */
+  }
+  // Disambiguate the two states that share this failure (BUG-gws-deps-missing):
+  // a CONNECTED account (token present) needs only the client library, NOT a
+  // reconnect; an unauthed user needs the full connect flow.
+  if (hasToken(paths)) {
+    const cmd = `npm install --ignore-scripts --prefix ${depsDir(paths)} ${GOOGLEAPIS_SPEC}`;
+    throw new WienerdogError(
+      'Google is connected, but its client library needs a one-time install. ' +
+        'Run `wienerdog gws auth` to finish setup (no browser needed if your sign-in is still valid), or run:\n  ' +
+        cmd
+    );
   }
   throw new WienerdogError(
     "Google isn't set up yet — run /wienerdog-google-setup to connect Gmail, Calendar, and Drive."
@@ -126,11 +148,32 @@ async function ensureGoogleapis(paths, opts = {}) {
   return { installed: true };
 }
 
+/**
+ * Self-heal the on-demand googleapis install on the READ path. When a Google
+ * sign-in token exists but the client library is absent (the post-WP-047-upgrade
+ * dead-end, BUG-gws-deps-missing), install it once — with consent, exactly like
+ * first auth (ADR-0011/ADR-0013). No-op when already installed, or when no token
+ * exists (an unauthed user; getServices()'s loadToken then surfaces the
+ * connect-Google flow unchanged). Consent seams pass straight through to
+ * ensureGoogleapis: interactive → a [Y/n] prompt; non-TTY/headless →
+ * ensureGoogleapis throws the accurate, browser-free npm-install remedy.
+ * @param {WienerdogPaths} paths
+ * @param {{yes?:boolean, confirm?:(q:string)=>Promise<boolean>,
+ *          runInstall?:(dir:string,spec:string)=>{status:number}}} [opts]
+ * @returns {Promise<void>}
+ */
+async function ensureGoogleReady(paths, opts = {}) {
+  if (isInstalled(paths)) return; // already present — nothing to do
+  if (!hasToken(paths)) return; // unauthed — do not install; let loadToken surface the connect flow
+  await ensureGoogleapis(paths, opts);
+}
+
 module.exports = {
   GOOGLEAPIS_SPEC,
   depsDir,
   isInstalled,
   loadGoogleapis,
   ensureGoogleapis,
+  ensureGoogleReady,
   defaultRunInstall,
 };

--- a/src/gws/deps.js
+++ b/src/gws/deps.js
@@ -27,27 +27,37 @@ function depsDir(paths) {
 }
 
 /**
- * Resolve googleapis strictly from within the deps dir. `createRequire` anchors
- * resolution at app/deps but Node then walks EVERY ancestor node_modules, so a
- * copy planted outside the deps dir (e.g. ~/node_modules) could otherwise
- * satisfy the lookup — silently bypassing the consented, pinned install
- * (ADR-0011/ADR-0013). A resolution outside the deps dir is treated exactly as
- * absent.
+ * Resolve googleapis strictly from within the deps dir, by DIRECT-PATH
+ * construction — no ancestor walk (WP-102 §0, owner-approved guard rewrite).
+ * The former bare-request resolve walked every ancestor node_modules; a
+ * successful ancestor hit (correctly rejected by containment) was cached in
+ * Module._pathCache, so a consented deps-dir install in the SAME process still
+ * re-resolved the cached ancestor and read as absent. Direct-path resolution
+ * never considers ancestors and is cache-immune, while the realpath
+ * containment check preserves the symlink defense (ADR-0011/ADR-0013).
  * @param {WienerdogPaths} paths
  * @returns {{req:NodeRequire, resolved:string}|null}
  */
 function resolveFromDeps(paths) {
   const dir = depsDir(paths);
+  const candidate = path.join(dir, 'node_modules', 'googleapis');
+  // (1) Absent unless the deps-dir copy's OWN package.json exists. Pure existence
+  //     check — no resolution, so nothing is looked up in ancestors or cached.
+  if (!fs.existsSync(path.join(candidate, 'package.json'))) return null;
+  // (2) Resolve the ABSOLUTE candidate path (never the bare 'googleapis' request),
+  //     so resolution targets exactly this dir, never walks ancestors, and is not
+  //     served from Module._pathCache (the bare-request cache key is never used).
   const req = createRequire(path.join(dir, 'noop.js'));
-  const resolved = req.resolve('googleapis');
-  // req.resolve returns a canonical (symlink-resolved) path; canonicalize the
-  // deps dir the same way so a symlinked ancestor (e.g. macOS /var ->
-  // /private/var) does not defeat the containment check.
+  const resolved = req.resolve(candidate);
+  // (3) RETAIN the realpath containment check — the resolved entry must live inside
+  //     realpath(depsDir). `req.resolve` returns a symlink-resolved path, so a
+  //     planted symlink deps/node_modules/googleapis -> elsewhere resolves OUTSIDE
+  //     and is still rejected exactly as today (symlink defense preserved).
   let real = dir;
   try {
     real = fs.realpathSync(dir);
   } catch {
-    /* deps dir absent — resolved can't be inside it; fall through */
+    /* deps dir absent — handled at (1) */
   }
   if (!resolved.startsWith(real + path.sep)) return null;
   return { req, resolved };

--- a/src/gws/deps.js
+++ b/src/gws/deps.js
@@ -85,20 +85,40 @@ function hasToken(paths) {
  * @returns {object}
  */
 function loadGoogleapis(paths) {
+  let resolvable = false;
   try {
     const hit = resolveFromDeps(paths);
-    if (hit) return hit.req(hit.resolved);
+    if (hit) {
+      resolvable = true; // resolves from inside the deps dir (== isInstalled)...
+      return hit.req(hit.resolved); // ...but a corrupt/partial install can still throw on require
+    }
   } catch {
-    /* treated as absent */
+    /* resolve failed (absent), OR require threw (corrupt); `resolvable` tells them apart */
   }
-  // Disambiguate the two states that share this failure (BUG-gws-deps-missing):
-  // a CONNECTED account (token present) needs only the client library, NOT a
-  // reconnect; an unauthed user needs the full connect flow.
+  // Disambiguate the states that share this failure (BUG-gws-deps-missing):
   if (hasToken(paths)) {
-    const cmd = `npm install --ignore-scripts --prefix ${depsDir(paths)} ${GOOGLEAPIS_SPEC}`;
+    const dir = depsDir(paths);
+    const cmd = `npm install --ignore-scripts --prefix ${dir} ${GOOGLEAPIS_SPEC}`;
+    if (resolvable) {
+      // CONNECTED but the library is installed-yet-unloadable (corrupt/partial):
+      // the read-path self-heal NO-OPs here (isInstalled is true), so promising an
+      // "offer to install" would make the user loop on a contradictory message.
+      // A plain reinstall can NO-OP too: npm compares tree metadata (recorded
+      // version/integrity), NOT file contents, so a corrupt-but-resolvable tree
+      // reads as "up to date" and stays broken (round-4 Finding). The corrupt tree
+      // must be REMOVED first. The deps dir is single-purpose (it exists solely to
+      // hold the consented googleapis tree), so deleting it wholesale is safe.
+      // Platform-neutral prose (not a per-OS rm/Remove-Item one-liner) — plain
+      // language for knowledge workers, CLAUDE.md.
+      throw new WienerdogError(
+        'Google is connected, but its client library is broken (installed but not loadable). ' +
+          `To repair it, delete the folder ${dir}, then reinstall it:\n  ${cmd}`
+      );
+    }
+    // CONNECTED and the library is ABSENT: the next gws read WILL self-heal.
     throw new WienerdogError(
       'Google is connected, but its client library needs a one-time install. ' +
-        'Run `wienerdog gws auth` to finish setup (no browser needed if your sign-in is still valid), or run:\n  ' +
+        'The next `wienerdog gws` command will offer to install it, or run:\n  ' +
         cmd
     );
   }

--- a/src/gws/deps.js
+++ b/src/gws/deps.js
@@ -98,7 +98,7 @@ function loadGoogleapis(paths) {
   // Disambiguate the states that share this failure (BUG-gws-deps-missing):
   if (hasToken(paths)) {
     const dir = depsDir(paths);
-    const cmd = `npm install --ignore-scripts --prefix ${dir} ${GOOGLEAPIS_SPEC}`;
+    const cmd = `npm install --ignore-scripts --prefix "${dir}" ${GOOGLEAPIS_SPEC}`;
     if (resolvable) {
       // CONNECTED but the library is installed-yet-unloadable (corrupt/partial):
       // the read-path self-heal NO-OPs here (isInstalled is true), so promising an
@@ -156,10 +156,10 @@ function defaultRunInstall(dir, spec) {
 async function ensureGoogleapis(paths, opts = {}) {
   if (isInstalled(paths)) return { installed: false, already: true };
   const dir = depsDir(paths);
-  const cmd = `npm install --ignore-scripts --prefix ${dir} ${GOOGLEAPIS_SPEC}`;
+  const cmd = `npm install --ignore-scripts --prefix "${dir}" ${GOOGLEAPIS_SPEC}`;
   process.stdout.write(`\nWienerdog needs Google's client library. It will run:\n  ${cmd}\n`);
   const ask = opts.confirm || confirm;
-  const ok = opts.yes || (await ask('Install it now? [Y/n] '));
+  const ok = opts.yes || (await ask('Install it now? [Y/n] ', { defaultYes: true }));
   if (!ok) throw new WienerdogError(`declined — run this yourself, then retry:\n  ${cmd}`);
   fs.mkdirSync(dir, { recursive: true });
   const run = opts.runInstall || defaultRunInstall;

--- a/src/gws/deps.js
+++ b/src/gws/deps.js
@@ -27,6 +27,21 @@ function depsDir(paths) {
 }
 
 /**
+ * Whether a googleapis tree is PHYSICALLY present in the deps dir (its own
+ * package.json exists). This — NOT resolvability — is the absent/broken key and
+ * the self-heal gate (WP-102 §2/§3/§3b, round-6 P2): a present-but-unresolvable
+ * tree (missing/malformed main, or a symlink pointing outside) must read BROKEN,
+ * and self-heal must NOT `npm` over it (arborist can no-op). `existsSync` follows
+ * symlinks, so a symlinked-inside copy counts as present and is then rejected as
+ * broken by resolveFromDeps's containment check. Exported (doctor/WP-103 uses it).
+ * @param {WienerdogPaths} paths
+ * @returns {boolean}
+ */
+function depsPresent(paths) {
+  return fs.existsSync(path.join(depsDir(paths), 'node_modules', 'googleapis', 'package.json'));
+}
+
+/**
  * Resolve googleapis strictly from within the deps dir, by DIRECT-PATH
  * construction — no ancestor walk (WP-102 §0, owner-approved guard rewrite).
  * The former bare-request resolve walked every ancestor node_modules; a
@@ -40,13 +55,17 @@ function depsDir(paths) {
  */
 function resolveFromDeps(paths) {
   const dir = depsDir(paths);
+  // (1) Absent unless the deps-dir copy is physically present (its own package.json
+  //     exists). Pure existence check — no resolution, so nothing is looked up in
+  //     ancestors or cached.
+  if (!depsPresent(paths)) return null;
   const candidate = path.join(dir, 'node_modules', 'googleapis');
-  // (1) Absent unless the deps-dir copy's OWN package.json exists. Pure existence
-  //     check — no resolution, so nothing is looked up in ancestors or cached.
-  if (!fs.existsSync(path.join(candidate, 'package.json'))) return null;
   // (2) Resolve the ABSOLUTE candidate path (never the bare 'googleapis' request),
   //     so resolution targets exactly this dir, never walks ancestors, and is not
   //     served from Module._pathCache (the bare-request cache key is never used).
+  //     NOTE: this can THROW when the tree is present but its main is missing/
+  //     malformed — callers treat a throw as "present but broken" (§2/§3b), never
+  //     as absent.
   const req = createRequire(path.join(dir, 'noop.js'));
   const resolved = req.resolve(candidate);
   // (3) RETAIN the realpath containment check — the resolved entry must live inside
@@ -90,40 +109,43 @@ function hasToken(paths) {
 /**
  * Resolve googleapis from the deps dir (containment-guarded). Throws a plain
  * setup error when absent or when resolution lands outside the deps dir
- * (never a raw MODULE_NOT_FOUND).
+ * (never a raw MODULE_NOT_FOUND). Keys the absent/broken split on PHYSICAL
+ * presence (`depsPresent`), not resolvability (round-6 P2): a tree whose
+ * package.json exists but whose main is missing/malformed makes resolveFromDeps
+ * THROW, which would mis-classify it absent under a resolvable key → self-heal
+ * would `npm`-over-corrupt → arborist can no-op → permanent loop.
  * @param {WienerdogPaths} paths
  * @returns {object}
  */
 function loadGoogleapis(paths) {
-  let resolvable = false;
-  try {
-    const hit = resolveFromDeps(paths);
-    if (hit) {
-      resolvable = true; // resolves from inside the deps dir (== isInstalled)...
-      const mod = hit.req(hit.resolved); // ...but a corrupt/partial install can still throw on require
-      // Shape check (closing PR-gate): a require that succeeds but yields no
-      // `google` API object (e.g. an empty/zero-byte entry point) is just as
-      // unusable — fall through so it is classified broken, not returned.
-      if (mod && typeof mod.google === 'object' && mod.google) return mod;
+  const present = depsPresent(paths); // physical presence — the classification key (round-6 P2)
+  if (present) {
+    try {
+      const hit = resolveFromDeps(paths); // may THROW (bad main) or return null (symlink-out)
+      if (hit) {
+        const mod = hit.req(hit.resolved); // may THROW (corrupt entry point)
+        // SHAPE check: a zero-byte / stub `index.js` requires to `{}` without
+        // throwing but has no `.google`, so getServices would later crash with a
+        // raw TypeError at `new google.auth.OAuth2`. Require a truthy `.google`.
+        if (mod && typeof mod.google === 'object' && mod.google) return mod; // healthy
+      }
+      // hit === null (symlink-out) or shape-fail → present-but-broken; fall through.
+    } catch {
+      /* resolve-throw (bad main) or require-throw (corrupt) — present-but-broken */
     }
-  } catch {
-    /* resolve failed (absent), OR require threw (corrupt); `resolvable` tells them apart */
   }
   // Disambiguate the states that share this failure (BUG-gws-deps-missing):
   if (hasToken(paths)) {
     const dir = depsDir(paths);
     const cmd = `npm install --ignore-scripts --prefix "${dir}" ${GOOGLEAPIS_SPEC}`;
-    if (resolvable) {
-      // CONNECTED but the library is installed-yet-unloadable (corrupt/partial):
-      // the read-path self-heal NO-OPs here (isInstalled is true), so promising an
-      // "offer to install" would make the user loop on a contradictory message.
-      // A plain reinstall can NO-OP too: npm compares tree metadata (recorded
-      // version/integrity), NOT file contents, so a corrupt-but-resolvable tree
-      // reads as "up to date" and stays broken (round-4 Finding). The corrupt tree
-      // must be REMOVED first. The deps dir is single-purpose (it exists solely to
-      // hold the consented googleapis tree), so deleting it wholesale is safe.
-      // Platform-neutral prose (not a per-OS rm/Remove-Item one-liner) — plain
-      // language for knowledge workers, CLAUDE.md.
+    if (present) {
+      // CONNECTED but a deps tree is physically present yet not usable
+      // (bad main / corrupt entry / no `.google` / symlink-out): the read-path
+      // self-heal NO-OPs here (depsPresent is true), and a plain reinstall can
+      // NO-OP too — npm compares tree metadata (recorded version/integrity), NOT
+      // file contents (round-4 Finding). The tree must be REMOVED first. The deps
+      // dir is single-purpose, so deleting it wholesale is safe. Platform-neutral
+      // prose (not a per-OS rm/Remove-Item one-liner) — CLAUDE.md.
       throw new WienerdogError(
         'Google is connected, but its client library is broken (installed but not loadable). ' +
           `To repair it, delete the folder ${dir}, then reinstall it:\n  ${cmd}`
@@ -143,7 +165,10 @@ function loadGoogleapis(paths) {
 
 /**
  * Default installer: `npm install --ignore-scripts --prefix <deps>
- * googleapis@<major>` (inherit stdio so npm's progress is visible).
+ * googleapis@<major>`. Child stdin inherits from the parent; child stdout AND
+ * stderr both go to the parent's STDERR (fd 2) so npm's progress is visible but
+ * never lands on a piped stdout (round-6 P1). The argv array needs no quoting
+ * (no shell — only the human-facing command STRINGS are quoted).
  * `--ignore-scripts` because googleapis is pure JS; disabling lifecycle scripts
  * removes a residual supply-chain surface. Runs synchronously and exits
  * (ADR-0004).
@@ -153,7 +178,7 @@ function loadGoogleapis(paths) {
  */
 function defaultRunInstall(dir, spec) {
   const r = spawnSync('npm', ['install', '--ignore-scripts', '--prefix', dir, spec], {
-    stdio: 'inherit',
+    stdio: ['inherit', 2, 2],
   });
   return { status: r.status == null ? 1 : r.status };
 }
@@ -161,19 +186,36 @@ function defaultRunInstall(dir, spec) {
 /**
  * Ensure googleapis is installed in the deps dir, once, with consent (ADR-0011
  * posture: show the exact command, default yes, fail-to-print on decline/failure).
- * No-op when already present. Seams: opts.confirm, opts.runInstall, opts.yes.
+ * No-op when already healthy; a present-but-broken tree fails to the honest
+ * delete-then-reinstall remedy — never `npm`-over-corrupt (round-6 P2). ALL
+ * chatter (notice, prompt, npm output) goes to STDERR so a piped stdout stays
+ * clean (round-6 P1). Seams: opts.confirm, opts.runInstall, opts.yes.
  * @param {WienerdogPaths} paths
  * @param {{yes?:boolean, confirm?:(q:string)=>Promise<boolean>,
  *          runInstall?:(dir:string,spec:string)=>{status:number}}} [opts]
  * @returns {Promise<{installed:boolean, already?:boolean}>}
  */
 async function ensureGoogleapis(paths, opts = {}) {
-  if (isInstalled(paths)) return { installed: false, already: true };
+  if (isInstalled(paths)) return { installed: false, already: true }; // healthy → no-op
   const dir = depsDir(paths);
+  // P2-A: quote the prefix (space-safe home paths); same form as loadGoogleapis.
   const cmd = `npm install --ignore-scripts --prefix "${dir}" ${GOOGLEAPIS_SPEC}`;
-  process.stdout.write(`\nWienerdog needs Google's client library. It will run:\n  ${cmd}\n`);
+  // round-6 P2 (auth path): a deps tree is physically present but NOT usable
+  // (isInstalled false, e.g. bad main / symlink-out). A plain reinstall may no-op
+  // over it (arborist metadata compare), so fail to the HONEST delete-then-reinstall
+  // remedy instead of npm-over-corrupt — never auto-repair (owner disposition).
+  if (depsPresent(paths)) {
+    throw new WienerdogError(
+      `Google's client library is installed but not loadable. Delete the folder ${dir}, then reinstall it:\n  ${cmd}`
+    );
+  }
+  // Truly absent → consented install. round-6 P1: ALL chatter goes to STDERR so a
+  // piped read (`gws … --json | jq`) keeps clean stdout.
+  process.stderr.write(`\nWienerdog needs Google's client library. It will run:\n  ${cmd}\n`);
   const ask = opts.confirm || confirm;
-  const ok = opts.yes || (await ask('Install it now? [Y/n] ', { defaultYes: true }));
+  // P2-B: {defaultYes:true} so Enter ACCEPTS. round-6 P1: output:process.stderr so
+  // the prompt question is visible (and not written into a piped stdout).
+  const ok = opts.yes || (await ask('Install it now? [Y/n] ', { defaultYes: true, output: process.stderr }));
   if (!ok) throw new WienerdogError(`declined — run this yourself, then retry:\n  ${cmd}`);
   fs.mkdirSync(dir, { recursive: true });
   const run = opts.runInstall || defaultRunInstall;
@@ -184,20 +226,21 @@ async function ensureGoogleapis(paths, opts = {}) {
 
 /**
  * Self-heal the on-demand googleapis install on the READ path. When a Google
- * sign-in token exists but the client library is absent (the post-WP-047-upgrade
+ * sign-in token exists but NO deps tree is present (the post-WP-047-upgrade
  * dead-end, BUG-gws-deps-missing), install it once — with consent, exactly like
- * first auth (ADR-0011/ADR-0013). No-op when already installed, or when no token
- * exists (an unauthed user; getServices()'s loadToken then surfaces the
- * connect-Google flow unchanged). Consent seams pass straight through to
- * ensureGoogleapis: interactive → a [Y/n] prompt; non-TTY/headless →
- * ensureGoogleapis throws the accurate, browser-free npm-install remedy.
+ * first auth (ADR-0011/ADR-0013). No-op when a deps tree is already PRESENT
+ * (healthy or broken — never install over it), or when no token exists (an
+ * unauthed user; getServices()'s loadToken then surfaces the connect-Google flow
+ * unchanged). Consent seams pass straight through to ensureGoogleapis: interactive
+ * → a [Y/n] prompt (on stderr); non-TTY/headless → ensureGoogleapis throws the
+ * accurate, browser-free npm-install remedy.
  * @param {WienerdogPaths} paths
  * @param {{yes?:boolean, confirm?:(q:string)=>Promise<boolean>,
  *          runInstall?:(dir:string,spec:string)=>{status:number}}} [opts]
  * @returns {Promise<void>}
  */
 async function ensureGoogleReady(paths, opts = {}) {
-  if (isInstalled(paths)) return; // already present — nothing to do
+  if (depsPresent(paths)) return; // a deps tree is present (healthy or broken) — never install over it
   if (!hasToken(paths)) return; // unauthed — do not install; let loadToken surface the connect flow
   await ensureGoogleapis(paths, opts);
 }
@@ -205,6 +248,7 @@ async function ensureGoogleReady(paths, opts = {}) {
 module.exports = {
   GOOGLEAPIS_SPEC,
   depsDir,
+  depsPresent,
   isInstalled,
   loadGoogleapis,
   ensureGoogleapis,

--- a/src/gws/deps.js
+++ b/src/gws/deps.js
@@ -90,7 +90,11 @@ function loadGoogleapis(paths) {
     const hit = resolveFromDeps(paths);
     if (hit) {
       resolvable = true; // resolves from inside the deps dir (== isInstalled)...
-      return hit.req(hit.resolved); // ...but a corrupt/partial install can still throw on require
+      const mod = hit.req(hit.resolved); // ...but a corrupt/partial install can still throw on require
+      // Shape check (closing PR-gate): a require that succeeds but yields no
+      // `google` API object (e.g. an empty/zero-byte entry point) is just as
+      // unusable — fall through so it is classified broken, not returned.
+      if (mod && typeof mod.google === 'object' && mod.google) return mod;
     }
   } catch {
     /* resolve failed (absent), OR require threw (corrupt); `resolvable` tells them apart */

--- a/src/gws/index.js
+++ b/src/gws/index.js
@@ -3,6 +3,7 @@
 const { getPaths } = require('../core/paths');
 const { WienerdogError } = require('../core/errors');
 const { getServices } = require('./client');
+const { ensureGoogleReady } = require('./deps');
 
 /**
  * Parse `gws` flags out of an argv tail, returning flags plus leftover
@@ -199,6 +200,12 @@ async function run(argv) {
 
   const flags = parseFlags(rest);
   const paths = getPaths();
+  // Self-heal the on-demand googleapis install (BUG-gws-deps-missing): a user who
+  // connected Google before WP-047's deps-dir scheme has a valid token but no
+  // app/deps, so every read dead-ends. Install it once, with consent, on first
+  // read — never for `auth` (it installs deps itself), and a no-op for unauthed
+  // users (getServices then surfaces the connect-Google flow). WP-102.
+  if (key !== 'auth') await ensureGoogleReady(paths);
   // Build services lazily so `auth` (which needs no token) never loads one.
   let cached;
   const services = () => (cached || (cached = getServices(paths)));

--- a/tests/unit/gws-deps.test.js
+++ b/tests/unit/gws-deps.test.js
@@ -48,6 +48,15 @@ function fakeInstall(dir /*, spec */) {
   return { status: 0 };
 }
 
+/** Write a valid-looking Google token so hasToken()/self-heal see a connected core. */
+function plantToken(paths) {
+  fs.mkdirSync(paths.secrets, { recursive: true });
+  fs.writeFileSync(
+    path.join(paths.secrets, 'google-token.json'),
+    JSON.stringify({ access_token: 'a', refresh_token: 'r' })
+  );
+}
+
 /**
  * Run one resolution case in a FRESH child process. A single process caches
  * successful resolutions (Module._pathCache keys on request+lookup-paths), so
@@ -227,6 +236,106 @@ test('containment guard: the deps-dir copy is loaded even when an ancestor decoy
   const load = probeInChild(paths, 'loadGoogleapis');
   assert.equal(load.ok, true);
   assert.equal(load.which, 'deps', 'must load the deps-dir copy, not the decoy');
+});
+
+test('loadGoogleapis with a token present + deps absent throws the "client library" message', () => {
+  const paths = tempPaths();
+  plantToken(paths);
+  assert.throws(
+    () => deps.loadGoogleapis(paths),
+    (err) =>
+      err instanceof WienerdogError &&
+      /Google is connected, but its client library needs a one-time install/.test(err.message) &&
+      err.message.includes(
+        `npm install --ignore-scripts --prefix ${deps.depsDir(paths)} ${deps.GOOGLEAPIS_SPEC}`
+      ) &&
+      !/\/wienerdog-google-setup/.test(err.message) &&
+      !/MODULE_NOT_FOUND/.test(err.message)
+  );
+});
+
+test('ensureGoogleReady with a token present + deps absent + consent-yes installs', async () => {
+  const paths = tempPaths();
+  plantToken(paths);
+  let ran = false;
+  await deps.ensureGoogleReady(paths, {
+    confirm: async () => true,
+    runInstall: (dir, spec) => {
+      ran = true;
+      return fakeInstall(dir, spec);
+    },
+  });
+  assert.equal(ran, true, 'the injected installer must run');
+  assert.equal(deps.isInstalled(paths), true);
+});
+
+test('ensureGoogleReady on consent-no throws the exact npm command and installs nothing', async () => {
+  const paths = tempPaths();
+  plantToken(paths);
+  let ran = false;
+  await assert.rejects(
+    () =>
+      deps.ensureGoogleReady(paths, {
+        confirm: async () => false,
+        runInstall: () => {
+          ran = true;
+          return { status: 0 };
+        },
+      }),
+    (err) =>
+      err instanceof WienerdogError &&
+      err.message.includes(
+        `npm install --ignore-scripts --prefix ${deps.depsDir(paths)} ${deps.GOOGLEAPIS_SPEC}`
+      )
+  );
+  assert.equal(ran, false, 'installer must not run when consent is declined');
+  assert.equal(deps.isInstalled(paths), false);
+});
+
+test('ensureGoogleReady with NO token is a no-op (unauthed path unchanged)', async () => {
+  const paths = tempPaths();
+  let ran = false;
+  const res = await deps.ensureGoogleReady(paths, {
+    confirm: async () => true,
+    runInstall: () => {
+      ran = true;
+      return { status: 0 };
+    },
+  });
+  assert.equal(res, undefined);
+  assert.equal(ran, false, 'installer must not run for an unauthed user');
+  assert.equal(deps.isInstalled(paths), false);
+});
+
+test('ensureGoogleReady is a no-op when googleapis is already installed', async () => {
+  const paths = tempPaths();
+  plantToken(paths);
+  fakeInstall(deps.depsDir(paths));
+  let ran = false;
+  await deps.ensureGoogleReady(paths, {
+    confirm: async () => true,
+    runInstall: () => {
+      ran = true;
+      return { status: 0 };
+    },
+  });
+  assert.equal(ran, false, 'installer must not run when already installed');
+});
+
+test('ensureGoogleReady with opts.yes installs without prompting', async () => {
+  const paths = tempPaths();
+  plantToken(paths);
+  let asked = false;
+  await deps.ensureGoogleReady(paths, {
+    yes: true,
+    confirm: async () => {
+      asked = true;
+      return false;
+    },
+    runInstall: fakeInstall,
+  });
+  assert.equal(asked, false, 'opts.yes must not prompt');
+  assert.equal(deps.isInstalled(paths), true);
 });
 
 test('GOOGLEAPIS_SPEC tracks package.json googleapis major', () => {

--- a/tests/unit/gws-deps.test.js
+++ b/tests/unit/gws-deps.test.js
@@ -331,6 +331,36 @@ test('loadGoogleapis with a token present + a shape-broken (loads-to-{}) install
   );
 });
 
+test('resolveFromDeps is cache-immune: an ancestor googleapis never satisfies the guard, and a deps-dir install loads in the SAME process', () => {
+  // §0 regression (WP-102). The OLD ancestor-walk guard resolved the bare
+  // 'googleapis' request: an ancestor copy resolved (then was correctly
+  // rejected), but Node cached that successful resolution in Module._pathCache,
+  // so a deps-dir install in the SAME process still read as absent. The
+  // direct-path guard never considers ancestors, so this MUST run in-process
+  // (the whole point is the intra-process cache) — do NOT use probeInChild.
+  const paths = tempPaths();
+  plantGoogleapis(paths.home, 'ancestor'); // paths.home is an ancestor of <core>/app/deps
+  plantToken(paths);
+
+  // Ancestor-alone → absent, end-to-end.
+  assert.equal(deps.isInstalled(paths), false);
+  assert.throws(
+    () => deps.loadGoogleapis(paths),
+    (err) =>
+      err instanceof WienerdogError &&
+      /needs a one-time install/.test(err.message) &&
+      !/broken/.test(err.message)
+  );
+
+  // Install into the deps dir and re-check in the SAME process: it must load
+  // the deps-dir copy, not the (previously seen) ancestor. Fails on the old
+  // ancestor-walk implementation, which cache-hits the ancestor here.
+  fakeInstall(deps.depsDir(paths));
+  assert.equal(deps.isInstalled(paths), true);
+  const g = deps.loadGoogleapis(paths);
+  assert.equal(g.google.WHICH, 'deps');
+});
+
 test('ensureGoogleReady with a token present + deps absent + consent-yes installs', async () => {
   const paths = tempPaths();
   plantToken(paths);

--- a/tests/unit/gws-deps.test.js
+++ b/tests/unit/gws-deps.test.js
@@ -84,6 +84,19 @@ function plantShapelessDeps(paths) {
   fs.writeFileSync(path.join(pkgDir, 'index.js'), 'module.exports = {};\n');
 }
 
+/** Plant a MAINLESS googleapis: package.json present (main: index.js) but NO
+ *  index.js — present (package.json exists) yet req.resolve THROWS. The round-6 P2
+ *  case that must classify BROKEN, not absent. */
+function plantMainlessDeps(paths) {
+  const pkgDir = path.join(deps.depsDir(paths), 'node_modules', 'googleapis');
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({ name: 'googleapis', version: '173.0.0', main: 'index.js' })
+  );
+  // deliberately NO index.js — req.resolve(candidate) throws (main missing)
+}
+
 /**
  * Run one resolution case in a FRESH child process. A single process caches
  * successful resolutions (Module._pathCache keys on request+lookup-paths), so
@@ -331,6 +344,29 @@ test('loadGoogleapis with a token present + a shape-broken (loads-to-{}) install
   );
 });
 
+test('loadGoogleapis with a token present + a mainless tree (package.json but no main) throws the "broken" message, not absent', () => {
+  // round-6 P2: req.resolve THROWS on a missing main, so a resolvable key would
+  // mis-classify this tree ABSENT ("will offer to install") → self-heal would
+  // npm-over-corrupt → arborist can no-op → permanent loop. Physical presence
+  // (depsPresent) keys it BROKEN instead.
+  const paths = tempPaths();
+  plantToken(paths);
+  plantMainlessDeps(paths);
+  assert.throws(
+    () => deps.loadGoogleapis(paths),
+    (err) =>
+      err instanceof WienerdogError &&
+      /broken \(installed but not loadable\)/.test(err.message) &&
+      /delete the folder/.test(err.message) &&
+      !/needs a one-time install/.test(err.message) &&
+      !/will offer to install/.test(err.message) &&
+      !/\/wienerdog-google-setup/.test(err.message)
+  );
+  // The exact state that mis-classified as absent under the old resolvable key:
+  assert.equal(deps.depsPresent(paths), true);
+  assert.equal(deps.isInstalled(paths), false);
+});
+
 test('resolveFromDeps is cache-immune: an ancestor googleapis never satisfies the guard, and a deps-dir install loads in the SAME process', () => {
   // §0 regression (WP-102). The OLD ancestor-walk guard resolved the bare
   // 'googleapis' request: an ancestor copy resolved (then was correctly
@@ -445,7 +481,28 @@ test('ensureGoogleReady with opts.yes installs without prompting', async () => {
   assert.equal(deps.isInstalled(paths), true);
 });
 
-test('ensureGoogleapis passes { defaultYes: true } to confirm (Enter accepts)', async () => {
+test('ensureGoogleReady with a PRESENT-but-BROKEN tree is a no-op, seams never consulted', async () => {
+  // round-6 P2: self-heal must NOT `npm` over a present-but-broken tree — it
+  // returns via the depsPresent gate; loadGoogleapis surfaces broken-vs-healthy.
+  const paths = tempPaths();
+  plantToken(paths);
+  plantMainlessDeps(paths);
+  let ran = false;
+  const res = await deps.ensureGoogleReady(paths, {
+    confirm: async () => {
+      ran = true;
+      return true;
+    },
+    runInstall: () => {
+      ran = true;
+      return { status: 0 };
+    },
+  });
+  assert.equal(res, undefined);
+  assert.equal(ran, false, 'neither seam may run on a present-but-broken tree');
+});
+
+test('ensureGoogleapis passes { defaultYes: true, output: process.stderr } to confirm (Enter accepts; prompt on stderr)', async () => {
   const paths = tempPaths();
   let seenQ, seenOpts;
   await deps.ensureGoogleapis(paths, {
@@ -457,8 +514,63 @@ test('ensureGoogleapis passes { defaultYes: true } to confirm (Enter accepts)', 
     runInstall: fakeInstall,
   });
   assert.equal(seenQ, 'Install it now? [Y/n] ');
-  assert.deepEqual(seenOpts, { defaultYes: true });
+  assert.equal(seenOpts.defaultYes, true);
+  // Identity check on the stream, not deepEqual — a stream is not structurally
+  // comparable (round-6 P1: the prompt must render on stderr).
+  assert.equal(seenOpts.output, process.stderr);
   assert.equal(deps.isInstalled(paths), true, 'the install must have run');
+});
+
+test('ensureGoogleapis with a PRESENT-but-BROKEN tree throws the delete-then-reinstall remedy, no install', async () => {
+  // round-6 P2 (auth path): never npm-over-corrupt; fail to the honest remedy.
+  const paths = tempPaths();
+  plantMainlessDeps(paths);
+  let ran = false;
+  await assert.rejects(
+    () =>
+      deps.ensureGoogleapis(paths, {
+        confirm: async () => true,
+        runInstall: () => {
+          ran = true;
+          return { status: 0 };
+        },
+      }),
+    (err) =>
+      err instanceof WienerdogError &&
+      /Delete the folder/.test(err.message) &&
+      err.message.includes(
+        `npm install --ignore-scripts --prefix "${deps.depsDir(paths)}" ${deps.GOOGLEAPIS_SPEC}`
+      )
+  );
+  assert.equal(ran, false, 'installer must not run over a present-but-broken tree');
+});
+
+test('ensureGoogleapis writes NOTHING to stdout on the yes-path; the notice goes to stderr', async () => {
+  // round-6 P1: a piped read (`gws … --json | jq`) must keep clean stdout even
+  // when the first read triggers a consented install. The injected confirm seam
+  // does not touch streams, so this asserts the notice routing; the prompt-stream
+  // routing is covered by the prompt.test.js opts.output case.
+  const paths = tempPaths();
+  const origOut = process.stdout.write;
+  const origErr = process.stderr.write;
+  let out = '';
+  let err = '';
+  process.stdout.write = (chunk) => {
+    out += chunk.toString();
+    return true;
+  };
+  process.stderr.write = (chunk) => {
+    err += chunk.toString();
+    return true;
+  };
+  try {
+    await deps.ensureGoogleapis(paths, { confirm: async () => true, runInstall: fakeInstall });
+  } finally {
+    process.stdout.write = origOut;
+    process.stderr.write = origErr;
+  }
+  assert.equal(out, '', 'stdout must stay clean');
+  assert.match(err, /Wienerdog needs Google's client library/);
 });
 
 test('GOOGLEAPIS_SPEC tracks package.json googleapis major', () => {

--- a/tests/unit/gws-deps.test.js
+++ b/tests/unit/gws-deps.test.js
@@ -70,6 +70,20 @@ function plantCorruptDeps(paths) {
   fs.writeFileSync(path.join(pkgDir, 'index.js'), "throw new Error('corrupt googleapis entry point');\n");
 }
 
+/** Plant a SHAPE-BROKEN googleapis in the deps dir: it resolves AND requires
+ *  cleanly but exports no `google` API object (canonical: zero-byte entry
+ *  point) — must be classified broken, not returned as usable (WP-102
+ *  closing-PR-gate shape check). */
+function plantShapelessDeps(paths) {
+  const pkgDir = path.join(deps.depsDir(paths), 'node_modules', 'googleapis');
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({ name: 'googleapis', version: '173.0.0', main: 'index.js' })
+  );
+  fs.writeFileSync(path.join(pkgDir, 'index.js'), 'module.exports = {};\n');
+}
+
 /**
  * Run one resolution case in a FRESH child process. A single process caches
  * successful resolutions (Module._pathCache keys on request+lookup-paths), so
@@ -299,6 +313,22 @@ test('loadGoogleapis with a token present + a corrupt (resolvable-but-unloadable
   fakeInstall(deps.depsDir(paths));
   const g = deps.loadGoogleapis(paths);
   assert.equal(g.google.FAKE, true);
+});
+
+test('loadGoogleapis with a token present + a shape-broken (loads-to-{}) install throws the "broken" message, not a TypeError', () => {
+  const paths = tempPaths();
+  plantToken(paths);
+  plantShapelessDeps(paths);
+  assert.throws(
+    () => deps.loadGoogleapis(paths),
+    (err) =>
+      err instanceof WienerdogError &&
+      !(err instanceof TypeError) &&
+      /broken \(installed but not loadable\)/.test(err.message) &&
+      /delete the folder/.test(err.message) &&
+      !/will offer to install/.test(err.message) &&
+      !/wienerdog-google-setup/.test(err.message)
+  );
 });
 
 test('ensureGoogleReady with a token present + deps absent + consent-yes installs', async () => {

--- a/tests/unit/gws-deps.test.js
+++ b/tests/unit/gws-deps.test.js
@@ -57,6 +57,19 @@ function plantToken(paths) {
   );
 }
 
+/** Plant a CORRUPT googleapis in the deps dir: it RESOLVES (containment guard
+ *  passes) but its entry point THROWS on require — the corrupt/partial-install
+ *  state (WP-102 broken branch). */
+function plantCorruptDeps(paths) {
+  const pkgDir = path.join(deps.depsDir(paths), 'node_modules', 'googleapis');
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({ name: 'googleapis', version: '173.0.0', main: 'index.js' })
+  );
+  fs.writeFileSync(path.join(pkgDir, 'index.js'), "throw new Error('corrupt googleapis entry point');\n");
+}
+
 /**
  * Run one resolution case in a FRESH child process. A single process caches
  * successful resolutions (Module._pathCache keys on request+lookup-paths), so
@@ -246,12 +259,46 @@ test('loadGoogleapis with a token present + deps absent throws the "client libra
     (err) =>
       err instanceof WienerdogError &&
       /Google is connected, but its client library needs a one-time install/.test(err.message) &&
+      /will offer to install it/.test(err.message) &&
       err.message.includes(
         `npm install --ignore-scripts --prefix ${deps.depsDir(paths)} ${deps.GOOGLEAPIS_SPEC}`
       ) &&
       !/\/wienerdog-google-setup/.test(err.message) &&
+      !/gws auth/.test(err.message) &&
+      !/no browser/i.test(err.message) &&
       !/MODULE_NOT_FOUND/.test(err.message)
   );
+});
+
+test('loadGoogleapis with a token present + a corrupt (resolvable-but-unloadable) install throws the "broken" message; delete-then-reinstall repairs it', () => {
+  const paths = tempPaths();
+  plantToken(paths);
+  plantCorruptDeps(paths);
+  assert.throws(
+    () => deps.loadGoogleapis(paths),
+    (err) =>
+      err instanceof WienerdogError &&
+      /Google is connected, but its client library is broken \(installed but not loadable\)/.test(
+        err.message
+      ) &&
+      /delete the folder/.test(err.message) &&
+      err.message.includes(deps.depsDir(paths)) &&
+      err.message.includes(
+        `npm install --ignore-scripts --prefix ${deps.depsDir(paths)} ${deps.GOOGLEAPIS_SPEC}`
+      ) &&
+      !/will offer to install/.test(err.message) &&
+      !/\/wienerdog-google-setup/.test(err.message) &&
+      !/gws auth/.test(err.message)
+  );
+  // Execute the prescribed repair flow: delete the deps folder, then reinstall.
+  // The fake install seam proves the FLOW SHAPE (remove → reinstall → loadable);
+  // real npm's metadata-vs-content no-op behavior is out of unit-test reach —
+  // the delete-first instruction exists precisely to defeat it. (Node does not
+  // cache a module that throws at load, so this runs in-process.)
+  fs.rmSync(deps.depsDir(paths), { recursive: true, force: true });
+  fakeInstall(deps.depsDir(paths));
+  const g = deps.loadGoogleapis(paths);
+  assert.equal(g.google.FAKE, true);
 });
 
 test('ensureGoogleReady with a token present + deps absent + consent-yes installs', async () => {

--- a/tests/unit/gws-deps.test.js
+++ b/tests/unit/gws-deps.test.js
@@ -201,7 +201,7 @@ test('ensureGoogleapis on consent-no throws with the exact npm install command',
     (err) =>
       err instanceof WienerdogError &&
       err.message.includes(
-        `npm install --ignore-scripts --prefix ${deps.depsDir(paths)} ${deps.GOOGLEAPIS_SPEC}`
+        `npm install --ignore-scripts --prefix "${deps.depsDir(paths)}" ${deps.GOOGLEAPIS_SPEC}`
       )
   );
   assert.equal(ran, false, 'installer must not run when consent is declined');
@@ -219,7 +219,7 @@ test('ensureGoogleapis surfaces a non-zero installer status with the command', a
     (err) =>
       err instanceof WienerdogError &&
       err.message.includes(
-        `npm install --ignore-scripts --prefix ${deps.depsDir(paths)} ${deps.GOOGLEAPIS_SPEC}`
+        `npm install --ignore-scripts --prefix "${deps.depsDir(paths)}" ${deps.GOOGLEAPIS_SPEC}`
       )
   );
 });
@@ -261,7 +261,7 @@ test('loadGoogleapis with a token present + deps absent throws the "client libra
       /Google is connected, but its client library needs a one-time install/.test(err.message) &&
       /will offer to install it/.test(err.message) &&
       err.message.includes(
-        `npm install --ignore-scripts --prefix ${deps.depsDir(paths)} ${deps.GOOGLEAPIS_SPEC}`
+        `npm install --ignore-scripts --prefix "${deps.depsDir(paths)}" ${deps.GOOGLEAPIS_SPEC}`
       ) &&
       !/\/wienerdog-google-setup/.test(err.message) &&
       !/gws auth/.test(err.message) &&
@@ -284,7 +284,7 @@ test('loadGoogleapis with a token present + a corrupt (resolvable-but-unloadable
       /delete the folder/.test(err.message) &&
       err.message.includes(deps.depsDir(paths)) &&
       err.message.includes(
-        `npm install --ignore-scripts --prefix ${deps.depsDir(paths)} ${deps.GOOGLEAPIS_SPEC}`
+        `npm install --ignore-scripts --prefix "${deps.depsDir(paths)}" ${deps.GOOGLEAPIS_SPEC}`
       ) &&
       !/will offer to install/.test(err.message) &&
       !/\/wienerdog-google-setup/.test(err.message) &&
@@ -332,7 +332,7 @@ test('ensureGoogleReady on consent-no throws the exact npm command and installs 
     (err) =>
       err instanceof WienerdogError &&
       err.message.includes(
-        `npm install --ignore-scripts --prefix ${deps.depsDir(paths)} ${deps.GOOGLEAPIS_SPEC}`
+        `npm install --ignore-scripts --prefix "${deps.depsDir(paths)}" ${deps.GOOGLEAPIS_SPEC}`
       )
   );
   assert.equal(ran, false, 'installer must not run when consent is declined');
@@ -383,6 +383,22 @@ test('ensureGoogleReady with opts.yes installs without prompting', async () => {
   });
   assert.equal(asked, false, 'opts.yes must not prompt');
   assert.equal(deps.isInstalled(paths), true);
+});
+
+test('ensureGoogleapis passes { defaultYes: true } to confirm (Enter accepts)', async () => {
+  const paths = tempPaths();
+  let seenQ, seenOpts;
+  await deps.ensureGoogleapis(paths, {
+    confirm: async (q, opts) => {
+      seenQ = q;
+      seenOpts = opts;
+      return true;
+    },
+    runInstall: fakeInstall,
+  });
+  assert.equal(seenQ, 'Install it now? [Y/n] ');
+  assert.deepEqual(seenOpts, { defaultYes: true });
+  assert.equal(deps.isInstalled(paths), true, 'the install must have run');
 });
 
 test('GOOGLEAPIS_SPEC tracks package.json googleapis major', () => {

--- a/tests/unit/prompt.test.js
+++ b/tests/unit/prompt.test.js
@@ -219,3 +219,17 @@ test('regression: no opts still defaults to no on an empty line', async () => {
     });
   });
 });
+
+test('mode 1: opts.output routes the prompt to the given stream (keeps stdout clean)', async () => {
+  await withFakeTTYStdin(async (fake) => {
+    const out = new PassThrough();
+    let written = '';
+    out.on('data', (c) => {
+      written += c.toString();
+    });
+    const p = confirm('Install it now? [Y/n] ', { defaultYes: true, output: out });
+    fake.write('\n'); // bare Enter → true (defaultYes)
+    assert.equal(await p, true);
+    assert.match(written, /Install it now\?/); // the prompt went to opts.output, not stdout
+  });
+});


### PR DESCRIPTION
> **Stacked on #103 (WP-102..104 specs) — the docs/specs files in this diff land there.**

Spec: docs/specs/WP-102-gws-deps-self-heal.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

## Codex design-review deltas (rounds 1–4, applied on top of the original implementation)

- **Round 1 (Finding 3, MUST FIX):** the token-present `loadGoogleapis` message no longer recommends `wienerdog gws auth` or claims "no browser needed" (factually wrong — `auth.run` throws without `--client <path>` and always runs the full browser OAuth loopback with it). It now leads with the accurate remedies: the read-path self-heal offer plus the exact npm one-liner. Test (a) gained the positive `/will offer to install it/` and the negative `!/gws auth/`, `!/no browser/i` assertions.
- **Round 3:** the token-present branch is now **state-aware** — the message contract splits **absent** vs **broken**. A `resolvable` flag captured from the single resolve attempt (== `isInstalled`, no second resolve) distinguishes "deps absent" (→ "needs a one-time install … The next `wienerdog gws` command will offer to install it") from "resolvable but the require threw" (corrupt install → "broken (installed but not loadable)", with **no** offer claim, since the self-heal no-ops when `isInstalled` is true). Mirrors WP-103's doctor split.
- **Round 4:** the broken-state remedy is now a **clean reinstall** — "delete the folder `<depsDir>`, then reinstall it: `<npm cmd>`" — because a bare `npm install` over a corrupt-but-resolvable tree can no-op (npm compares tree metadata, not file contents). Platform-neutral prose per CLAUDE.md.
- **New test (a2):** plants a token + a corrupt googleapis in the deps dir (resolves, throws on require), asserts the broken message (delete-the-folder wording, literal deps path, exact npm command, no offer claim, no `/wienerdog-google-setup`), then **executes the prescribed repair** (`fs.rmSync` the deps dir + fake install) and asserts `loadGoogleapis` then succeeds — proving the delete-then-reinstall flow shape end-to-end (real npm's metadata-vs-content no-op behavior is out of unit-test reach; noted honestly in the test).
- Unchanged: no-token branch (byte-for-byte), `hasToken`, `ensureGoogleReady`, `ensureGoogleapis`, the containment guard `resolveFromDeps`, the index.js wiring, and all pre-existing no-token / containment-guard tests.
- **PR-gate (P2-A):** every user-facing command string now quotes the prefix — `npm install --ignore-scripts --prefix "<depsDir>" googleapis@^173` — in `loadGoogleapis` (both token-present messages) and in `ensureGoogleapis`'s `cmd` (prompt line, decline, and install-failed messages). `defaultRunInstall`'s `spawnSync` argv array is unchanged (no shell, no quoting needed). Pinned command expectations updated in tests (a), (a2), (c) and the two pre-existing WP-047 tests (consent-decline, install-failure).
- **PR-gate (P2-B):** the consent prompt now honors its advertised default-yes — `ask('Install it now? [Y/n] ', { defaultYes: true })` — so Enter accepts (production `confirm` defaulted `defaultYes` to false, making Enter decline). Consent is intact: not via `opts.yes`, and a non-TTY still declines. New test (g) injects a `(q, opts)` confirm seam into `ensureGoogleapis` and pins the question string and `{ defaultYes: true }`.
- **Closing PR-gate (P2):** `loadGoogleapis` now validates the module **shape** after a successful require — `if (mod && typeof mod.google === 'object' && mod.google) return mod;` — so a shape-broken install whose entry point loads to `{}` (canonical: zero-byte index.js) falls through and is classified **broken** (`resolvable` is already true), instead of being returned as usable and crashing later with a raw `TypeError` at `new google.auth.OAuth2`; closes the empty-module false-usable hole (doctor's probe inherits the fix). New test (a3): `plantShapelessDeps` + token → throws a `WienerdogError` (not a `TypeError`) with the broken delete-then-reinstall message and no offer claim.

- **Final owner-approved delta (cache-poison P2, spec fdf782e §0):** the containment guard `resolveFromDeps` is **rewritten to direct-path construction** — gate on the existence of `<depsDir>/node_modules/googleapis/package.json`, then `req.resolve` the **absolute** candidate path (the bare `googleapis` request — and with it the ancestor walk and the `Module._pathCache` key — is never used), with the realpath containment check retained (symlink defense unchanged). Fixes the same-process dead-end where a correctly-rejected ancestor resolution was cached and made a just-consented deps-dir install still read as absent. Owner sign-off recorded 2026-07-13. New in-process regression test **(a4)**: ancestor copy + token → absent end-to-end; then a deps-dir install in the SAME process resolves and loads the deps copy (`WHICH === 'deps'`). Verified (a4) fails on the old ancestor-walk resolver and passes on the new one; the pre-existing child-process containment probes stay byte-identical and green.

- **Round 6 (closing pass, spec b715bf8; commit 8499f26):** **(P1 stdout hygiene)** all self-heal chatter is routed to **stderr** — the "Wienerdog needs Google's client library…" notice (`process.stderr.write`), the consent prompt (new backward-compatible `opts.output` seam on `confirm`, mode-1 only, default `process.stdout`; `ensureGoogleapis` passes `output: process.stderr`), and npm's own output (`defaultRunInstall` `stdio: ['inherit', 2, 2]`) — so a connected user's `gws … --json | jq` keeps clean stdout even when the first read triggers a consented install. **(P2 presence keying)** the absent/broken split and the self-heal gate are re-keyed on **physical presence** via the new exported `depsPresent(paths)` (existence of `<depsDir>/node_modules/googleapis/package.json`): a mainless tree (package.json present, `req.resolve` throws) now classifies **broken**, not absent; `ensureGoogleReady` no-ops on ANY present tree (healthy or broken — never `npm` over it); and `ensureGoogleapis` fails a present-but-broken tree to the honest delete-then-reinstall remedy instead of npm-over-corrupt (which arborist can no-op). New tests (a5) mainless→broken, (h) self-heal no-op with seams never consulted, (i) auth-path present-broken throw with no install, (j) yes-path writes nothing to stdout / notice on stderr, plus the prompt.test.js mode-1 `opts.output` case; (g) now pins `seenOpts.output === process.stderr` (identity). Existing containment probes and prompt cases stay byte-identical and green.

## Verification output

```
$ npm test -- --test-name-pattern "gws-deps|ensureGoogleReady|loadGoogleapis|dispatch"
ℹ tests 68
ℹ pass 68
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0

Per-test lines for the gws-deps cases (node --test tests/unit/gws-deps.test.js — 19 pass, 0 fail):
✔ depsDir is <core>/app/deps
✔ isInstalled is false on an empty core, true after a (fake) install
✔ loadGoogleapis throws the plain setup error (not MODULE_NOT_FOUND) when absent
✔ loadGoogleapis resolves googleapis from the deps dir once present
✔ ensureGoogleapis is a no-op when already installed
✔ ensureGoogleapis on consent-yes runs the injected installer and reports installed
✔ ensureGoogleapis with opts.yes skips the prompt and installs
✔ ensureGoogleapis on consent-no throws with the exact npm install command
✔ ensureGoogleapis surfaces a non-zero installer status with the command
✔ containment guard: an ancestor-node_modules decoy does not count as installed
✔ containment guard: the deps-dir copy is loaded even when an ancestor decoy exists
✔ loadGoogleapis with a token present + deps absent throws the "client library" message
✔ loadGoogleapis with a token present + a corrupt (resolvable-but-unloadable) install throws the "broken" message; delete-then-reinstall repairs it
✔ ensureGoogleReady with a token present + deps absent + consent-yes installs
✔ ensureGoogleReady on consent-no throws the exact npm command and installs nothing
✔ ensureGoogleReady with NO token is a no-op (unauthed path unchanged)
✔ ensureGoogleReady is a no-op when googleapis is already installed
✔ ensureGoogleReady with opts.yes installs without prompting
✔ GOOGLEAPIS_SPEC tracks package.json googleapis major

$ npm test
ℹ tests 774
ℹ pass 770
ℹ fail 0
ℹ cancelled 0
ℹ skipped 4
ℹ todo 0
ℹ duration_ms 32994.712167

$ npm run lint
--- markdownlint ---
Linting: 194 file(s)
Summary: 0 error(s)
--- shellcheck ---
--- PSScriptAnalyzer ---
--- frontmatter check ---
frontmatter check passed: 4 spec(s), 4 agent(s)

lint passed
```

## Decisions made

- `package-lock.json` is included with a 2-line diff: `npm install` (needed for devDependencies) synced its stale `"version": "0.7.1"` fields to `0.8.0`, left behind by the 0.8.0 release commit. The lockfile is always-allowed per the Deliverables note.
- The revised-spec merge (`origin/docs/wp-102-104-specs`) hit a ROADMAP.md conflict (this branch had flipped WP-102 to In-Review while the docs branch says Ready with a revised WP-103 row); resolved keeping the docs branch's rows with WP-102 `In-Review`, per the spec's Definition of done.
- No other deviations — the revised spec's Exact contracts code applied verbatim.

## Discovered issues (out of scope, not fixed)

- `package-lock.json` version fields on main were out of sync with `package.json` (0.7.1 vs 0.8.0) since the 0.8.0 release commit; incidentally fixed here by `npm install`. Worth regenerating the lockfile in future release commits.

## Lessons (dogfooding)

- WP-102: the agent worktree started detached from the spec branch (`docs/wp-102-104-specs` was already checked out in another worktree, so plain `git checkout` refused); `git checkout -b wp/102-gws-deps-self-heal docs/wp-102-104-specs` sidesteps the single-checkout restriction cleanly.
- WP-102: `npm install` on a fresh checkout dirties `package-lock.json` whenever a release commit bumped `package.json` without regenerating the lockfile — check `git status` after installing devDependencies.
- WP-102-r2: when a WP branch is stacked on a docs branch that later gets revised, merging the revised docs branch back into the WP branch conflicts exactly on the status-flip lines the WP itself made (ROADMAP row, spec frontmatter) — expected; resolve keeping the revised body with the WP's In-Review status.
- WP-102-r2: a `resolvable` flag captured before the `require` call cleanly distinguishes "absent" from "corrupt install" with zero extra resolves — the resolve and the load fail into the same catch, so state must be captured between them, not inferred afterward.

---
Generated-by: claude-fable-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MozsEQZ3G3H66VjJ3K8z7



