### PR TITLE
feat(init,sync): warn on a half-sandbox WIENERDOG_HOME redirect (WP-108)

### DIFF
--- a/docs/specs/WP-108-half-sandbox-guard.md
+++ b/docs/specs/WP-108-half-sandbox-guard.md
@@ -1,7 +1,7 @@
 ---
 id: WP-108
 title: half-sandbox guard — warn when WIENERDOG_HOME is redirected but harness configs are not
-status: Ready
+status: In-Review
 model: sonnet
 size: M
 depends_on: []
@@ -106,7 +106,7 @@ There is no existing "sandbox guard" module. Test harnesses that set `WIENERDOG_
 
 | Action | Path | Notes |
 |--------|------|-------|
-| create | src/core/sandbox-guard.js | pure `sandboxMismatchWarning(paths, env, harnesses)` → `string|null` |
+| create | src/core/sandbox-guard.js | pure `sandboxMismatchWarning(paths, env, harnesses)` → `string\|null` |
 | modify | src/cli/init.js | print the warning in the plan (before the `Proceed?` confirm); pass `{ suppressSandboxWarning: true, harnesses }` (init's snapshot) to its `sync` call |
 | modify | src/cli/sync.js | compute ONE harness snapshot per run (`opts.harnesses \|\| detectHarnesses(process.env)`); print the warning near the top of `run` unless `opts.suppressSandboxWarning`; gate each adapter on `snapshot.present ∧ isDir(dir)` — snapshot upper bound + pre-write revalidation (replace the two inline `detectHarnesses` calls); document `opts.suppressSandboxWarning` + `opts.harnesses` |
 | create | tests/unit/sandbox-guard.test.js | unit-test the pure function across all branches, plus subprocess integration for `init --dry-run` (warns / silent) and `sync` (warns), and the snapshot-consistency race test |

--- a/src/cli/init.js
+++ b/src/cli/init.js
@@ -108,6 +108,10 @@ async function run(argv) {
   console.log(`  Claude Code: ${harnesses.claude.present ? 'found' : 'not found'} (${harnesses.claude.dir})`);
   console.log(`  Codex CLI:   ${harnesses.codex.present ? 'found' : 'not found'} (${harnesses.codex.dir})`);
 
+  const { sandboxMismatchWarning } = require('../core/sandbox-guard');
+  const sandboxWarning = sandboxMismatchWarning(paths, process.env, harnesses);
+  if (sandboxWarning) console.log(`\n${sandboxWarning}`);
+
   if (dryRun) {
     console.log('\n--dry-run: no changes made.');
     return;
@@ -161,7 +165,7 @@ async function run(argv) {
   // is live the moment init finishes. sync is idempotent; with no vault it installs
   // skills + hooks and defers memory features (exit 0). Passing our argv is safe —
   // sync only reads --dry-run from it, and we never reach here on a dry-run.
-  await require('./sync').run(argv);
+  await require('./sync').run(argv, { suppressSandboxWarning: true, harnesses });
 
   if (vaultStep) {
     const { ensureDreamSchedule } = require('./schedule');

--- a/src/cli/sync.js
+++ b/src/cli/sync.js
@@ -122,16 +122,31 @@ function stageSkills(paths, dryRun, manifest, out) {
  * @param {string[]} argv
  * @param {{loader?: (argv:string[])=>{status:number},
  *          interactive?: boolean,
- *          ensureGoogleReady?: (paths:import('../core/paths').WienerdogPaths)=>Promise<void>}} [opts]
+ *          ensureGoogleReady?: (paths:import('../core/paths').WienerdogPaths)=>Promise<void>,
+ *          suppressSandboxWarning?: boolean,
+ *          harnesses?: {claude:{present:boolean,dir:string}, codex:{present:boolean,dir:string}}}} [opts]
  *   `loader`: scheduler loader seam. `interactive`: overrides terminal detection
  *   (tests); default `!!process.stdin.isTTY`. `ensureGoogleReady`: inject the
  *   googleapis self-heal fn (tests); default `require('../gws/deps').ensureGoogleReady`.
+ *   `suppressSandboxWarning`: skip the half-sandbox warning print (init already
+ *   printed it). `harnesses`: a pre-computed harness snapshot (init passes its
+ *   plan-time snapshot); a standalone sync detects once here when omitted.
  * @returns {Promise<void>}
  */
 async function run(argv, opts = {}) {
   const dryRun = argv.includes('--dry-run');
   const paths = getPaths();
   const vaultPath = readVaultPath(paths.config);
+  // One harness snapshot for the whole run: the guard warns about the harnesses the adapters
+  // below MAY write into (they write a subset — those still present at revalidation). From init
+  // this is init's snapshot (opts.harnesses); a standalone sync detects once here. A harness
+  // that appears mid-run is not in the snapshot → not written unwarned (round-7).
+  const harnesses = opts.harnesses || detectHarnesses(process.env);
+  if (!opts.suppressSandboxWarning) {
+    const { sandboxMismatchWarning } = require('../core/sandbox-guard');
+    const w = sandboxMismatchWarning(paths, process.env, harnesses);
+    if (w) console.log(w);
+  }
 
   // A configured vault MUST exist on disk. An UNSET vault is a valid first-time
   // state (WP-027): we still install skills + hooks, we just defer memory.
@@ -220,19 +235,33 @@ async function run(argv, opts = {}) {
 
   // 3. Apply each present harness adapter — ALWAYS. They install skills + hooks
   //    and only skip the managed block when skipManagedBlock is true.
-  if (detectHarnesses(process.env).claude.present) {
+  // The initial snapshot is an AUTHORIZATION UPPER BOUND, not a promise the dir still exists.
+  // Adapter set = { snapshot.present harnesses whose dir is STILL a directory at this check } —
+  // the intersection of the snapshot and on-disk state at revalidation time. It does not grow
+  // past the snapshot: a harness that APPEARED mid-run is not in the snapshot → not written
+  // unwarned (round-7); a harness whose disappearance is OBSERVABLE here fails revalidation →
+  // skipped (round-8). A removal/symlink-retarget in the window AFTER this check and before the
+  // adapter's write is an inherent non-atomic-fs micro-race (accepted residual — see
+  // Implementation notes). fs is already required at the top of sync.js.
+  const isDir = (p) => { try { return fs.statSync(p).isDirectory(); } catch { return false; } };
+
+  if (harnesses.claude.present && isDir(harnesses.claude.dir)) {
     const res = applyClaudeAdapter(paths, { dryRun, manifest, skipManagedBlock });
     summary.changed.push(...res.changed);
     summary.unchanged.push(...res.unchanged);
     summary.notices.push(...res.notices);
+  } else if (harnesses.claude.present) {
+    console.log('Claude Code config is no longer present; skipping adapter (it will be applied on the next `wienerdog sync`).');
   } else {
     console.log('Claude Code not detected; skipping adapter.');
   }
-  if (detectHarnesses(process.env).codex.present) {
+  if (harnesses.codex.present && isDir(harnesses.codex.dir)) {
     const res = applyCodexAdapter(paths, { dryRun, manifest, skipManagedBlock });
     summary.changed.push(...res.changed);
     summary.unchanged.push(...res.unchanged);
     summary.notices.push(...res.notices);
+  } else if (harnesses.codex.present) {
+    console.log('Codex CLI config is no longer present; skipping adapter (it will be applied on the next `wienerdog sync`).');
   } else {
     console.log('Codex CLI not detected; skipping adapter.');
   }

--- a/src/core/sandbox-guard.js
+++ b/src/core/sandbox-guard.js
@@ -1,0 +1,115 @@
+'use strict';
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+/** Detect the "half-sandbox" foot-gun: WIENERDOG_HOME redirects the core to a
+ *  non-default (possibly ephemeral) location, but one or more DETECTED harness config
+ *  dirs are NOT co-redirected — so init/sync will write skill links + session hooks into
+ *  the user's REAL ~/.claude / ~/.codex pointing at that core. If the core is later
+ *  removed (e.g. a temp dir the OS purges), every /wienerdog-* command and hook there
+ *  breaks (the 2026-07-12 demo-sandbox incident). Returns a loud multi-line warning, or
+ *  null when there is no mismatch: WIENERDOG_HOME unset, or set to the default core path,
+ *  or every DETECTED harness config dir is co-redirected. Reads the disk ONLY via realpath
+ *  (to resolve symlink/case aliases when comparing dirs); never writes, never spawns,
+ *  never prompts.
+ *  @param {import('./paths').WienerdogPaths} paths
+ *  @param {NodeJS.ProcessEnv} env
+ *  @param {{claude:{present:boolean,dir:string}, codex:{present:boolean,dir:string}}} harnesses
+ *  @returns {string|null} */
+function sandboxMismatchWarning(paths, env, harnesses) {
+  if (!env.WIENERDOG_HOME) return null;
+
+  const home = env.HOME || os.homedir();
+  const defaultCore = path.join(home, '.wienerdog');
+  // Redirected only if the core is not the default location. sameDir ALWAYS compares by
+  // physicalPath (canonicalize the longest EXISTING ancestor via realpath, re-append the
+  // absent suffix) — so a not-yet-created core at init plan time still compares by its
+  // existing parent's physical identity (e.g. a symlinked HOME), never a lexical whole-path
+  // compare that would false-flag a fresh default core as redirected (round-4).
+  if (sameDir(paths.core, defaultCore)) return null;
+
+  // A detected harness is "exposed" when its config dir is the SAME DIRECTORY as the real
+  // default — compared by physicalPath IDENTITY, never a lexical string compare. Two ways a
+  // string compare fails: (1) env PRESENCE is not co-redirection — CLAUDE_CONFIG_DIR=$HOME/
+  // .claude / CODEX_HOME=$HOME/.codex point at the real config; (2) a SYMLINK or a
+  // differently-CASED alias (macOS case-insensitive APFS) of ~/.claude mutates the real dir
+  // but differs as a string. harnesses.<h>.dir is getPaths()'s resolved dir and a DETECTED
+  // harness's dir necessarily EXISTS, so physicalPath fully realpaths it; the default side
+  // is canonicalized the same way, so both are physical.
+  const claudeDefault = path.join(home, '.claude');
+  const codexDefault = path.join(home, '.codex');
+  const exposed = [];
+  if (harnesses.claude.present && sameDir(harnesses.claude.dir, claudeDefault)) {
+    exposed.push({ name: 'Claude Code', dir: harnesses.claude.dir });
+  }
+  if (harnesses.codex.present && sameDir(harnesses.codex.dir, codexDefault)) {
+    exposed.push({ name: 'Codex CLI', dir: harnesses.codex.dir });
+  }
+  if (exposed.length === 0) return null;
+
+  const temp = looksTemporary(paths.core, env);
+  const where = temp
+    ? `${paths.core}, which looks like a TEMPORARY directory your system may delete.`
+    : `${paths.core}, a non-default location.`;
+  const targets = exposed.map((e) => `${e.name} (${e.dir})`).join(', ');
+  return [
+    `wienerdog: WARNING — WIENERDOG_HOME points the core at ${where}`,
+    `But these AI tool config dir(s) are NOT redirected and will receive skill links + session hooks pointing back at that core: ${targets}.`,
+    `If that core is ever removed, the /wienerdog-* commands and session hooks written there will break.`,
+    `If this is a permanent custom location, you can ignore this. Otherwise co-redirect the config dir (set CLAUDE_CONFIG_DIR / CODEX_HOME to a matching sandbox) or unset WIENERDOG_HOME before continuing.`,
+  ].join('\n');
+}
+
+/** True iff `a` and `b` are the SAME directory, by PHYSICAL identity via physicalPath
+ *  (below). physicalPath canonicalizes the longest EXISTING ancestor of each path (realpath
+ *  — resolving symlinks AND case on macOS APFS) and re-appends the not-yet-created suffix,
+ *  so: (1) a config dir aliased by a symlink or a differently-cased name is caught; and
+ *  (2) a not-yet-created core under a SYMLINKED parent (e.g. a symlinked HOME on a fresh
+ *  install) still compares by its parent's physical identity — never a false "redirected"
+ *  (round-4 P3). The compare is CASE-SENSITIVE on every platform: for EXISTING dirs realpath
+ *  already canonicalizes case on a case-insensitive filesystem; for an ABSENT
+ *  differently-cased suffix the compare treats the two names as distinct, which errs toward
+ *  a (cautious, non-blocking) WARNING — the safe direction, never hiding a real half-sandbox
+ *  (round-6; the case-insensitive-FS false-positive is an accepted residual — see
+ *  Implementation notes). @param {string} a @param {string} b @returns {boolean} */
+function sameDir(a, b) {
+  return physicalPath(a) === physicalPath(b);
+}
+
+/** Canonicalize as much of `p` as exists: realpath the longest existing ancestor, then
+ *  re-append the unresolved leaf suffix. A whole-path realpath is NOT enough — an absent
+ *  leaf beneath a symlinked/case-aliased parent must still compare by that parent's
+ *  physical identity (a bare path.resolve fallback would compare divergent lexical parents
+ *  and mis-classify a fresh default core as redirected). If nothing up to the filesystem
+ *  root resolves (never, in practice — the root always exists), degrade to path.resolve(p).
+ *  @param {string} p @returns {string} */
+function physicalPath(p) {
+  let cur = path.resolve(p);
+  const suffix = [];
+  for (;;) {
+    try {
+      const real = fs.realpathSync.native(cur);
+      return suffix.length ? path.join(real, ...suffix) : real;
+    } catch {
+      const parent = path.dirname(cur);
+      if (parent === cur) return path.resolve(p); // reached the root; nothing resolved
+      suffix.unshift(path.basename(cur));
+      cur = parent;
+    }
+  }
+}
+
+/** True when `p` resolves under a known temp root ($TMPDIR / os.tmpdir() / /var/folders
+ *  / /tmp). Best-effort heuristic — only escalates warning wording, never gates — so it
+ *  stays lexical (a symlinked temp core merely gets the milder wording, still warns).
+ *  @param {string} p @param {NodeJS.ProcessEnv} env @returns {boolean} */
+function looksTemporary(p, env) {
+  const rp = path.resolve(p);
+  const roots = [os.tmpdir(), env.TMPDIR, '/tmp', '/var/folders', '/private/var/folders']
+    .filter(Boolean)
+    .map((r) => path.resolve(r));
+  return roots.some((r) => rp === r || rp.startsWith(r + path.sep));
+}
+
+module.exports = { sandboxMismatchWarning };

--- a/tests/unit/sandbox-guard.test.js
+++ b/tests/unit/sandbox-guard.test.js
@@ -1,0 +1,543 @@
+'use strict';
+
+// WP-108: half-sandbox guard — WIENERDOG_HOME redirects the core but a detected
+// harness config dir is not co-redirected. Covers the pure `sandboxMismatchWarning`
+// function across all branches (including physical-identity alias cases), the
+// `init`/`sync` subprocess wiring (warn placement, no double-print, TEMPORARY
+// wording), and the sync single-snapshot/isDir-revalidation race guarantees.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const { sandboxMismatchWarning } = require('../../src/core/sandbox-guard');
+const { getPaths } = require('../../src/core/paths');
+const { detectHarnesses } = require('../../src/core/detect');
+const manifestLib = require('../../src/core/manifest');
+const syncMod = require('../../src/cli/sync');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const bin = path.join(repoRoot, 'bin', 'wienerdog.js');
+
+/**
+ * @param {{claude?: string|false, codex?: string|false}} o
+ * @returns {{claude:{present:boolean,dir:string}, codex:{present:boolean,dir:string}}}
+ */
+function mkHarnesses({ claude = false, codex = false } = {}) {
+  return {
+    claude: claude === false ? { present: false, dir: '' } : { present: true, dir: claude },
+    codex: codex === false ? { present: false, dir: '' } : { present: true, dir: codex },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure-function cases — no disk needed (fake, wholly non-existent paths).
+// ---------------------------------------------------------------------------
+
+test('sandbox-guard: WIENERDOG_HOME unset returns null', () => {
+  const home = '/home/u';
+  const result = sandboxMismatchWarning(
+    { core: path.join(home, '.wienerdog') },
+    { HOME: home },
+    mkHarnesses({ claude: path.join(home, '.claude') })
+  );
+  assert.equal(result, null);
+});
+
+test('sandbox-guard: WIENERDOG_HOME set to the default core path returns null', () => {
+  const home = '/home/u';
+  const core = path.join(home, '.wienerdog');
+  const result = sandboxMismatchWarning(
+    { core },
+    { HOME: home, WIENERDOG_HOME: core },
+    mkHarnesses({ claude: path.join(home, '.claude') })
+  );
+  assert.equal(result, null);
+});
+
+test('sandbox-guard: redirected core + Claude present at default + Codex absent warns', () => {
+  const home = '/home/u';
+  const core = path.join(home, 'sandbox', 'wd');
+  const result = sandboxMismatchWarning(
+    { core },
+    { HOME: home, WIENERDOG_HOME: core },
+    mkHarnesses({ claude: path.join(home, '.claude') })
+  );
+  assert.notEqual(result, null);
+  assert.match(result, /WARNING/);
+  assert.ok(result.includes(core), 'includes the core path');
+  assert.match(result, /Claude Code/);
+});
+
+test('sandbox-guard: redirected core + Claude present at a non-default (co-redirected) dir returns null', () => {
+  const home = '/home/u';
+  const core = path.join(home, 'sandbox', 'wd');
+  const result = sandboxMismatchWarning(
+    { core },
+    { HOME: home, WIENERDOG_HOME: core },
+    mkHarnesses({ claude: path.join(home, 'sandbox', '.claude') })
+  );
+  assert.equal(result, null);
+});
+
+test('sandbox-guard: redirected core + Codex present at default warns and names Codex CLI', () => {
+  const home = '/home/u';
+  const core = path.join(home, 'sandbox', 'wd');
+  const result = sandboxMismatchWarning(
+    { core },
+    { HOME: home, WIENERDOG_HOME: core },
+    mkHarnesses({ codex: path.join(home, '.codex') })
+  );
+  assert.notEqual(result, null);
+  assert.match(result, /Codex CLI/);
+});
+
+test('sandbox-guard: redirected core + Codex present at a non-default (co-redirected) dir returns null', () => {
+  const home = '/home/u';
+  const core = path.join(home, 'sandbox', 'wd');
+  const result = sandboxMismatchWarning(
+    { core },
+    { HOME: home, WIENERDOG_HOME: core },
+    mkHarnesses({ codex: path.join(home, 'sandbox', '.codex') })
+  );
+  assert.equal(result, null);
+});
+
+test('sandbox-guard: redirected core + both harnesses present at their defaults names both', () => {
+  const home = '/home/u';
+  const core = path.join(home, 'sandbox', 'wd');
+  const result = sandboxMismatchWarning(
+    { core },
+    { HOME: home, WIENERDOG_HOME: core },
+    mkHarnesses({ claude: path.join(home, '.claude'), codex: path.join(home, '.codex') })
+  );
+  assert.notEqual(result, null);
+  assert.match(result, /Claude Code/);
+  assert.match(result, /Codex CLI/);
+});
+
+test('sandbox-guard: a harness absent (present:false), even with its dir equal to the default, does not expose', () => {
+  const home = '/home/u';
+  const core = path.join(home, 'sandbox', 'wd');
+  const harnesses = {
+    claude: { present: false, dir: path.join(home, '.claude') },
+    codex: { present: false, dir: path.join(home, '.codex') },
+  };
+  const result = sandboxMismatchWarning({ core }, { HOME: home, WIENERDOG_HOME: core }, harnesses);
+  assert.equal(result, null);
+});
+
+test('sandbox-guard: Finding 4 — CLAUDE_CONFIG_DIR set to the default path does not suppress', () => {
+  const home = '/home/u';
+  const core = path.join(home, 'sandbox', 'wd');
+  const claudeDefault = path.join(home, '.claude');
+  const result = sandboxMismatchWarning(
+    { core },
+    { HOME: home, WIENERDOG_HOME: core, CLAUDE_CONFIG_DIR: claudeDefault },
+    mkHarnesses({ claude: claudeDefault })
+  );
+  assert.notEqual(result, null);
+  assert.match(result, /Claude Code/);
+});
+
+test('sandbox-guard: Finding 4 — CODEX_HOME set to the default path does not suppress', () => {
+  const home = '/home/u';
+  const core = path.join(home, 'sandbox', 'wd');
+  const codexDefault = path.join(home, '.codex');
+  const result = sandboxMismatchWarning(
+    { core },
+    { HOME: home, WIENERDOG_HOME: core, CODEX_HOME: codexDefault },
+    mkHarnesses({ codex: codexDefault })
+  );
+  assert.notEqual(result, null);
+  assert.match(result, /Codex CLI/);
+});
+
+test('sandbox-guard: a core under os.tmpdir() escalates wording to TEMPORARY', () => {
+  const home = '/home/u';
+  const core = path.join(os.tmpdir(), 'wd-sandbox-guard-fake-core');
+  const result = sandboxMismatchWarning(
+    { core },
+    { HOME: home, WIENERDOG_HOME: core },
+    mkHarnesses({ claude: path.join(home, '.claude') })
+  );
+  assert.notEqual(result, null);
+  assert.match(result, /TEMPORARY/);
+});
+
+test('sandbox-guard: a core at a normal non-temp path does not mention TEMPORARY', () => {
+  const home = '/home/u';
+  const core = '/opt/custom/wd';
+  const result = sandboxMismatchWarning(
+    { core },
+    { HOME: home, WIENERDOG_HOME: core },
+    mkHarnesses({ claude: path.join(home, '.claude') })
+  );
+  assert.notEqual(result, null);
+  assert.doesNotMatch(result, /TEMPORARY/);
+});
+
+// ---------------------------------------------------------------------------
+// Physical-identity (alias) cases — real dirs under a temp HOME.
+// ---------------------------------------------------------------------------
+
+test('sandbox-guard: a symlink alias of the real config dir warns (round-3 fix)', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-sbx-alias-'));
+  const realClaude = path.join(root, '.claude');
+  fs.mkdirSync(realClaude, { recursive: true });
+  const aliasClaude = path.join(root, 'claude-link');
+  fs.symlinkSync(realClaude, aliasClaude);
+  const core = path.join(root, 'wd');
+  const result = sandboxMismatchWarning(
+    { core },
+    { HOME: root, WIENERDOG_HOME: core },
+    mkHarnesses({ claude: aliasClaude })
+  );
+  assert.notEqual(result, null);
+  assert.match(result, /Claude Code/);
+});
+
+/** Probe filesystem case-sensitivity under a fresh temp dir (self-contained,
+ * independent of any other test's root). @returns {boolean} */
+function probeCaseInsensitiveFs() {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-sbx-case-probe-'));
+  fs.mkdirSync(path.join(d, '.claude'), { recursive: true });
+  return fs.existsSync(path.join(d, '.CLAUDE'));
+}
+const CASE_INSENSITIVE_FS = probeCaseInsensitiveFs();
+
+test(
+  'sandbox-guard: a case alias of the real config dir warns on a case-insensitive filesystem',
+  { skip: CASE_INSENSITIVE_FS ? false : 'case-insensitive filesystem only' },
+  () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-sbx-case-'));
+    fs.mkdirSync(path.join(root, '.claude'), { recursive: true });
+    const core = path.join(root, 'wd');
+    const result = sandboxMismatchWarning(
+      { core },
+      { HOME: root, WIENERDOG_HOME: core },
+      mkHarnesses({ claude: path.join(root, '.Claude') })
+    );
+    assert.notEqual(result, null);
+    assert.match(result, /Claude Code/);
+  }
+);
+
+test('sandbox-guard: a real, non-default, non-aliased config dir (co-redirected) does not false-warn', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-sbx-inverse-'));
+  const sandboxClaude = path.join(root, 'sandbox', '.claude');
+  fs.mkdirSync(sandboxClaude, { recursive: true });
+  const core = path.join(root, 'wd');
+  const result = sandboxMismatchWarning(
+    { core },
+    { HOME: root, WIENERDOG_HOME: core },
+    mkHarnesses({ claude: sandboxClaude })
+  );
+  assert.equal(result, null);
+});
+
+// ---------------------------------------------------------------------------
+// Core-side alias cases (round-4) — the trigger must use physical identity too.
+// ---------------------------------------------------------------------------
+
+test('sandbox-guard: a symlinked WIENERDOG_HOME alias of ~/.wienerdog is recognized as the default', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-sbx-corealias-'));
+  const realCore = path.join(root, '.wienerdog');
+  fs.mkdirSync(realCore, { recursive: true });
+  const aliasCore = path.join(root, 'wd-link');
+  fs.symlinkSync(realCore, aliasCore);
+  fs.mkdirSync(path.join(root, '.claude'), { recursive: true });
+  const result = sandboxMismatchWarning(
+    { core: aliasCore },
+    { HOME: root, WIENERDOG_HOME: aliasCore },
+    mkHarnesses({ claude: path.join(root, '.claude') })
+  );
+  assert.equal(result, null);
+});
+
+test(
+  'sandbox-guard: a differently-cased WIENERDOG_HOME of ~/.wienerdog is recognized as the default on a case-insensitive FS',
+  { skip: CASE_INSENSITIVE_FS ? false : 'case-insensitive filesystem only' },
+  () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-sbx-corecase-'));
+    fs.mkdirSync(path.join(root, '.wienerdog'), { recursive: true });
+    fs.mkdirSync(path.join(root, '.claude'), { recursive: true });
+    const core = path.join(root, '.WIENERDOG');
+    const result = sandboxMismatchWarning(
+      { core },
+      { HOME: root, WIENERDOG_HOME: core },
+      mkHarnesses({ claude: path.join(root, '.claude') })
+    );
+    assert.equal(result, null);
+  }
+);
+
+test('sandbox-guard: a fresh (not-yet-created) core under a symlinked HOME does not false-warn', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-sbx-symhome-'));
+  const physHome = path.join(root, 'phys');
+  fs.mkdirSync(physHome, { recursive: true });
+  const linkHome = path.join(root, 'link');
+  fs.symlinkSync(physHome, linkHome);
+  fs.mkdirSync(path.join(physHome, '.claude'), { recursive: true });
+  const core = path.join(physHome, '.wienerdog');
+  const result = sandboxMismatchWarning(
+    { core },
+    { HOME: linkHome, WIENERDOG_HOME: core },
+    mkHarnesses({ claude: path.join(linkHome, '.claude') })
+  );
+  assert.equal(result, null);
+});
+
+test('sandbox-guard: an absent differently-cased WIENERDOG_HOME suffix WARNS (pins the no-fold behavior; round-6)', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-sbx-nofold-'));
+  // Do NOT create .wienerdog (default core absent).
+  fs.mkdirSync(path.join(root, '.claude'), { recursive: true });
+  const core = path.join(root, '.WIENERDOG');
+  const result = sandboxMismatchWarning(
+    { core },
+    { HOME: root, WIENERDOG_HOME: core },
+    mkHarnesses({ claude: path.join(root, '.claude') })
+  );
+  assert.notEqual(result, null);
+  assert.match(result, /Claude Code/);
+});
+
+// ---------------------------------------------------------------------------
+// Integration (subprocess) — mirrors doctor.test.js's run(args, env).
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string[]} args
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {{status: number, stdout: string, stderr: string}}
+ */
+function run(args, env) {
+  try {
+    const stdout = execFileSync(process.execPath, [bin, ...args], { env, encoding: 'utf8' });
+    return { status: 0, stdout, stderr: '' };
+  } catch (err) {
+    return { status: err.status, stdout: err.stdout || '', stderr: err.stderr || '' };
+  }
+}
+
+/** Isolated temp HOME env for the half-sandbox subprocess cases: WIENERDOG_HOME
+ * redirected, no CLAUDE_CONFIG_DIR/CODEX_HOME/WIENERDOG_CLAUDE_DIR overrides —
+ * so the harness config dirs sit at their real default relative to the temp HOME.
+ * @returns {{root: string, env: NodeJS.ProcessEnv}} */
+function exposedEnv() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-sbx-cli-'));
+  fs.mkdirSync(path.join(root, '.claude'), { recursive: true });
+  const env = {
+    ...process.env,
+    HOME: root,
+    WIENERDOG_HOME: path.join(root, 'wd'),
+    WIENERDOG_VAULT: path.join(root, 'vault'),
+    WIENERDOG_LOADER_NOOP: '1',
+  };
+  delete env.CLAUDE_CONFIG_DIR;
+  delete env.CODEX_HOME;
+  delete env.WIENERDOG_CLAUDE_DIR;
+  return { root, env };
+}
+
+test('sandbox-guard: init --dry-run warns on a half-sandbox', () => {
+  const { env } = exposedEnv();
+  const r = run(['init', '--dry-run'], env);
+  assert.match(r.stdout, /WIENERDOG_HOME points the core at/);
+  assert.match(r.stdout, /Claude Code \(/);
+});
+
+test('sandbox-guard: init --dry-run is silent when co-redirected', () => {
+  const { root, env } = exposedEnv();
+  const claudeCfg = path.join(root, 'claude-cfg');
+  const codexCfg = path.join(root, 'codex-cfg');
+  fs.mkdirSync(claudeCfg, { recursive: true });
+  fs.mkdirSync(codexCfg, { recursive: true });
+  env.CLAUDE_CONFIG_DIR = claudeCfg;
+  env.CODEX_HOME = codexCfg;
+  const r = run(['init', '--dry-run'], env);
+  assert.doesNotMatch(r.stdout, /WIENERDOG_HOME points the core/);
+});
+
+test('sandbox-guard: sync warns on a half-sandbox (standalone-sync wiring)', () => {
+  const { env } = exposedEnv();
+  run(['init', '--yes'], env);
+  const r = run(['sync'], env);
+  assert.match(r.stdout, /WIENERDOG_HOME points the core at/);
+  assert.match(r.stdout, /Claude Code \(/);
+});
+
+test('sandbox-guard: init --yes prints the warning exactly once (Finding 5)', () => {
+  const { env } = exposedEnv();
+  const r = run(['init', '--yes'], env);
+  assert.equal(r.stdout.split('WIENERDOG_HOME points the core at').length - 1, 1);
+});
+
+test('sandbox-guard: an env var set to the default path still warns (Finding 4, subprocess)', () => {
+  const { root, env } = exposedEnv();
+  env.CLAUDE_CONFIG_DIR = path.join(root, '.claude');
+  const r = run(['init', '--dry-run'], env);
+  assert.match(r.stdout, /WIENERDOG_HOME points the core at/);
+  assert.match(r.stdout, /Claude Code \(/);
+});
+
+// ---------------------------------------------------------------------------
+// Snapshot-consistency (rounds 7-8) — in-process sync.run with an injected
+// snapshot. Mirrors the hermetic sync harness from tests/unit/sync-repoint.test.js.
+// ---------------------------------------------------------------------------
+
+/** @param {string} c @returns {string} */
+function sha256(c) {
+  return crypto.createHash('sha256').update(c).digest('hex');
+}
+
+// Vault UNSET → sync skips the digest + managed block but still stages skills
+// and applies adapters.
+const BASE_CONFIG = `# Wienerdog configuration
+version: 1
+vault:
+harnesses:
+  claude: true
+  codex: false
+memory_mode: standard
+`;
+
+/** Build an isolated temp core with config + matching manifest. @returns {{root:string, paths: import('../../src/core/paths').WienerdogPaths}} */
+function setupHermeticCore() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-sbx-snap-'));
+  const paths = getPaths({ HOME: root, WIENERDOG_HOME: path.join(root, 'wd') });
+  fs.mkdirSync(paths.core, { recursive: true });
+  fs.mkdirSync(paths.state, { recursive: true });
+  fs.mkdirSync(paths.logs, { recursive: true });
+  fs.writeFileSync(paths.config, BASE_CONFIG);
+  const manifest = {
+    version: 1,
+    createdAt: new Date().toISOString(),
+    entries: [
+      { kind: 'dir', path: paths.core },
+      { kind: 'file', path: paths.config, hash: sha256(BASE_CONFIG) },
+    ],
+  };
+  manifestLib.save(paths, manifest);
+  return { root, paths };
+}
+
+/** No-op scheduler loader (WIENERDOG_LOADER_NOOP='1' already neutralizes real
+ * loader spawns; passed for parity with the spec's injected-opts contract). */
+function noopLoader() {
+  return { status: 0 };
+}
+
+/**
+ * Point process.env at a hermetic core (round-8 Finding 1: CLAUDE_CONFIG_DIR
+ * must resolve to `claudeDir`, not an absent path, and WIENERDOG_CLAUDE_DIR
+ * must be cleared, or getPaths() prefers the stale absent override). Restores
+ * the previous values in `finally`.
+ * @param {string} root
+ * @param {string} claudeDir
+ * @param {string} codexDir
+ * @param {() => Promise<void>} fn
+ */
+async function withHermeticEnv(root, claudeDir, codexDir, fn) {
+  const savedKeys = ['HOME', 'WIENERDOG_HOME', 'CLAUDE_CONFIG_DIR', 'CODEX_HOME', 'WIENERDOG_CLAUDE_DIR', 'WIENERDOG_LOADER_NOOP'];
+  const saved = Object.fromEntries(savedKeys.map((k) => [k, process.env[k]]));
+  process.env.HOME = root;
+  process.env.WIENERDOG_HOME = path.join(root, 'wd');
+  process.env.CLAUDE_CONFIG_DIR = claudeDir;
+  delete process.env.WIENERDOG_CLAUDE_DIR;
+  process.env.CODEX_HOME = codexDir;
+  process.env.WIENERDOG_LOADER_NOOP = '1';
+  const origLog = console.log;
+  const origWrite = process.stdout.write.bind(process.stdout);
+  try {
+    await fn();
+  } finally {
+    console.log = origLog;
+    process.stdout.write = origWrite;
+    for (const k of savedKeys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  }
+}
+
+test('sandbox-guard: (a) upper bound — present:false snapshot skips even when a fresh detect would be present', async () => {
+  const { root } = setupHermeticCore();
+  const claudeDir = path.join(root, '.claude');
+  const codexDir = path.join(root, '.codex');
+  fs.mkdirSync(claudeDir, { recursive: true });
+
+  await withHermeticEnv(root, claudeDir, codexDir, async () => {
+    assert.equal(detectHarnesses(process.env).claude.present, true, 'fresh detect sees the dir');
+
+    console.log = () => {};
+    process.stdout.write = () => true;
+
+    await syncMod.run(['sync'], {
+      loader: noopLoader,
+      interactive: false,
+      suppressSandboxWarning: true,
+      harnesses: {
+        claude: { present: false, dir: claudeDir },
+        codex: { present: false, dir: codexDir },
+      },
+    });
+  });
+
+  assert.equal(fs.existsSync(path.join(claudeDir, 'settings.json')), false);
+  assert.equal(fs.existsSync(path.join(claudeDir, 'skills')), false);
+});
+
+test('sandbox-guard: (b) revalidation — present:true snapshot with the dir gone succeeds without writing', async () => {
+  const { root } = setupHermeticCore();
+  const claudeDir = path.join(root, '.claude'); // never created
+  const codexDir = path.join(root, '.codex');
+
+  await withHermeticEnv(root, claudeDir, codexDir, async () => {
+    console.log = () => {};
+    process.stdout.write = () => true;
+
+    await assert.doesNotReject(() =>
+      syncMod.run(['sync'], {
+        loader: noopLoader,
+        interactive: false,
+        suppressSandboxWarning: true,
+        harnesses: {
+          claude: { present: true, dir: claudeDir },
+          codex: { present: false, dir: codexDir },
+        },
+      })
+    );
+  });
+
+  assert.equal(fs.existsSync(claudeDir), false, 'not recreated');
+  assert.equal(fs.existsSync(path.join(claudeDir, 'settings.json')), false);
+});
+
+test('sandbox-guard: (c) intersection — present:true with the dir there runs the adapter', async () => {
+  const { root } = setupHermeticCore();
+  const claudeDir = path.join(root, '.claude');
+  const codexDir = path.join(root, '.codex');
+  fs.mkdirSync(claudeDir, { recursive: true });
+
+  await withHermeticEnv(root, claudeDir, codexDir, async () => {
+    console.log = () => {};
+    process.stdout.write = () => true;
+
+    await syncMod.run(['sync'], {
+      loader: noopLoader,
+      interactive: false,
+      suppressSandboxWarning: true,
+      harnesses: {
+        claude: { present: true, dir: claudeDir },
+        codex: { present: false, dir: codexDir },
+      },
+    });
+  });
+
+  assert.equal(fs.existsSync(path.join(claudeDir, 'settings.json')), true);
+});


### PR DESCRIPTION
Spec: docs/specs/WP-108-half-sandbox-guard.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

## Verification output

```
$ npm test -- --test-name-pattern "sandbox-guard"
...
ℹ tests 80
ℹ suites 0
ℹ pass 80
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
(30 sandbox-guard tests all ✔; the other 50 lines are other test FILES that
run as their own subprocess and print a single file-level ✔ line when no
individual test name inside them matches the --test-name-pattern filter.)
```

```
$ npm test
...
ℹ tests 828
ℹ suites 0
ℹ pass 824
ℹ fail 0
ℹ cancelled 0
ℹ skipped 4
ℹ todo 0
ℹ duration_ms 31755.25225
(the 4 skips are pre-existing, unrelated WP-102-gated cases in doctor.test.js)
```

```
$ npm run lint
--- markdownlint ---
markdownlint-cli2 v0.23.0 (markdownlint v0.41.0)
Finding: docs/**/*.md skills/**/*.md templates/**/*.md tests/**/*.md *.md
Linting: 197 file(s)
Summary: 3 error(s)
docs/specs/WP-107-doctor-stale-wienerdog-hook-detection.md:210:67 error MD038/no-space-in-code Spaces inside code span elements [Context: "`; assert `"]
docs/specs/WP-107-doctor-stale-wienerdog-hook-detection.md:215:19 error MD038/no-space-in-code Spaces inside code span elements [Context: "`; assert `"]
docs/specs/WP-107-doctor-stale-wienerdog-hook-detection.md:219:80 error MD038/no-space-in-code Spaces inside code span elements [Context: "`; assert `"]
markdownlint failed
--- shellcheck ---
--- PSScriptAnalyzer ---
--- frontmatter check ---
frontmatter check passed: 7 spec(s), 4 agent(s)
lint failed
```
**`npm run lint` still fails, but only on pre-existing errors in
`docs/specs/WP-107-doctor-stale-wienerdog-hook-detection.md` — a sibling
spec file that is not in WP-108's Deliverables table.** Verified these three
errors are identical on `main` before any WP-108 change (`git stash` +
re-run reproduced the exact same 4 errors, the 4th being WP-108's own
table-pipe issue, which I *did* fix — see "Decisions made"). I did not touch
WP-107's spec file: it belongs to a different, separate work package and
editing it here would violate the Deliverables boundary and could conflict
with WP-107's own branch.

## Decisions made

- Fixed an unescaped `|` inside a backtick-quoted `string|null` return-type
  cell in WP-108's **own** Deliverables table (`docs/specs/WP-108-half-sandbox-guard.md`
  line 109), which markdownlint's MD056 flagged as a 4th table column. This
  spec file is in the "always allowed without listing" set and the fix is a
  1-character escape (`string|null` → `` string\|null ``) with zero semantic
  change — kept it in scope since it's necessary to isolate the pre-existing,
  out-of-scope WP-107 lint failure as the sole remaining `npm run lint`
  blocker.
- Alias/case-sensitivity test cases that need independent temp roots
  (symlink alias, case alias, core-side alias) each get their own
  `fs.mkdtempSync` root rather than sharing one root across cases as the
  spec's prose loosely suggests — simpler test isolation, same coverage.
- Case-insensitive-FS-gated tests use a self-contained probe helper
  (`probeCaseInsensitiveFs()`) run once at module load, mirroring
  `doctor.test.js`'s `depsShapeCheckPresent()` skip-gating pattern, rather
  than probing inline per-test.
- All new test names are prefixed `sandbox-guard:` (mirroring
  `sync-repoint.test.js`'s `sync-repoint:` convention) so
  `--test-name-pattern "sandbox-guard"` actually selects them.

## Discovered issues (out of scope, not fixed)

- `docs/specs/WP-107-doctor-stale-wienerdog-hook-detection.md` has 3
  pre-existing markdownlint MD038 errors (spaces inside code spans at lines
  210, 215, 219) that make `npm run lint` fail regardless of WP-108. Not in
  WP-108's Deliverables table; left untouched.

---

## Lessons (dogfooding — do not edit memory/lessons/inbox.md; maintainer appends these)

- WP-108: `node --test --test-name-pattern` runs every test *file* as its own
  subprocess; files with zero matching test names still print a single
  passing file-level line, so a spec's literal `--test-name-pattern
  "<slug>"` verification command only actually exercises the new tests if
  every new test name contains that slug — worth calling out explicitly in
  future specs' test sections (or check for it) since it's easy to write
  tests that silently don't get selected by the intended filter.
- WP-108: `npm run lint` aggregates markdownlint across the whole `docs/`
  tree in one pass, so a pre-existing error in an unrelated sibling spec
  (WP-107 here) fails the lint gate for every other WP branched off the same
  main commit until that sibling spec is fixed on its own branch — worth a
  `git stash && npm run lint` sanity check before assuming a lint failure is
  yours.
- WP-108: the round-7/8/9 "snapshot as authorization upper bound + isDir
  revalidation" design was straightforward to implement exactly as
  specified once the contract code blocks were copy-pasted verbatim from
  the spec — an 11-round adversarially-reviewed spec with literal code
  blocks for the tricky bits (physicalPath, sameDir) is dramatically faster
  and safer to implement than one with prose-only descriptions of subtle
  path-aliasing logic.

Generated-by: claude-sonnet-5
