### PR TITLE
feat(doctor): validate skill-link targets for Claude + Codex (WP-106)

### DIFF
--- a/docs/specs/WP-106-doctor-skill-link-target-validation.md
+++ b/docs/specs/WP-106-doctor-skill-link-target-validation.md
@@ -1,7 +1,7 @@
 ---
 id: WP-106
 title: doctor validates skill-link targets (Claude + Codex), not just presence
-status: Ready
+status: In-Review
 model: sonnet
 size: M
 depends_on: []

--- a/src/cli/doctor.js
+++ b/src/cli/doctor.js
@@ -39,38 +39,111 @@ function readVaultPath(configPath) {
   return value === '' || value === 'null' ? null : value;
 }
 
-/** Verify each shipped wienerdog-* skill is registered under <codexDir>/skills/
- *  (a symlink OR a copied dir — both count; WP-050). Read-only; a missing/broken
- *  link is a WARN (remediation: 'wienerdog sync'), never a fail. Empty array when
- *  Codex is not detected. Codex's own <codexDir>/skills/.system/ is ignored.
+/** Validate that each SHIPPED wienerdog-* skill is CORRECTLY registered under a
+ *  harness's skills dir — not merely present (WP-079 checked only existence, which
+ *  let a symlink repointed at a foreign/ephemeral core read as healthy until it went
+ *  dangling; the 2026-07-12 demo-sandbox incident). The shipped inventory is read from
+ *  the PACKAGED source (path.resolve(__dirname,'..','..','skills')), NOT the mutable
+ *  <core>/skills, so a deleted staged skill is a reported problem, never a smaller
+ *  count.
+ *  For each shipped name:
+ *    - staged core copy <core>/skills/<name> absent / no SKILL.md → 'core copy missing'
+ *      (and the harness sub-check is skipped — sync re-stages).
+ *    - else the harness entry:
+ *      · SYMLINK: fs.realpathSync(linkPath) must resolve (else 'broken link') AND
+ *        equal fs.realpathSync(<core>/skills/<name>) (else 'points outside this install')
+ *        AND the resolved dir must contain SKILL.md (else 'no SKILL.md').
+ *      · real DIRECTORY (copied skill, WP-050): DISCOVERABILITY only — must contain
+ *        SKILL.md (else 'no SKILL.md'); NOT an ownership check (a user-modified/unrecorded
+ *        dir with SKILL.md reads as discoverable; ownership is WP-088/089's job).
+ *      · absent / a plain file: 'missing' / 'a file is in the way'.
+ *  Read-only; every problem is a WARN with the `wienerdog sync` remediation, never a
+ *  fail. Returns [] when the packaged source is unreadable or ships no wienerdog-* skills.
+ *  Callers gate on harness presence.
  *  @param {import('../core/paths').WienerdogPaths} paths
- *  @param {{codex:{present:boolean}}} harnesses
+ *  @param {string} harnessSkillsDir  e.g. path.join(paths.claudeDir, 'skills')
+ *  @param {string} label             e.g. 'Claude Code' | 'Codex'
  *  @returns {{status:'ok'|'warn', msg:string}[]} */
