### PR TITLE
feat(sync): interactive consented backfill of the googleapis deps dir (WP-105)

### DIFF
--- a/docs/specs/ROADMAP.md
+++ b/docs/specs/ROADMAP.md
@@ -121,7 +121,7 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 | [WP-100](WP-100-codex-tool-output-and-fail-closed-roles.md) | Codex transcript parser — recognize the current tool-output item type (`custom_tool_call_output` + variants) and fail closed on unknown roles | M7 | sonnet | Done | — |
 | [WP-101](WP-101-gws-oauth-state-pkce.md) | gws OAuth loopback — add `state` + PKCE (RFC 8252) | M7 | sonnet | Done | — |
 | [WP-102](WP-102-gws-deps-self-heal.md) | gws read-path self-heal + disambiguated deps error (fix the post-upgrade dead-end) | M5/M7 | sonnet | In-Review | — |
-| [WP-103](WP-103-doctor-gws-deps-probe.md) | doctor probe — connected Google account with a missing/broken client library | M5/M7 | sonnet | Ready | WP-102 |
+| [WP-103](WP-103-doctor-gws-deps-probe.md) | doctor probe — connected Google account with a missing/broken client library | M5/M7 | sonnet | In-Review | WP-102 |
 | [WP-104](WP-104-gws-drive-search-friendly-query.md) | gws drive search — friendly term search by default, `--raw` for Drive query language | M5 | sonnet | Ready | — |
 | [WP-105](WP-105-sync-interactive-gws-backfill.md) | sync interactive backfill of the on-demand googleapis install (headless-only users) | M5/M7 | sonnet | In-Review | WP-102 |
 

--- a/docs/specs/ROADMAP.md
+++ b/docs/specs/ROADMAP.md
@@ -123,7 +123,7 @@ Milestone acceptance criteria are binding; WPs are the unit of implementation. S
 | [WP-102](WP-102-gws-deps-self-heal.md) | gws read-path self-heal + disambiguated deps error (fix the post-upgrade dead-end) | M5/M7 | sonnet | In-Review | — |
 | [WP-103](WP-103-doctor-gws-deps-probe.md) | doctor probe — connected Google account with a missing/broken client library | M5/M7 | sonnet | Ready | WP-102 |
 | [WP-104](WP-104-gws-drive-search-friendly-query.md) | gws drive search — friendly term search by default, `--raw` for Drive query language | M5 | sonnet | Ready | — |
