### PR TITLE
feat(doctor): flag stale Wienerdog session hooks whose script is gone (WP-107)

### DIFF
--- a/docs/specs/WP-107-doctor-stale-wienerdog-hook-detection.md
+++ b/docs/specs/WP-107-doctor-stale-wienerdog-hook-detection.md
@@ -1,7 +1,7 @@
 ---
 id: WP-107
 title: doctor flags stale/foreign wienerdog session hooks whose script is gone
-status: Ready
+status: In-Review
 model: sonnet
 size: S
 depends_on: [WP-106]

--- a/src/cli/doctor.js
+++ b/src/cli/doctor.js
@@ -148,6 +148,85 @@ function skillLinkChecks(paths, harnessSkillsDir, label) {
   ];
 }
 
+// The EXACT (event → script basename) pairs Wienerdog registers, per settings file.
+// A generic filename alone is NOT enough — a user's own SessionEnd hook could be named
+// session-end.sh — so a hook is Wienerdog-shaped ONLY when BOTH the event AND the basename
+// match a pair the corresponding adapter actually writes (src/adapters/{claude,codex}.js).
+const WD_HOOK_PAIRS = {
+  claude: { SessionStart: 'session-start.sh', SessionEnd: 'session-end.sh' },
+  codex: { SessionStart: 'session-start.sh', Stop: 'codex-session-end.sh' },
+};
+
+/** Recover the script path from a hook command. Wienerdog writes single-quoted
+ *  forward-slash paths (shellQuoteCommand); undo that. A bare/unquoted command (older
+ *  or foreign) is returned as-is. @param {string} command @returns {string} */
+function unquoteCommand(command) {
+  const c = String(command).trim();
+  if (c.length >= 2 && c.startsWith("'") && c.endsWith("'")) {
+    return c.slice(1, -1).replace(/'\\''/g, "'");
+  }
+  return c;
+}
+
+/** Detect a Wienerdog-SHAPED session hook whose target SCRIPT no longer exists — the
+ *  2026-07-12 demo-sandbox residue: a second SessionStart/SessionEnd pair was merged into
+ *  the real ~/.claude/settings.json pointing at a temp core the OS later purged, so every
+ *  session logged "SessionEnd hook failed". applySettings only prunes variants of its OWN
+ *  current command path, so a foreign-path wienerdog hook survives forever. A match
+ *  requires the EXACT (event, basename) pair Wienerdog registers for that harness AND a
+ *  missing script — this refuses to claim a user's unrelated hook (a session-end.sh under
+ *  PreToolUse, or a session-start.sh under SessionEnd, is NOT ours). Ownership still can't
+ *  be PROVEN (the path is foreign/unrecorded), so the WARN is HEDGED ("possible leftover …
+ *  if you didn't add this yourself"), and NEVER auto-removed (reversibility, ADR-0004).
+ *  Read-only; never throws.
+ *  @param {import('../core/paths').WienerdogPaths} paths
+ *  @param {{claude:{present:boolean}, codex:{present:boolean}}} harnesses
+ *  @returns {{status:'warn', msg:string}[]} */
+function staleHookChecks(paths, harnesses) {
+  const targets = [];
+  if (harnesses.claude.present) {
+    targets.push({ settingsPath: path.join(paths.claudeDir, 'settings.json'), pairs: WD_HOOK_PAIRS.claude });
+  }
+  if (harnesses.codex.present) {
+    targets.push({ settingsPath: path.join(paths.codexDir, 'hooks.json'), pairs: WD_HOOK_PAIRS.codex });
+  }
+
+  const findings = [];
+  for (const { settingsPath, pairs } of targets) {
+    let settings;
+    try {
+      settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    } catch {
+      continue;
+    }
+    const hooks = settings && settings.hooks;
+    if (hooks === null || typeof hooks !== 'object' || Array.isArray(hooks)) continue;
+
+    for (const [event, groups] of Object.entries(hooks)) {
+      const expectedBase = pairs[event];
+      if (!expectedBase) continue;
+      if (!Array.isArray(groups)) continue;
+      for (const group of groups) {
+        if (!group || !Array.isArray(group.hooks)) continue;
+        for (const h of group.hooks) {
+          if (!h || typeof h.command !== 'string') continue;
+          const scriptPath = unquoteCommand(h.command);
+          const base = scriptPath.replace(/\\/g, '/').split('/').pop();
+          if (base !== expectedBase) continue;
+          if (fs.existsSync(scriptPath)) continue;
+          findings.push({
+            status: 'warn',
+            msg:
+              `possible leftover Wienerdog session hook in ${settingsPath} (${event}): its script is gone, ` +
+              `so it fails every session — if you didn't add this hook yourself, remove this entry: ${h.command}`,
+          });
+        }
+      }
+    }
+  }
+  return findings;
+}
+
 /** Report Google client-library readiness for a CONNECTED account. Read-only;
  *  never fails (WARN, not fail). Emits NOTHING when Google is not connected (no
  *  token). A damaged token warns separately (never [ok]). Uses a containment-
@@ -306,6 +385,11 @@ async function run(_argv) {
   if (harnesses.codex.present) {
     for (const c of skillLinkChecks(paths, path.join(paths.codexDir, 'skills'), 'Codex')) check(c.status, c.msg);
   }
+
+  // Stale/foreign Wienerdog session hooks: a wienerdog-shaped hook whose target script no
+  // longer exists (e.g. a since-purged temp core merged into the real settings). Read-only;
+  // warn with a manual-removal hint — we never edit a settings file we did not record.
+  for (const c of staleHookChecks(paths, harnesses)) check(c.status, c.msg);
 
   // Google client-library readiness for a connected account (WP-103).
   // Read-only; silent when Google is not connected; a missing library is a warn.

--- a/tests/unit/doctor.test.js
+++ b/tests/unit/doctor.test.js
@@ -511,6 +511,111 @@ test('doctor reports [ok] when Google is connected and the client library is ins
   assert.match(r.stdout, /\[ok\] Google connected and its client library is installed/);
 });
 
+/** Append a hook group to a harness settings file. @param {string} settingsPath
+ *  @param {string} event @param {string} command */
+function appendHook(settingsPath, event, command) {
+  const s = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+  s.hooks = s.hooks || {};
+  s.hooks[event] = s.hooks[event] || [];
+  s.hooks[event].push({ matcher: '*', hooks: [{ type: 'command', command, timeout: 10 }] });
+  fs.writeFileSync(settingsPath, `${JSON.stringify(s, null, 2)}\n`);
+}
+
+test('doctor: valid current hooks only → no leftover-hook warn', () => {
+  const { root, env } = tempEnv();
+  const claudeHome = path.join(root, 'claude');
+  fs.mkdirSync(claudeHome, { recursive: true });
+  env.CLAUDE_CONFIG_DIR = claudeHome;
+  run(['init', '--yes'], env);
+  const r = run(['doctor'], env);
+  assert.equal(r.status, 0);
+  assert.doesNotMatch(r.stdout, /possible leftover Wienerdog session hook/);
+});
+
+test('doctor warns (exit 0) on a foreign Wienerdog hook (correct pair) whose script is gone', () => {
+  const { root, env } = tempEnv();
+  const claudeHome = path.join(root, 'claude');
+  fs.mkdirSync(claudeHome, { recursive: true });
+  env.CLAUDE_CONFIG_DIR = claudeHome;
+  run(['init', '--yes'], env);
+  const settingsPath = path.join(claudeHome, 'settings.json');
+  appendHook(settingsPath, 'SessionEnd', `'${path.join(root, 'gone-temp', 'wd', 'bin', 'session-end.sh')}'`);
+  const r = run(['doctor'], env);
+  assert.equal(r.status, 0);
+  assert.match(
+    r.stdout,
+    /\[warn\] possible leftover Wienerdog session hook in .*settings\.json \(SessionEnd\): its script is gone/
+  );
+});
+
+test('doctor: unrelated basename with a missing script is NOT flagged', () => {
+  const { root, env } = tempEnv();
+  const claudeHome = path.join(root, 'claude');
+  fs.mkdirSync(claudeHome, { recursive: true });
+  env.CLAUDE_CONFIG_DIR = claudeHome;
+  run(['init', '--yes'], env);
+  const settingsPath = path.join(claudeHome, 'settings.json');
+  appendHook(settingsPath, 'SessionEnd', `'${path.join(root, 'gone', 'my-hook.sh')}'`);
+  const r = run(['doctor'], env);
+  assert.equal(r.status, 0);
+  assert.doesNotMatch(r.stdout, /possible leftover Wienerdog session hook/);
+});
+
+test('doctor: right basename under an event Wienerdog never registers is NOT flagged', () => {
+  const { root, env } = tempEnv();
+  const claudeHome = path.join(root, 'claude');
+  fs.mkdirSync(claudeHome, { recursive: true });
+  env.CLAUDE_CONFIG_DIR = claudeHome;
+  run(['init', '--yes'], env);
+  const settingsPath = path.join(claudeHome, 'settings.json');
+  appendHook(settingsPath, 'PreToolUse', `'${path.join(root, 'gone', 'x', 'session-end.sh')}'`);
+  const r = run(['doctor'], env);
+  assert.equal(r.status, 0);
+  assert.doesNotMatch(r.stdout, /possible leftover Wienerdog session hook/);
+});
+
+test('doctor: right basename under the wrong event for that basename is NOT flagged', () => {
+  const { root, env } = tempEnv();
+  const claudeHome = path.join(root, 'claude');
+  fs.mkdirSync(claudeHome, { recursive: true });
+  env.CLAUDE_CONFIG_DIR = claudeHome;
+  run(['init', '--yes'], env);
+  const settingsPath = path.join(claudeHome, 'settings.json');
+  appendHook(settingsPath, 'SessionEnd', `'${path.join(root, 'gone', 'x', 'session-start.sh')}'`);
+  const r = run(['doctor'], env);
+  assert.equal(r.status, 0);
+  assert.doesNotMatch(r.stdout, /possible leftover Wienerdog session hook/);
+});
+
+test('doctor warns (exit 0) on a Codex-side stale hook (Stop → codex-session-end.sh)', () => {
+  const { root, env } = tempEnv();
+  const codexHome = path.join(root, 'codex');
+  fs.mkdirSync(codexHome, { recursive: true });
+  env.CODEX_HOME = codexHome;
+  run(['init', '--yes'], env);
+  const hooksPath = path.join(codexHome, 'hooks.json');
+  appendHook(hooksPath, 'Stop', `'${path.join(root, 'gone', 'bin', 'codex-session-end.sh')}'`);
+  const r = run(['doctor'], env);
+  assert.equal(r.status, 0);
+  assert.match(
+    r.stdout,
+    /\[warn\] possible leftover Wienerdog session hook in .*hooks\.json \(Stop\)/
+  );
+});
+
+test('doctor: Codex wrong pair (Stop → session-end.sh) is NOT flagged', () => {
+  const { root, env } = tempEnv();
+  const codexHome = path.join(root, 'codex');
+  fs.mkdirSync(codexHome, { recursive: true });
+  env.CODEX_HOME = codexHome;
+  run(['init', '--yes'], env);
+  const hooksPath = path.join(codexHome, 'hooks.json');
+  appendHook(hooksPath, 'Stop', `'${path.join(root, 'gone', 'session-end.sh')}'`);
+  const r = run(['doctor'], env);
+  assert.equal(r.status, 0);
+  assert.doesNotMatch(r.stdout, /possible leftover Wienerdog session hook/);
+});
+
 test('doctor with a set-but-missing vault fails and exits 1', () => {
   const { core, env } = tempEnv();
   run(['init', '--yes'], env);


### PR DESCRIPTION
Spec: docs/specs/WP-107-doctor-stale-wienerdog-hook-detection.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

## Verification output

```
$ npm test -- --test-name-pattern doctor
ℹ tests 88
ℹ suites 0
ℹ pass 88
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0

$ npm test
ℹ tests 842
ℹ suites 0
ℹ pass 838
ℹ fail 0
ℹ cancelled 0
ℹ skipped 4
ℹ todo 0

$ npm run lint
--- markdownlint ---
Summary: 0 error(s)
--- shellcheck ---
--- PSScriptAnalyzer ---
--- frontmatter check ---
frontmatter check passed: 7 spec(s), 4 agent(s)

lint passed
```

(4 skips are pre-existing WP-102-gated tests, unrelated to this WP.)

## Decisions made

None — implementation followed the spec's exact contracts (`WD_HOOK_PAIRS`, `unquoteCommand`, pair-gate-then-basename-then-existsSync ordering, hedged warn wording) verbatim.

## Discovered issues (out of scope, not fixed)

None.

---
Generated-by: claude-sonnet-5