-function codexSkillChecks(paths, harnesses) {
-  if (!harnesses.codex.present) return [];
-
-  const coreSkillsDir = path.join(paths.core, 'skills');
+function skillLinkChecks(paths, harnessSkillsDir, label) {
+  const pkgSkillsRoot = path.resolve(__dirname, '..', '..', 'skills');
   let entries;
   try {
-    entries = fs.readdirSync(coreSkillsDir, { withFileTypes: true });
+    entries = fs.readdirSync(pkgSkillsRoot, { withFileTypes: true });
   } catch {
     return [];
   }
-  const names = entries
-    .filter((e) => e.name.startsWith('wienerdog-') && (e.isDirectory() || e.isSymbolicLink()))
+  const shippedNames = entries
+    .filter((e) => e.isDirectory() && e.name.startsWith('wienerdog-'))
     .map((e) => e.name);
-  if (names.length === 0) return [];
+  if (shippedNames.length === 0) return [];
 
-  const codexSkillsDir = path.join(paths.codexDir, 'skills');
-  const missing = names.filter((name) => !fs.existsSync(path.join(codexSkillsDir, name)));
+  const problems = [];
+  for (const name of shippedNames) {
+    const coreSkill = path.join(paths.core, 'skills', name);
+    let coreIsDir = false;
+    try {
+      coreIsDir = fs.statSync(coreSkill).isDirectory();
+    } catch {
+      coreIsDir = false;
+    }
+    if (!coreIsDir || !fs.existsSync(path.join(coreSkill, 'SKILL.md'))) {
+      problems.push({ name, reason: "core copy missing — run 'wienerdog sync'" });
+      continue;
+    }
 
-  if (missing.length === 0) {
-    return [{ status: 'ok', msg: `Codex skills registered (${names.length}) under ${codexSkillsDir}` }];
+    const linkPath = path.join(harnessSkillsDir, name);
+    let lstat;
+    try {
+      lstat = fs.lstatSync(linkPath);
+    } catch {
+      problems.push({ name, reason: 'missing' });
+      continue;
+    }
+
+    if (lstat.isSymbolicLink()) {
+      let real = null;
+      try {
+        real = fs.realpathSync(linkPath);
+      } catch {
+        real = null;
+      }
+      if (real === null) {
+        problems.push({ name, reason: 'broken link (target is gone)' });
+        continue;
+      }
+      let expectedReal = coreSkill;
+      try {
+        expectedReal = fs.realpathSync(coreSkill);
+      } catch {
+        // fall back to the literal expected path — coreSkill was already
+        // verified to exist above, so realpathSync should not throw here;
+        // this guards only against a race, not a real gap.
+      }
+      if (real !== expectedReal) {
+        problems.push({ name, reason: `points outside this install → ${real}` });
+        continue;
+      }
+      if (!fs.existsSync(path.join(real, 'SKILL.md'))) {
+        problems.push({ name, reason: `no SKILL.md at ${real}` });
+      }
+    } else if (lstat.isDirectory()) {
+      if (!fs.existsSync(path.join(linkPath, 'SKILL.md'))) {
+        problems.push({ name, reason: 'no SKILL.md' });
+      }
+    } else {
+      problems.push({ name, reason: 'a file is in the way' });
+    }
+  }
+
+  if (problems.length === 0) {
+    return [{ status: 'ok', msg: `${label} skills registered (${shippedNames.length}) under ${harnessSkillsDir}` }];
   }
   return [
     {
       status: 'warn',
-      msg: `Codex skills NOT registered under ${codexSkillsDir}: ${missing.join(', ')} — run 'wienerdog sync' to (re)link them`,
+      msg:
+        `${label} skills need attention under ${harnessSkillsDir}: ` +
+        `${problems.map((p) => `${p.name} (${p.reason})`).join(', ')} — run 'wienerdog sync' to re-link them`,
     },
   ];
 }
@@ -224,9 +297,15 @@ async function run(_argv) {
   const { doctorSchedulerChecks } = require('../scheduler/status');
   for (const c of doctorSchedulerChecks(paths)) check(c.status, c.msg);
 
-  // Codex skill-link health: shipped skills registered under $CODEX_HOME/skills/.
-  // Read-only; missing links are a warn (remediation: 'wienerdog sync').
-  for (const c of codexSkillChecks(paths, harnesses)) check(c.status, c.msg);
+  // Skill-link health: each shipped wienerdog-* skill is registered — and its symlink
+  // points at THIS install's core (not a stale/foreign one) — under each present
+  // harness's skills dir. Read-only; problems are warns (remediation: 'wienerdog sync').
+  if (harnesses.claude.present) {
+    for (const c of skillLinkChecks(paths, path.join(paths.claudeDir, 'skills'), 'Claude Code')) check(c.status, c.msg);
+  }
+  if (harnesses.codex.present) {
+    for (const c of skillLinkChecks(paths, path.join(paths.codexDir, 'skills'), 'Codex')) check(c.status, c.msg);
+  }
 
   // Google client-library readiness for a connected account (WP-103).
   // Read-only; silent when Google is not connected; a missing library is a warn.

--- a/tests/unit/doctor.test.js
+++ b/tests/unit/doctor.test.js
@@ -188,7 +188,7 @@ test('doctor warns (exit 0) when a Codex skill link is removed', () => {
   fs.rmSync(path.join(codexHome, 'skills', 'wienerdog-setup'), { recursive: true, force: true });
   const r = run(['doctor'], env);
   assert.equal(r.status, 0);
-  assert.match(r.stdout, /\[warn\] Codex skills NOT registered .*wienerdog-setup/);
+  assert.match(r.stdout, /\[warn\] Codex skills need attention .*wienerdog-setup/);
 });
 
 test('doctor prints no Codex-skill line when Codex is not detected', () => {
@@ -197,6 +197,112 @@ test('doctor prints no Codex-skill line when Codex is not detected', () => {
   const r = run(['doctor'], env);
   assert.equal(r.status, 0);
   assert.doesNotMatch(r.stdout, /Codex skills/);
+});
+
+test('doctor reports [ok] Claude Code skills registered when Claude is present and links intact', () => {
+  const { root, env } = tempEnv();
+  const claudeHome = path.join(root, 'claude');
+  fs.mkdirSync(claudeHome, { recursive: true });
+  env.CLAUDE_CONFIG_DIR = claudeHome;
+  run(['init', '--yes'], env);
+  const r = run(['doctor'], env);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /\[ok\] Claude Code skills registered \(\d+\)/);
+});
+
+test(
+  'doctor warns (exit 0) when a Claude skill link is repointed at a foreign core',
+  { skip: process.platform === 'win32' ? 'symlink-target test is POSIX-only' : false },
+  () => {
+    const { root, env } = tempEnv();
+    const claudeHome = path.join(root, 'claude');
+    fs.mkdirSync(claudeHome, { recursive: true });
+    env.CLAUDE_CONFIG_DIR = claudeHome;
+    run(['init', '--yes'], env);
+    const foreign = path.join(root, 'foreign', 'wienerdog-setup');
+    fs.mkdirSync(foreign, { recursive: true });
+    fs.writeFileSync(path.join(foreign, 'SKILL.md'), 'x');
+    const link = path.join(claudeHome, 'skills', 'wienerdog-setup');
+    fs.rmSync(link, { recursive: true, force: true });
+    fs.symlinkSync(foreign, link);
+    const r = run(['doctor'], env);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /\[warn\] Claude Code skills need attention .*wienerdog-setup \(points outside this install/);
+  }
+);
+
+test(
+  'doctor warns (exit 0) when a Claude skill link is dangling',
+  { skip: process.platform === 'win32' ? 'symlink-target test is POSIX-only' : false },
+  () => {
+    const { root, env } = tempEnv();
+    const claudeHome = path.join(root, 'claude');
+    fs.mkdirSync(claudeHome, { recursive: true });
+    env.CLAUDE_CONFIG_DIR = claudeHome;
+    run(['init', '--yes'], env);
+    const link = path.join(claudeHome, 'skills', 'wienerdog-dream');
+    fs.rmSync(link, { recursive: true, force: true });
+    fs.symlinkSync(path.join(root, 'gone', 'wienerdog-dream'), link);
+    const r = run(['doctor'], env);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /\[warn\] Claude Code skills need attention .*wienerdog-dream \(broken link/);
+  }
+);
+
+test(
+  'doctor warns (exit 0) when a Claude skill symlink resolves but the core copy lost its SKILL.md',
+  { skip: process.platform === 'win32' ? 'symlink SKILL.md test is POSIX-only' : false },
+  () => {
+    const { root, core, env } = tempEnv();
+    const claudeHome = path.join(root, 'claude');
+    fs.mkdirSync(claudeHome, { recursive: true });
+    env.CLAUDE_CONFIG_DIR = claudeHome;
+    run(['init', '--yes'], env);
+    fs.rmSync(path.join(core, 'skills', 'wienerdog-routines', 'SKILL.md'), { force: true });
+    const r = run(['doctor'], env);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /\[warn\] Claude Code skills need attention .*wienerdog-routines/);
+  }
+);
+
+test('doctor: copied-directory branch — real dir without SKILL.md warns; with SKILL.md registers', () => {
+  const { root, env } = tempEnv();
+  const claudeHome = path.join(root, 'claude');
+  fs.mkdirSync(claudeHome, { recursive: true });
+  env.CLAUDE_CONFIG_DIR = claudeHome;
+  run(['init', '--yes'], env);
+  const link = path.join(claudeHome, 'skills', 'wienerdog-dream');
+  fs.rmSync(link, { recursive: true, force: true });
+  fs.mkdirSync(link, { recursive: true });
+  let r = run(['doctor'], env);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /\[warn\] Claude Code skills need attention .*wienerdog-dream \(no SKILL\.md/);
+
+  fs.writeFileSync(path.join(link, 'SKILL.md'), 'x');
+  r = run(['doctor'], env);
+  assert.equal(r.status, 0);
+  assert.doesNotMatch(r.stdout, /wienerdog-dream \(no SKILL\.md/);
+  assert.match(r.stdout, /\[ok\] Claude Code skills registered/);
+});
+
+test('doctor: a deleted staged core skill is reported, not silently dropped', () => {
+  const { root, core, env } = tempEnv();
+  const claudeHome = path.join(root, 'claude');
+  fs.mkdirSync(claudeHome, { recursive: true });
+  env.CLAUDE_CONFIG_DIR = claudeHome;
+  run(['init', '--yes'], env);
+  fs.rmSync(path.join(core, 'skills', 'wienerdog-routines'), { recursive: true, force: true });
+  const r = run(['doctor'], env);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /\[warn\] Claude Code skills need attention .*wienerdog-routines \(core copy missing/);
+});
+
+test('doctor prints no Claude-skill line when Claude is not detected', () => {
+  const { env } = tempEnv();
+  run(['init', '--yes'], env);
+  const r = run(['doctor'], env);
+  assert.equal(r.status, 0);
+  assert.doesNotMatch(r.stdout, /Claude Code skills/);
 });
 
 /** Plant a WORKING fake googleapis under <core>/app/deps (resolves AND loads). */


### PR DESCRIPTION
Spec: docs/specs/WP-106-doctor-skill-link-target-validation.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

## Verification output

```
$ npm test -- --test-name-pattern doctor
...
✔ doctor reports [ok] Codex skills registered when Codex is present and links intact
✔ doctor warns (exit 0) when a Codex skill link is removed
✔ doctor prints no Codex-skill line when Codex is not detected
✔ doctor reports [ok] Claude Code skills registered when Claude is present and links intact
✔ doctor warns (exit 0) when a Claude skill link is repointed at a foreign core
✔ doctor warns (exit 0) when a Claude skill link is dangling
✔ doctor warns (exit 0) when a Claude skill symlink resolves but the core copy lost its SKILL.md
✔ doctor: copied-directory branch — real dir without SKILL.md warns; with SKILL.md registers
✔ doctor: a deleted staged core skill is reported, not silently dropped
✔ doctor prints no Claude-skill line when Claude is not detected
...
ℹ tests 80
ℹ suites 0
ℹ pass 80
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0

$ npm test
...
ℹ tests 808
ℹ suites 0
ℹ pass 804
ℹ fail 0
ℹ cancelled 0
ℹ skipped 4
ℹ todo 0

$ npm run lint
--- markdownlint ---
Summary: 4 error(s)
docs/specs/WP-107-doctor-stale-wienerdog-hook-detection.md:210:67 error MD038/no-space-in-code Spaces inside code span elements
docs/specs/WP-107-doctor-stale-wienerdog-hook-detection.md:215:19 error MD038/no-space-in-code Spaces inside code span elements
docs/specs/WP-107-doctor-stale-wienerdog-hook-detection.md:219:80 error MD038/no-space-in-code Spaces inside code span elements
docs/specs/WP-108-half-sandbox-guard.md:109:102 error MD056/table-column-count Table column count
--- shellcheck ---
--- PSScriptAnalyzer ---
--- frontmatter check ---
frontmatter check passed: 7 spec(s), 4 agent(s)
lint failed
```

`npm run lint`'s 4 markdownlint errors are pre-existing in `docs/specs/WP-107-*.md` and
`docs/specs/WP-108-*.md` — files this WP's Deliverables table does not list and does not
touch. Confirmed via `git stash` on this branch (removes my changes, keeping the same
base commit `e4cd309`): the identical 4 errors reproduce on the unmodified tree. `npm test`
and the `doctor`-scoped run both pass fully (0 failures).

## Decisions made

- The realpath-equality fallback comment for `expectedReal` (spec's "fall back to the
  literal `expected` string only when `realpathSync(expected)` throws") is effectively
  dead in practice at that point in the code: `coreSkill` was already verified to exist
  as a directory just above, so `realpathSync(coreSkill)` should not throw except under a
  concurrent-mutation race. Implemented the fallback as specified anyway (simpler than
  omitting it, matches the exact contract), just noted the reasoning in the code comment
  instead of repeating the spec's own words.

## Discovered issues (out of scope, not fixed)

none

---
Generated-by: claude-sonnet-5