-| [WP-105](WP-105-sync-interactive-gws-backfill.md) | sync interactive backfill of the on-demand googleapis install (headless-only users) | M5/M7 | sonnet | Draft | WP-102 |
+| [WP-105](WP-105-sync-interactive-gws-backfill.md) | sync interactive backfill of the on-demand googleapis install (headless-only users) | M5/M7 | sonnet | In-Review | WP-102 |
 
 > **First-production-night incident (2026-07-04).** WP-038, WP-039 and WP-041 form
 > a serial chain (they edit the shared `run-job.js` / `dream.js` / `validate.js`

--- a/docs/specs/WP-105-sync-interactive-gws-backfill.md
+++ b/docs/specs/WP-105-sync-interactive-gws-backfill.md
@@ -1,7 +1,7 @@
 ---
 id: WP-105
 title: sync interactive backfill of the on-demand googleapis install (headless-only users)
-status: Draft
+status: In-Review
 model: sonnet
 size: S
 depends_on: [WP-102]

--- a/src/cli/sync.js
+++ b/src/cli/sync.js
@@ -120,7 +120,12 @@ function stageSkills(paths, dryRun, manifest, out) {
  * adapter (Claude Code in this WP). Idempotent and manifest-tracked; a second
  * run with unchanged inputs makes zero changes.
  * @param {string[]} argv
- * @param {{loader?: (argv:string[])=>{status:number}}} [opts]  scheduler loader seam
+ * @param {{loader?: (argv:string[])=>{status:number},
+ *          interactive?: boolean,
+ *          ensureGoogleReady?: (paths:import('../core/paths').WienerdogPaths)=>Promise<void>}} [opts]
+ *   `loader`: scheduler loader seam. `interactive`: overrides terminal detection
+ *   (tests); default `!!process.stdin.isTTY`. `ensureGoogleReady`: inject the
+ *   googleapis self-heal fn (tests); default `require('../gws/deps').ensureGoogleReady`.
  * @returns {Promise<void>}
  */
 async function run(argv, opts = {}) {
@@ -238,6 +243,27 @@ async function run(argv, opts = {}) {
     `wienerdog: ${summary.changed.length} changed, ${summary.unchanged.length} unchanged.`
   );
   for (const n of summary.notices) console.log(`  note: ${n}`);
+
+  // Interactive backfill of the on-demand googleapis install (BUG-gws-deps-missing).
+  // A routines-only (headless) user who connected Google before WP-047 never
+  // reaches an interactive read to self-heal — their non-TTY routines decline the
+  // consented install by design, so app/deps is never populated. When a PERSON runs
+  // sync (or update/init hands off with the terminal attached) and a token exists
+  // but the deps dir is absent, offer the same consented install here so their
+  // routines then work. No-op when already installed or unauthed (ensureGoogleReady
+  // handles both). RUN LAST — after manifestMod.save — so a Ctrl-C at the prompt or
+  // a kill during npm leaves a fully persisted, consistent sync (the install is not
+  // manifest-tracked). Best-effort: a decline/failure prints a note and NEVER fails
+  // sync. A non-TTY (or dry-run) sync stays mutation-free (no prompt, no install). WP-105.
+  const interactive = opts.interactive !== undefined ? opts.interactive : !!process.stdin.isTTY;
+  if (!dryRun && interactive) {
+    const ensureGoogleReady = opts.ensureGoogleReady || require('../gws/deps').ensureGoogleReady;
+    try {
+      await ensureGoogleReady(paths);
+    } catch (e) {
+      console.log(`wienerdog: Google's client library was not installed — ${e.message}`);
+    }
+  }
 }
 
 module.exports = { run };

--- a/tests/unit/sync-gws-backfill.test.js
+++ b/tests/unit/sync-gws-backfill.test.js
@@ -1,0 +1,158 @@
+'use strict';
+
+// WP-105: `sync` ends with a consented, interactive-only backfill of the
+// on-demand googleapis install (BUG-gws-deps-missing) — the deps dir a
+// headless-only user's routines consume but can never populate themselves.
+// Fully hermetic: temp HOME + WIENERDOG_HOME, WIENERDOG_LOADER_NOOP=1 so the
+// default loaders never spawn launchctl/systemctl, harnesses pointed at absent
+// dirs, no vault (skips digest), no network. The backfill itself is injected
+// via the opts.ensureGoogleReady seam — no prompt, no npm.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const { getPaths } = require('../../src/core/paths');
+const { WienerdogError } = require('../../src/core/errors');
+const manifestLib = require('../../src/core/manifest');
+const sync = require('../../src/cli/sync');
+
+// Hermeticity: CI sets XDG_CONFIG_HOME to the real ~/.config, which
+// systemdUserDir() prefers over $HOME. Unset it (this file runs in its own
+// `node --test` process) so systemd units resolve under the temp HOME, never a
+// real dir — and so parallel test files never collide on a shared unit path.
+delete process.env.XDG_CONFIG_HOME;
+
+/** @param {string} c @returns {string} */
+function sha256(c) {
+  return crypto.createHash('sha256').update(c).digest('hex');
+}
+
+// Vault UNSET → sync skips the digest + managed block but still vendors and
+// reaches the final backfill. Harness dirs are set to absent paths in the env.
+const BASE_CONFIG = `# Wienerdog configuration
+version: 1
+vault:
+harnesses:
+  claude: true
+  codex: false
+memory_mode: standard
+`;
+
+/** Isolated temp core with config + matching manifest + absent harness dirs. */
+function setup() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-gws-backfill-'));
+  const env = {
+    HOME: root,
+    WIENERDOG_HOME: path.join(root, 'wd'),
+    CLAUDE_CONFIG_DIR: path.join(root, 'absent-claude'),
+    CODEX_HOME: path.join(root, 'absent-codex'),
+  };
+  const paths = getPaths(env);
+  fs.mkdirSync(paths.core, { recursive: true });
+  fs.mkdirSync(paths.state, { recursive: true });
+  fs.mkdirSync(paths.logs, { recursive: true });
+  fs.writeFileSync(paths.config, BASE_CONFIG);
+  const manifest = {
+    version: 1,
+    createdAt: new Date().toISOString(),
+    entries: [
+      { kind: 'dir', path: paths.core },
+      { kind: 'file', path: paths.config, hash: sha256(BASE_CONFIG) },
+    ],
+  };
+  manifestLib.save(paths, manifest);
+  return { root, env, paths };
+}
+
+/**
+ * Run sync.run with process.env pointed at the temp core and the loader no-op
+ * set, forwarding `opts` (the interactive + ensureGoogleReady seams) through.
+ * @param {Record<string,string>} env
+ * @param {string[]} argv
+ * @param {object} opts
+ */
+async function runSync(env, argv = [], opts = {}) {
+  const savedKeys = ['HOME', 'WIENERDOG_HOME', 'CLAUDE_CONFIG_DIR', 'CODEX_HOME', 'WIENERDOG_LOADER_NOOP'];
+  const saved = Object.fromEntries(savedKeys.map((k) => [k, process.env[k]]));
+  Object.assign(process.env, env, { WIENERDOG_LOADER_NOOP: '1' });
+  // Silence sync's chatty stdout.
+  const origWrite = process.stdout.write.bind(process.stdout);
+  const origLog = console.log;
+  console.log = () => {};
+  process.stdout.write = () => true;
+  try {
+    await sync.run(argv, opts);
+  } finally {
+    process.stdout.write = origWrite;
+    console.log = origLog;
+    for (const k of savedKeys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  }
+}
+
+test('sync-gws-backfill: non-TTY sync never calls the backfill', async () => {
+  const { env } = setup();
+  let called = false;
+  await runSync(env, [], {
+    interactive: false,
+    ensureGoogleReady: async () => {
+      called = true;
+    },
+  });
+  assert.equal(called, false, 'non-TTY sync must not prompt or install');
+});
+
+test('sync-gws-backfill: interactive sync calls the backfill once with paths', async () => {
+  const { env, paths } = setup();
+  let calls = 0;
+  let seen;
+  await runSync(env, [], {
+    interactive: true,
+    ensureGoogleReady: async (p) => {
+      calls += 1;
+      seen = p;
+    },
+  });
+  assert.equal(calls, 1, 'backfill called exactly once');
+  assert.equal(seen.core, paths.core, 'backfill receives the resolved paths');
+});
+
+test('sync-gws-backfill: a throwing backfill never fails sync, and the manifest was already persisted', async () => {
+  const { env, paths } = setup();
+  await assert.doesNotReject(() =>
+    runSync(env, [], {
+      interactive: true,
+      ensureGoogleReady: async () => {
+        throw new WienerdogError('declined — run this yourself');
+      },
+    })
+  );
+  // Crash-safety (Codex round-2 Finding 1): manifestMod.save ran BEFORE the
+  // backfill, so every manifest-tracked mutation is persisted even when the
+  // backfill throws (or is interrupted). The vendor step records a
+  // vendored-tree entry — its presence proves the save happened.
+  assert.ok(fs.existsSync(paths.manifest), 'manifest file persisted');
+  const m = manifestLib.load(paths);
+  assert.ok(
+    m.entries.some((e) => e.kind === 'vendored-tree'),
+    'manifest holds the vendored-tree entry recorded by this sync'
+  );
+});
+
+test('sync-gws-backfill: --dry-run never calls the backfill, even interactive', async () => {
+  const { env } = setup();
+  let called = false;
+  await runSync(env, ['--dry-run'], {
+    interactive: true,
+    ensureGoogleReady: async () => {
+      called = true;
+    },
+  });
+  assert.equal(called, false, 'dry-run must stay mutation-free');
+});


### PR DESCRIPTION
> **Stacked on `wp/102-gws-deps-self-heal` (PR #105) — merge after it; the `src/gws/deps.js` / `src/gws/index.js` / WP-102-spec files in this diff land there.** This PR's own delta is `src/cli/sync.js`, `tests/unit/sync-gws-backfill.test.js`, and the WP-105 spec/ROADMAP status flips (commit 52c3e2f).

Spec: docs/specs/WP-105-sync-interactive-gws-backfill.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

## Verification output

```
$ npm test -- --test-name-pattern "sync-gws-backfill|sync"
✔ sync-gws-backfill: non-TTY sync never calls the backfill
✔ sync-gws-backfill: interactive sync calls the backfill once with paths
✔ sync-gws-backfill: a throwing backfill never fails sync, and the manifest was already persisted
✔ sync-gws-backfill: --dry-run never calls the backfill, even interactive
✔ sync-repoint: rewrites a stale scheduler entry to the vendored bin, then is idempotent
✔ sync-repoint: --dry-run repoints nothing
✔ update: newer version installs and hands off to the new version bin sync
✔ update: already current prints up-to-date and performs no download or sync
✔ update: a failed handoff sync throws WienerdogError telling the user to run wienerdog sync
ℹ tests 60  pass 60  fail 0  skipped 0

$ npm test
ℹ tests 778  pass 774  fail 0  skipped 4 (platform-gated)

$ npm run lint
markdownlint: Summary: 0 error(s)
shellcheck / PSScriptAnalyzer: clean
frontmatter check passed: 4 spec(s), 4 agent(s)
lint passed
```

## Decisions made

- `runSync` in the new test passes `argv = []` (mirroring `sync-repoint.test.js`) rather than the spec sketch's `['sync']` — `sync.run` only inspects `argv` for `--dry-run`, so the subcommand token is inert; the simpler form matches the existing harness.
- Asserted the backfill is called exactly once (a `calls` counter) in the interactive test, slightly stronger than the spec's "called with paths" sketch; no behavioral ambiguity.

## Discovered issues (out of scope, not fixed)

none

---
Generated-by: claude-fable-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MozsEQZ3G3H66VjJ3K8z7
