### PR TITLE
test(scenarios): add a loaded-record scheduler tripwire (WP-scheduler-loaded-record-tripwire)

### DIFF
--- a/docs/specs/WP-scheduler-loaded-record-tripwire.md
+++ b/docs/specs/WP-scheduler-loaded-record-tripwire.md
@@ -1,7 +1,7 @@
 ---
 id: WP-scheduler-loaded-record-tripwire
 title: Give the scenario harnesses a LOADED-RECORD tripwire that catches stale cross-run scheduler leaks
-status: Ready
+status: In-Review
 model: opus
 size: M
 depends_on: []

--- a/tests/scenarios/negative/run-negative.js
+++ b/tests/scenarios/negative/run-negative.js
@@ -511,6 +511,7 @@ async function main() {
     // `root`), so it is order-independent; it also runs here regardless.
     if (shim) failures.push(...scg.assertNoLoaderInvoked(shim));
     if (root) failures.push(...scg.assertNoRealSchedulerLeak(root));
+    if (root) failures.push(...scg.assertNoLoadedSchedulerLeak(root));
     if (root) fs.rmSync(root, { recursive: true, force: true });
   }
 

--- a/tests/scenarios/run-scenarios.js
+++ b/tests/scenarios/run-scenarios.js
@@ -483,6 +483,7 @@ async function main() {
     // `root`), so it is order-independent; it also runs here regardless.
     if (shim) failures.push(...scg.assertNoLoaderInvoked(shim));
     if (root) failures.push(...scg.assertNoRealSchedulerLeak(root));
+    if (root) failures.push(...scg.assertNoLoadedSchedulerLeak(root));
     if (root) fs.rmSync(root, { recursive: true, force: true });
   }
 

--- a/tests/scenarios/scheduler-guard.js
+++ b/tests/scenarios/scheduler-guard.js
@@ -10,19 +10,42 @@
 // resolves the real launchd/systemd dirs and would register a REAL agent
 // pointing at the harness's temp core — an orphan once that temp core is
 // deleted. This module sandboxes only the `init` subprocess's env
-// (`buildInitEnv`) and adds two fail-closed tripwires: a PATH-shim that
+// (`buildInitEnv`) and installs three fail-closed tripwires: a PATH-shim that
 // captures + fails any real loader invocation (`makeLoaderShimDir` +
-// `assertNoLoaderInvoked`), and a report-only observer that scans the real
+// `assertNoLoaderInvoked`); a report-only observer that scans the real
 // scheduler dir(s) for anything this run actually leaked
-// (`assertNoRealSchedulerLeak`).
+// (`assertNoRealSchedulerLeak`); and a LOADED-RECORD observer that asks the OS
+// what every Wienerdog-named registration will actually execute
+// (`assertNoLoadedSchedulerLeak`).
 //
-// Zero deps, plain Node >= 18: only node:fs/os/path. No `child_process` here
-// — the shims are `sh` files written to disk, spawned only by the harnesses
-// (via the real `init` subprocess) or by the unit test that exercises them.
+// Zero deps, plain Node >= 18: node:fs/os/path plus node:child_process. The
+// `child_process` import exists for the loaded-record observer, which has to
+// ask the OS itself: a harness run that registers under an already-used
+// launchd label OVERWRITES the loaded record for that per-user-global label
+// and leaves the `.plist` file on disk untouched and perfectly correct, so no
+// amount of file reading can see it. That observer is strictly read-only
+// (`/bin/launchctl print` and nothing else) and reaches the OS through an
+// injectable `opts.run` seam, so no unit test ever spawns a real loader. The
+// shims themselves are still `sh` files written to disk, spawned only by the
+// harnesses (via the real `init` subprocess) or by the unit test that
+// exercises them.
 
+const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+
+/** The absolute launchd client path. ABSOLUTE BY CONTRACT: the harness prepends
+ *  a fail-closed loader-shim dir to the sandboxed init env's PATH, and a
+ *  bare-name lookup could resolve to that shim — the guard would then observe
+ *  its own containment machinery instead of the OS and report a false clean. */
+const LAUNCHCTL_PATH = '/bin/launchctl';
+
+/** Loaded-record label pattern. Deliberately looser than the product's
+ *  `[a-z0-9-]` job-name charset: the guard must be able to SEE a foreign-shaped
+ *  Wienerdog label, not only the ones we would have written. Fully anchored, no
+ *  `m` flag. */
+const LOADED_LABEL_PATTERN = /^ai\.wienerdog\.[a-z0-9.-]+$/;
 
 /** The four bare-name loader commands the product's scheduler chokepoint
  *  (`src/scheduler/spawn.js`'s `schedulerSpawn`) may invoke. */
@@ -353,4 +376,245 @@ function assertNoRealSchedulerLeak(tempRoot, opts = {}) {
   return failures;
 }
 
-module.exports = { makeLoaderShimDir, buildInitEnv, assertNoLoaderInvoked, assertNoRealSchedulerLeak };
+/**
+ * Tripwire 3: the LOADED-RECORD observer. Reads what the OS scheduler will
+ * ACTUALLY EXECUTE for every Wienerdog-named registration, and fails the run
+ * when any of it points into a temp directory. Deliberately takes NO `env`
+ * parameter — it must never be handed the sandboxed init env; the default
+ * `run` inherits the RUNNER's own environment.
+ * Reads NO scheduler artifact file: not the plist, not the systemd unit, not
+ * the manifest. That artifact was clean throughout the incident this exists to
+ * catch (the loaded record for `ai.wienerdog.catchup` pointed at a deleted
+ * harness temp core for weeks while its `.plist` on disk stayed correct).
+ * (`fs.realpathSync(os.tmpdir())` in the prefix step is a directory-name
+ * resolution, not an artifact read.)
+ *
+ * darwin: enumerate the loaded labels from the `services = {` block of
+ * `launchctl print gui/<uid>` — the SAME domain every record is then read
+ * from, so a domain this process cannot see fails closed instead of reporting
+ * an unexamined clean — then read each `ai.wienerdog.*` record's
+ * `arguments = {` block via `launchctl print gui/<uid>/<label>`. Every
+ * unverifiable condition is a failure; the single tolerated non-zero exit is
+ * `113` (launchd's "could not find service … in domain": a genuine
+ * listed-then-unloaded race), which is skipped WITH a printed notice.
+ * linux / win32 / anything else: returns `[]` and prints one notice naming the
+ * residual — a `systemd --user` manager's unit search path cannot be moved by
+ * a child process, and no `schtasks` interceptor exists.
+ *
+ * Failures carry one of exactly two class prefixes: `scheduler-guard: LEAK — `
+ * (a record was read and an argument is temp-origin — this machine is
+ * genuinely poisoned) or `scheduler-guard: UNVERIFIABLE — ` (the observer
+ * could not establish what a record will execute). Both fail the run.
+ *
+ * Strictly read-only: never issues `bootstrap`, `bootout` or any other
+ * mutation, and nothing it starts outlives the call (ADR-0004).
+ * @param {string} tempRoot  this run's temp root
+ * @param {{platform?:NodeJS.Platform,
+ *          run?: (argv:string[]) => {status:number|null, stdout?:string, error?:Error},
+ *          uid?: number, prefixes?: string[],
+ *          notice?: (msg:string) => void}} [opts]
+ * @returns {string[]} one loud, actionable failure per offending record; [] if clean
+ */
+function assertNoLoadedSchedulerLeak(tempRoot, opts = {}) {
+  const notice = opts.notice || ((m) => console.log(m));
+  // Parenthesised on purpose: `(opts.platform || process.platform === 'darwin')`
+  // parses as `opts.platform || (process.platform === 'darwin')`, which is
+  // truthy for ANY non-empty opts.platform — including 'linux'.
+  const isDarwin = (opts.platform || process.platform) === 'darwin';
+  if (!isDarwin) {
+    const platform = opts.platform || process.platform;
+    notice(
+      platform === 'linux'
+        ? 'scheduler-guard: note — the loaded-record observer is a no-op on linux. A running ' +
+            "`systemd --user` manager's unit search path is fixed when the MANAGER starts and is " +
+            "not moved by a child process's XDG_CONFIG_HOME, so a harness cannot load a unit from " +
+            'its temp dir; the only reachable leak shape is a unit FILE in the real user dir, ' +
+            'which assertNoRealSchedulerLeak already catches.'
+        : `scheduler-guard: note — the loaded-record observer is a no-op on ${platform}. ` +
+            'Accepted residual (WP-161): there is no schtasks PATH interceptor and no Windows CI runner.'
+    );
+    return [];
+  }
+
+  const run = opts.run || ((argv) => spawnSync(argv[0], argv.slice(1), { encoding: 'utf8' }));
+  const uid = opts.uid ?? process.getuid();
+  const domain = `gui/${uid}`;
+
+  // Table D — the ONE temp-origin mechanism, location-shaped. The whole OS temp
+  // base is in the prefix set (not just tempRoot) because a record poisoned by
+  // an EARLIER harness run sits under a SIBLING of this run's root; os.tmpdir()
+  // and its realpath differ on macOS and the poisoned argv used the non-realpath
+  // form, so both must be present.
+  let prefixes = opts.prefixes;
+  if (!prefixes) {
+    prefixes = [tempRoot, os.tmpdir()];
+    try {
+      prefixes.push(fs.realpathSync(os.tmpdir()));
+    } catch {
+      // Unresolvable realpath: just omit that third entry.
+    }
+  }
+  const bases = [];
+  for (const p of prefixes) {
+    const stripped = String(p).replace(/\/+$/, '');
+    if (stripped !== '' && !bases.includes(stripped)) bases.push(stripped);
+  }
+  const isTempOrigin = (a) => bases.some((p) => a === p || a.startsWith(`${p}/`));
+
+  /** @param {string} why @returns {string} */
+  const unverifiable = (why) => `scheduler-guard: UNVERIFIABLE — ${why}`;
+
+  /**
+   * Extract the body rows of the first block whose OPENING line trims to
+   * exactly `opener`, up to the next line trimming to exactly `}`.
+   * @param {string} stdout @param {string} opener
+   * @returns {{ok:boolean, reason?:string, rows?:string[]}}
+   */
+  const block = (stdout, opener) => {
+    const lines = stdout.split('\n');
+    // Exact trimmed EQUALITY, never includes(): the same output carries a
+    // `disabled services = {` block whose rows end in enabled/disabled, which
+    // would yield zero labels and a FALSE CLEAN.
+    const open = lines.findIndex((l) => l.trim() === opener);
+    if (open === -1) return { ok: false, reason: `no line whose trimmed content is exactly \`${opener}\`` };
+    for (let i = open + 1; i < lines.length; i += 1) {
+      if (lines[i].trim() === '}') return { ok: true, rows: lines.slice(open + 1, i) };
+    }
+    return { ok: false, reason: `the \`${opener}\` block is never closed by a line trimming to \`}\`` };
+  };
+
+  // ── Enumerate, from the SAME domain the records are read from ────────────
+  const enumerated = run([LAUNCHCTL_PATH, 'print', domain]);
+  if (enumerated && enumerated.error) {
+    return [
+      unverifiable(
+        `could not enumerate the LOADED launchd records in domain ${domain}: spawning ` +
+          `${LAUNCHCTL_PATH} failed (${enumerated.error.message}). The observer could not start, so ` +
+          'nothing behind it may be reported clean. This is NOT evidence of a leak.'
+      ),
+    ];
+  }
+  if (!enumerated || enumerated.status !== 0) {
+    const status = enumerated ? enumerated.status : null;
+    return [
+      unverifiable(
+        `could not enumerate the LOADED launchd records in domain ${domain} ` +
+          `(launchctl print exit ${status}). The observer cannot see this domain at all, so it ` +
+          'fails closed rather than reporting clean. This is NOT evidence of a leak: exit 112 is ' +
+          '"no such domain", which is what a headless/SSH session with no gui/<uid> domain ' +
+          'produces. Re-run from a GUI login session.'
+      ),
+    ];
+  }
+  if (typeof enumerated.stdout !== 'string') {
+    return [
+      unverifiable(
+        `could not enumerate the LOADED launchd records in domain ${domain}: launchctl print ` +
+          'exited 0 but produced no readable stdout. Fail-closed; NOT evidence of a leak.'
+      ),
+    ];
+  }
+  const services = block(enumerated.stdout, 'services = {');
+  if (!services.ok) {
+    return [
+      unverifiable(
+        `could not enumerate the LOADED launchd records in domain ${domain}: ${services.reason}. ` +
+          'The domain answered but its service list could not be located — an unparsed list is ' +
+          'not an empty list. Fail-closed; NOT evidence of a leak.'
+      ),
+    ];
+  }
+
+  const labels = [];
+  for (const row of services.rows) {
+    const trimmed = row.trim();
+    if (trimmed === '') continue;
+    // Observed live on macOS 26.5: every services row splits into exactly three
+    // whitespace-separated fields (PID, Status, Label), so the label is the last.
+    const label = trimmed.split(/\s+/).pop();
+    if (LOADED_LABEL_PATTERN.test(label)) labels.push(label);
+  }
+
+  // ── Read EVERY selected label's record — never stop at the first ─────────
+  const failures = [];
+  for (const label of labels) {
+    const record = run([LAUNCHCTL_PATH, 'print', `${domain}/${label}`]);
+    if (record && record.error) {
+      failures.push(
+        unverifiable(
+          `could not read the LOADED launchd record ${label}: spawning ${LAUNCHCTL_PATH} failed ` +
+            `(${record.error.message}). Fail-closed; NOT evidence of a leak.`
+        )
+      );
+      continue;
+    }
+    if (!record || record.status !== 0) {
+      const status = record ? record.status : null;
+      if (status === 113) {
+        // The ONLY tolerated non-zero exit: launchd's "could not find service …
+        // in domain" — the label was listed a moment ago and is no longer
+        // loaded, i.e. a genuine race. It prints; no disposition here is silent.
+        notice(
+          `scheduler-guard: note — label ${label} was listed but is no longer loaded ` +
+            '(launchctl print exit 113); skipped.'
+        );
+        continue;
+      }
+      failures.push(
+        unverifiable(
+          `could not read the LOADED launchd record ${label} (launchctl print exit ${status}). ` +
+            'Only exit 113 ("no such service in domain", a listed-then-unloaded race) is tolerated; ' +
+            'every other exit — 112 (no such domain), 64 (malformed target) — leaves what this ' +
+            'record will execute unknown. Fail-closed; NOT evidence of a leak.'
+        )
+      );
+      continue;
+    }
+    if (typeof record.stdout !== 'string') {
+      failures.push(
+        unverifiable(
+          `could not read the LOADED launchd record ${label}: launchctl print exited 0 but ` +
+            'produced no readable stdout. Fail-closed; NOT evidence of a leak.'
+        )
+      );
+      continue;
+    }
+    const args = block(record.stdout, 'arguments = {');
+    if (!args.ok) {
+      failures.push(
+        unverifiable(
+          `could not read what the LOADED launchd record ${label} will execute: ${args.reason}. ` +
+            'The record exists but its exec identity could not be read. Fail-closed; NOT evidence ' +
+            'of a leak.'
+        )
+      );
+      continue;
+    }
+    for (const row of args.rows) {
+      const program = row.trim();
+      if (program === '' || !isTempOrigin(program)) continue;
+      failures.push(
+        [
+          `scheduler-guard: LEAK — the LOADED launchd record ${label}` +
+            ` will execute ${program}` +
+            ', which is inside a temp directory. A harness run clobbered the real' +
+            ' per-user label; the .plist FILE on disk is not the artifact at fault' +
+            ' and may look clean. Repair, IN THIS ORDER:',
+          '  1) wienerdog sync',
+          '  2) only if a re-run still reports this record:',
+          `     launchctl bootout gui/$(id -u)/${label} ; wienerdog sync`,
+        ].join('\n')
+      );
+      break; // one failure per offending record
+    }
+  }
+  return failures;
+}
+
+module.exports = {
+  makeLoaderShimDir,
+  buildInitEnv,
+  assertNoLoaderInvoked,
+  assertNoRealSchedulerLeak,
+  assertNoLoadedSchedulerLeak,
+};

--- a/tests/unit/scheduler-leak-guard.test.js
+++ b/tests/unit/scheduler-leak-guard.test.js
@@ -372,3 +372,593 @@ test('scheduler-leak-guard: F6 Linux XDG-scan branch — the observer honors XDG
   assert.equal(failures.length, 1);
   assert.match(failures[0], /wienerdog-dream\.timer/);
 });
+
+// ── assertNoLoadedSchedulerLeak: the LOADED-RECORD observer (tripwire 3) ──
+//
+// WHICH ARTIFACT THESE ASSERTIONS READ, AND WHY IT IS THE AUTHORITATIVE ONE:
+// every test below drives the observer off the OS scheduler's OWN record of
+// what it will execute — the `arguments = {` block of
+// `launchctl print gui/<uid>/<label>` — supplied as canned `opts.run` output.
+// The `.plist` file on disk is NOT authoritative and no assertion here reads
+// one: throughout the 2026-07-22 incident that file was perfectly correct
+// while the LOADED record for `ai.wienerdog.catchup` pointed at a deleted
+// harness temp core and failed hourly with MODULE_NOT_FOUND. `opts.run` is
+// injected in every test — none of them spawns a real `launchctl`.
+
+const UID = 501;
+const DOMAIN = `gui/${UID}`;
+
+/** @param {string} stdout @returns {{status:number, stdout:string, stderr:string}} a successful canned call. */
+function ok(stdout) {
+  return { status: 0, stdout, stderr: '' };
+}
+
+/**
+ * A canned `launchctl print gui/<uid>` stdout, in the shape observed live on
+ * macOS 26.5: a `services = {` block of three-field rows (PID, Status, Label),
+ * followed by a `disabled services = {` block that must NOT be mistaken for it.
+ * @param {string[]} labels @returns {string}
+ */
+function domainPrint(labels) {
+  return [
+    'com.apple.xpc.launchd.domain.gui.501 = {',
+    '\ttype = user',
+    '\tservices = {',
+    ...labels.map((l) => `\t\t       0      0 \t${l}`),
+    '\t}',
+    '\tdisabled services = {',
+    '\t\t"com.google.keystone.user.xpcservice" => enabled',
+    '\t}',
+    '}',
+  ].join('\n');
+}
+
+/**
+ * A canned `launchctl print gui/<uid>/<label>` stdout whose `arguments = {`
+ * block holds `args`, one per line — the live shape.
+ * @param {string} label @param {string[]} args @returns {string}
+ */
+function recordPrint(label, args) {
+  return [
+    `${label} = {`,
+    '\tactive count = 1',
+    `\tpath = /Users/u/Library/LaunchAgents/${label}.plist`,
+    '\targuments = {',
+    ...args.map((a) => `\t\t${a}`),
+    '\t}',
+    '}',
+  ].join('\n');
+}
+
+/**
+ * The injected `opts.run` seam: records every argv it is handed and answers
+ * from a target→result map. An unstubbed target throws, so a test can never
+ * silently pass over a call it did not expect.
+ * @param {string[][]} calls @param {Record<string, object>} byTarget
+ * @returns {(argv:string[]) => object}
+ */
+function makeRun(calls, byTarget) {
+  return (argv) => {
+    calls.push([...argv]);
+    const target = argv[2];
+    if (!Object.prototype.hasOwnProperty.call(byTarget, target)) {
+      throw new Error(`unexpected launchctl target in a canned run: ${target}`);
+    }
+    return byTarget[target];
+  };
+}
+
+/**
+ * The contracted LEAK message, reproduced HERE character for character rather
+ * than imported from scheduler-guard.js — an imported template would move with
+ * any mutation of the message and the equality assertion would be a tautology.
+ * @param {string} label @param {string} program @returns {string}
+ */
+function expectedLeakMessage(label, program) {
+  return [
+    'scheduler-guard: LEAK — the LOADED launchd record ' +
+      label +
+      ' will execute ' +
+      program +
+      ', which is inside a temp directory. A harness run clobbered the real' +
+      ' per-user label; the .plist FILE on disk is not the artifact at fault' +
+      ' and may look clean. Repair, IN THIS ORDER:',
+    '  1) wienerdog sync',
+    '  2) only if a re-run still reports this record:',
+    '     launchctl bootout gui/$(id -u)/' + label + ' ; wienerdog sync',
+  ].join('\n');
+}
+
+/**
+ * Run `fn` with the two product NEUTRALIZER env vars forced to the given
+ * values, restoring the originals in a `finally` so the suite-wide setting
+ * (WIENERDOG_TEST_NO_REAL_SCHEDULER=1 from tests/run.js) is not disturbed.
+ * Same shape as tests/unit/scheduler-guard.test.js's `withEnv`.
+ * @param {{guard?: string, noop?: string}} vals  undefined = delete the var
+ * @param {() => void} fn
+ */
+function withGuardEnv(vals, fn) {
+  const savedGuard = process.env.WIENERDOG_TEST_NO_REAL_SCHEDULER;
+  const savedNoop = process.env.WIENERDOG_LOADER_NOOP;
+  const set = (k, v) => {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  };
+  set('WIENERDOG_TEST_NO_REAL_SCHEDULER', vals.guard);
+  set('WIENERDOG_LOADER_NOOP', vals.noop);
+  try {
+    fn();
+  } finally {
+    set('WIENERDOG_TEST_NO_REAL_SCHEDULER', savedGuard);
+    set('WIENERDOG_LOADER_NOOP', savedNoop);
+  }
+}
+
+const LEAK_PREFIX = 'scheduler-guard: LEAK — ';
+const UNVERIFIABLE_PREFIX = 'scheduler-guard: UNVERIFIABLE — ';
+
+test('scheduler-leak-guard: loaded-record observer FAILS on a record whose loaded argv is under the OS temp dir', () => {
+  // The incident's own shape: a LOADED record executing a launcher inside a
+  // harness temp core. The plist on disk is irrelevant and is never read.
+  const tempRoot = path.join(os.tmpdir(), 'wd-negative-UezlJP');
+  const program = path.join(tempRoot, 'core', 'launcher', 'launch.js');
+  const calls = [];
+  const out = scg.assertNoLoadedSchedulerLeak(tempRoot, {
+    platform: 'darwin',
+    uid: UID,
+    notice: () => {},
+    run: makeRun(calls, {
+      [DOMAIN]: ok(domainPrint(['ai.wienerdog.dream'])),
+      [`${DOMAIN}/ai.wienerdog.dream`]: ok(
+        recordPrint('ai.wienerdog.dream', ['/opt/homebrew/bin/node', program, 'dream'])
+      ),
+    }),
+  });
+  assert.equal(out.length, 1);
+  assert.ok(out[0].startsWith(LEAK_PREFIX), `expected a LEAK failure, got: ${out[0]}`);
+  assert.ok(out[0].includes('ai.wienerdog.dream'), 'the failure names the label');
+  assert.ok(out[0].includes(program), 'the failure names the offending argument');
+
+  // Converse: the same record shape with no temp-origin argument is a
+  // VERIFIED clean — the domain was reachable and every record was read.
+  const cleanCalls = [];
+  const clean = scg.assertNoLoadedSchedulerLeak(tempRoot, {
+    platform: 'darwin',
+    uid: UID,
+    notice: () => {},
+    run: makeRun(cleanCalls, {
+      [DOMAIN]: ok(domainPrint(['ai.wienerdog.dream'])),
+      [`${DOMAIN}/ai.wienerdog.dream`]: ok(
+        recordPrint('ai.wienerdog.dream', ['/opt/homebrew/bin/node', '/Users/u/.wienerdog/launcher/launch.js', 'dream'])
+      ),
+    }),
+  });
+  assert.deepEqual(clean, []);
+});
+
+test('scheduler-leak-guard: loaded-record observer does not stop at the FIRST selected label', () => {
+  const tempRoot = path.join(os.tmpdir(), 'wd-scenarios-AC1b');
+  const program = path.join(tempRoot, 'core', 'launcher', 'launch.js');
+  const calls = [];
+  const out = scg.assertNoLoadedSchedulerLeak(tempRoot, {
+    platform: 'darwin',
+    uid: UID,
+    notice: () => {},
+    run: makeRun(calls, {
+      [DOMAIN]: ok(domainPrint(['ai.wienerdog.dream', 'ai.wienerdog.catchup'])),
+      [`${DOMAIN}/ai.wienerdog.dream`]: ok(
+        recordPrint('ai.wienerdog.dream', ['/usr/bin/node', '/Users/u/.wienerdog/launcher/launch.js', 'dream'])
+      ),
+      [`${DOMAIN}/ai.wienerdog.catchup`]: ok(
+        recordPrint('ai.wienerdog.catchup', ['/usr/bin/node', program, 'catchup'])
+      ),
+    }),
+  });
+  assert.equal(out.length, 1, 'exactly one failure — the second, poisoned label');
+  assert.ok(out[0].includes('ai.wienerdog.catchup'), `the failure must name the SECOND label: ${out[0]}`);
+  const targets = calls.map((argv) => argv[2]);
+  assert.deepEqual(targets, [DOMAIN, `${DOMAIN}/ai.wienerdog.dream`, `${DOMAIN}/ai.wienerdog.catchup`]);
+});
+
+test('scheduler-leak-guard: loaded-record observer inspects EVERY selected label, including the last', () => {
+  // AC-1b alone is satisfied by `labels.slice(0, 2)`, a real implementation
+  // shape that still skips a poisoned THIRD label. Only this test proves the
+  // every-label property.
+  const tempRoot = path.join(os.tmpdir(), 'wd-scenarios-AC1c');
+  const program = path.join(tempRoot, 'core', 'launcher', 'launch.js');
+  const calls = [];
+  const out = scg.assertNoLoadedSchedulerLeak(tempRoot, {
+    platform: 'darwin',
+    uid: UID,
+    notice: () => {},
+    run: makeRun(calls, {
+      [DOMAIN]: ok(domainPrint(['ai.wienerdog.dream', 'ai.wienerdog.weekly', 'ai.wienerdog.catchup'])),
+      [`${DOMAIN}/ai.wienerdog.dream`]: ok(
+        recordPrint('ai.wienerdog.dream', ['/usr/bin/node', '/Users/u/.wienerdog/launcher/launch.js', 'dream'])
+      ),
+      [`${DOMAIN}/ai.wienerdog.weekly`]: ok(
+        recordPrint('ai.wienerdog.weekly', ['/usr/bin/node', '/Users/u/.wienerdog/launcher/launch.js', 'weekly'])
+      ),
+      [`${DOMAIN}/ai.wienerdog.catchup`]: ok(
+        recordPrint('ai.wienerdog.catchup', ['/usr/bin/node', program, 'catchup'])
+      ),
+    }),
+  });
+  assert.equal(out.length, 1);
+  assert.ok(out[0].includes('ai.wienerdog.catchup'), `the failure must name the THIRD label: ${out[0]}`);
+  const targets = calls.map((argv) => argv[2]);
+  assert.deepEqual(targets, [
+    DOMAIN,
+    `${DOMAIN}/ai.wienerdog.dream`,
+    `${DOMAIN}/ai.wienerdog.weekly`,
+    `${DOMAIN}/ai.wienerdog.catchup`,
+  ]);
+});
+
+test('scheduler-leak-guard: loaded-record observer invokes the loader by ABSOLUTE path (domain print and record print)', () => {
+  // The harness prepends a fail-closed loader-shim dir to PATH, so a bare
+  // `launchctl` could resolve to the guard's OWN containment machinery.
+  const tempRoot = path.join(os.tmpdir(), 'wd-scenarios-AC4');
+  const calls = [];
+  scg.assertNoLoadedSchedulerLeak(tempRoot, {
+    platform: 'darwin',
+    uid: UID,
+    notice: () => {},
+    run: makeRun(calls, {
+      [DOMAIN]: ok(domainPrint(['ai.wienerdog.dream'])),
+      [`${DOMAIN}/ai.wienerdog.dream`]: ok(
+        recordPrint('ai.wienerdog.dream', ['/usr/bin/node', '/Users/u/.wienerdog/launcher/launch.js', 'dream'])
+      ),
+    }),
+  });
+  assert.equal(calls.length, 2, 'one domain print plus one record print');
+  for (const argv of calls) {
+    assert.equal(argv[0], '/bin/launchctl', `every call must use the absolute loader path: ${JSON.stringify(argv)}`);
+  }
+});
+
+test('scheduler-leak-guard: a print exit of 1 or 112 is a FAILURE, not a skip', () => {
+  // 113 and ONLY 113 is tolerated. A blanket "any non-zero exit is a skip"
+  // would fail open in a module whose whole doctrine is fail-closed.
+  const tempRoot = path.join(os.tmpdir(), 'wd-scenarios-M3');
+  const label = 'ai.wienerdog.dream';
+  const forRecord = (recordResult) => {
+    const calls = [];
+    return scg.assertNoLoadedSchedulerLeak(tempRoot, {
+      platform: 'darwin',
+      uid: UID,
+      notice: () => {},
+      run: makeRun(calls, { [DOMAIN]: ok(domainPrint([label])), [`${DOMAIN}/${label}`]: recordResult }),
+    });
+  };
+
+  for (const status of [1, 112]) {
+    const out = forRecord({ status, stdout: '', stderr: 'boom' });
+    assert.equal(out.length, 1, `record print exit ${status} must be a failure, not a skip`);
+    assert.ok(out[0].startsWith(UNVERIFIABLE_PREFIX), `exit ${status} → UNVERIFIABLE, got: ${out[0]}`);
+    assert.ok(!out[0].startsWith(LEAK_PREFIX), `exit ${status} is not evidence of a leak`);
+  }
+});
+
+test('scheduler-leak-guard: loaded-record observer fails closed when the domain cannot be enumerated', () => {
+  // Table A's enumerate rows: there is NO path from "unreachable domain" to
+  // []. 112 is the load-bearing one — a headless/SSH session with no
+  // gui/<uid> domain must not print a green line over a domain it never saw.
+  const tempRoot = path.join(os.tmpdir(), 'wd-scenarios-M3b');
+  const enumerateWith = (domainResult) => {
+    const calls = [];
+    const out = scg.assertNoLoadedSchedulerLeak(tempRoot, {
+      platform: 'darwin',
+      uid: UID,
+      notice: () => {},
+      run: makeRun(calls, { [DOMAIN]: domainResult }),
+    });
+    return { out, calls };
+  };
+
+  const unterminated = ['com.apple.xpc.launchd.domain.gui.501 = {', '\tservices = {', '\t\t       0      0 \tai.wienerdog.dream'].join('\n');
+  const branches = [
+    ['spawn error', { error: new Error('spawn /bin/launchctl ENOENT'), status: null }],
+    ['exit 112 (no such domain — headless/SSH)', { status: 112, stdout: '', stderr: 'Could not find domain for user gui: 501' }],
+    ['non-string stdout', { status: 0, stdout: undefined, stderr: '' }],
+    ['unterminated services block', { status: 0, stdout: unterminated, stderr: '' }],
+  ];
+  for (const [name, domainResult] of branches) {
+    const { out, calls } = enumerateWith(domainResult);
+    assert.equal(out.length, 1, `${name} must yield exactly one failure`);
+    assert.ok(out[0].startsWith(UNVERIFIABLE_PREFIX), `${name} → UNVERIFIABLE, got: ${out[0]}`);
+    assert.ok(!out[0].startsWith(LEAK_PREFIX), `${name} is not evidence of a leak`);
+    assert.equal(calls.length, 1, `${name} must make ZERO per-record calls`);
+  }
+
+  // The verified clean: the domain WAS reachable and WAS enumerated, and it
+  // holds no Wienerdog registration.
+  const clean = enumerateWith(ok(domainPrint(['com.apple.Finder', 'com.google.keystone.user.agent'])));
+  assert.deepEqual(clean.out, []);
+  assert.equal(clean.calls.length, 1, 'no record print is issued when no label matches');
+});
+
+test('scheduler-leak-guard: a disabled services block is NOT accepted as the services block', () => {
+  // Exact trimmed EQUALITY on the opener. An `includes` implementation accepts
+  // the `disabled services = {` block, extracts zero labels (every row's last
+  // token is enabled/disabled) and returns a FALSE CLEAN where Table A
+  // requires UNVERIFIABLE. Without this decoy the rule is unfalsifiable.
+  const tempRoot = path.join(os.tmpdir(), 'wd-scenarios-M3c');
+  const decoy = [
+    'com.apple.xpc.launchd.domain.gui.501 = {',
+    '\ttype = user',
+    '\tdisabled services = {',
+    '\t\t"com.google.keystone.user.xpcservice" => enabled',
+    '\t\t"ai.wienerdog.dream" => disabled',
+    '\t}',
+    '}',
+  ].join('\n');
+  const calls = [];
+  const out = scg.assertNoLoadedSchedulerLeak(tempRoot, {
+    platform: 'darwin',
+    uid: UID,
+    notice: () => {},
+    run: makeRun(calls, { [DOMAIN]: ok(decoy) }),
+  });
+  assert.equal(out.length, 1, 'a domain print with no real services block is UNVERIFIABLE, never clean');
+  assert.ok(out[0].startsWith(UNVERIFIABLE_PREFIX), `expected UNVERIFIABLE, got: ${out[0]}`);
+  assert.equal(calls.length, 1, 'no record print may be issued');
+});
+
+test("scheduler-leak-guard: loaded-record observer catches a STALE leak from another run's temp root", () => {
+  // The 2026-07-22 record belonged to an EARLIER run: a tempRoot-only prefix
+  // set would report it clean, which is exactly how it survived for weeks.
+  const tempRoot = path.join(os.tmpdir(), 'wd-scenarios-THISRUN');
+  const staleRoot = path.join(os.tmpdir(), 'wd-negative-UezlJP');
+  const program = path.join(staleRoot, 'core', 'launcher', 'launch.js');
+  const calls = [];
+  const out = scg.assertNoLoadedSchedulerLeak(tempRoot, {
+    platform: 'darwin',
+    uid: UID,
+    notice: () => {},
+    run: makeRun(calls, {
+      [DOMAIN]: ok(domainPrint(['ai.wienerdog.catchup'])),
+      [`${DOMAIN}/ai.wienerdog.catchup`]: ok(
+        recordPrint('ai.wienerdog.catchup', ['/usr/bin/node', program, 'catchup'])
+      ),
+    }),
+  });
+  assert.equal(out.length, 1, "a leak under a SIBLING run's root must still be caught");
+  assert.ok(out[0].startsWith(LEAK_PREFIX));
+  assert.ok(out[0].includes(program));
+
+  // The converse pins Table D's single mechanism: a `wd-` path SEGMENT is not
+  // a temp marker (WIENERDOG_HOME=~/wd-dev is a legitimate install), so
+  // re-introducing a `wd-` rule turns this half red instead of shipping.
+  const cleanCalls = [];
+  const clean = scg.assertNoLoadedSchedulerLeak(tempRoot, {
+    platform: 'darwin',
+    uid: UID,
+    notice: () => {},
+    prefixes: ['/nonexistent-root'],
+    run: makeRun(cleanCalls, {
+      [DOMAIN]: ok(domainPrint(['ai.wienerdog.dream', 'ai.wienerdog.catchup'])),
+      [`${DOMAIN}/ai.wienerdog.dream`]: ok(
+        recordPrint('ai.wienerdog.dream', ['/usr/bin/node', '/Users/u/.wienerdog/launcher/launch.js', 'dream'])
+      ),
+      [`${DOMAIN}/ai.wienerdog.catchup`]: ok(
+        recordPrint('ai.wienerdog.catchup', ['/usr/bin/node', '/Users/u/wd-dev/launcher/launch.js', 'catchup'])
+      ),
+    }),
+  });
+  assert.deepEqual(clean, [], 'Table D has exactly one, location-shaped mechanism — no `wd-` segment rule');
+});
+
+test("scheduler-leak-guard: the product's neutralizer env vars do NOT silence the observer", () => {
+  // WIENERDOG_LOADER_NOOP and WIENERDOG_TEST_NO_REAL_SCHEDULER neutralize the
+  // PRODUCT's loader. Honoring them here would let the leaking configuration
+  // disable its own detector — and tests/run.js sets the second one for the
+  // whole suite, so such a guard would be dead under CI.
+  const tempRoot = path.join(os.tmpdir(), 'wd-scenarios-M5');
+  const program = path.join(tempRoot, 'core', 'launcher', 'launch.js');
+  withGuardEnv({ guard: '1', noop: '1' }, () => {
+    assert.equal(process.env.WIENERDOG_TEST_NO_REAL_SCHEDULER, '1');
+    assert.equal(process.env.WIENERDOG_LOADER_NOOP, '1');
+    const calls = [];
+    const out = scg.assertNoLoadedSchedulerLeak(tempRoot, {
+      platform: 'darwin',
+      uid: UID,
+      notice: () => {},
+      run: makeRun(calls, {
+        [DOMAIN]: ok(domainPrint(['ai.wienerdog.catchup'])),
+        [`${DOMAIN}/ai.wienerdog.catchup`]: ok(
+          recordPrint('ai.wienerdog.catchup', ['/usr/bin/node', program, 'catchup'])
+        ),
+      }),
+    });
+    assert.equal(out.length, 1, 'the neutralizers must not silence the observer');
+    assert.ok(out[0].startsWith(LEAK_PREFIX));
+  });
+});
+
+test('scheduler-leak-guard: the loaded-record observer reads NO scheduler artifact file', () => {
+  // The clean-looking plist must not be able to satisfy the observer: it was
+  // correct for the whole incident. fs.realpathSync(os.tmpdir()) is outside
+  // the spied set on purpose — it resolves a directory NAME and reads no
+  // content.
+  const tempRoot = path.join(os.tmpdir(), 'wd-scenarios-M6');
+  const program = path.join(tempRoot, 'core', 'launcher', 'launch.js');
+  const calls = [];
+  const run = makeRun(calls, {
+    [DOMAIN]: ok(domainPrint(['ai.wienerdog.catchup'])),
+    [`${DOMAIN}/ai.wienerdog.catchup`]: ok(
+      recordPrint('ai.wienerdog.catchup', ['/usr/bin/node', program, 'catchup'])
+    ),
+  });
+  const realReadFileSync = fs.readFileSync;
+  const realReaddirSync = fs.readdirSync;
+  const realOpenSync = fs.openSync;
+  let fsReads = 0;
+  let out;
+  try {
+    fs.readFileSync = (...a) => {
+      fsReads += 1;
+      return realReadFileSync(...a);
+    };
+    fs.readdirSync = (...a) => {
+      fsReads += 1;
+      return realReaddirSync(...a);
+    };
+    fs.openSync = (...a) => {
+      fsReads += 1;
+      return realOpenSync(...a);
+    };
+    out = scg.assertNoLoadedSchedulerLeak(tempRoot, { platform: 'darwin', uid: UID, notice: () => {}, run });
+  } finally {
+    fs.readFileSync = realReadFileSync;
+    fs.readdirSync = realReaddirSync;
+    fs.openSync = realOpenSync;
+  }
+  assert.equal(fsReads, 0, 'the observer must consult no scheduler artifact file');
+  assert.equal(out.length, 1);
+  assert.ok(out[0].startsWith(LEAK_PREFIX));
+});
+
+test("scheduler-leak-guard: opts.platform 'linux' does not take the darwin arm", () => {
+  // The operator-precedence trap: `(opts.platform || process.platform === 'darwin')`
+  // is truthy for ANY non-empty opts.platform, including 'linux'.
+  const notices = [];
+  const calls = [];
+  const run = (argv) => {
+    calls.push([...argv]);
+    throw new Error('the non-darwin arm must not invoke launchctl');
+  };
+  const notice = (m) => notices.push(m);
+
+  const linux = scg.assertNoLoadedSchedulerLeak('/tmp/wd-nonexistent', { platform: 'linux', uid: UID, run, notice });
+  assert.deepEqual(linux, []);
+  assert.equal(calls.length, 0, "opts.platform 'linux' must not take the darwin arm");
+  assert.equal(notices.length, 1, 'exactly one notice naming the linux residual');
+
+  const win = scg.assertNoLoadedSchedulerLeak('/tmp/wd-nonexistent', { platform: 'win32', uid: UID, run, notice });
+  assert.deepEqual(win, []);
+  assert.equal(calls.length, 0);
+  assert.equal(notices.length, 2, 'exactly one notice per call');
+});
+
+test('scheduler-leak-guard: a listed-then-unloaded label is skipped WITH a notice', () => {
+  // 113 is launchd's "could not find service … in domain" — a genuine race
+  // between the domain print and the record print. It is the ONLY tolerated
+  // non-zero exit, and no disposition in Table A is silent.
+  const tempRoot = path.join(os.tmpdir(), 'wd-scenarios-M9');
+  const notices = [];
+  const calls = [];
+  const out = scg.assertNoLoadedSchedulerLeak(tempRoot, {
+    platform: 'darwin',
+    uid: UID,
+    notice: (m) => notices.push(m),
+    run: makeRun(calls, {
+      [DOMAIN]: ok(domainPrint(['ai.wienerdog.dream'])),
+      [`${DOMAIN}/ai.wienerdog.dream`]: {
+        status: 113,
+        stdout: '',
+        stderr: 'Could not find service "ai.wienerdog.dream" in domain for user gui: 501',
+      },
+    }),
+  });
+  assert.deepEqual(out, [], 'exit 113 is a skip, not a failure');
+  assert.equal(notices.length, 1, 'the skip must PRINT');
+  assert.ok(notices[0].includes('ai.wienerdog.dream'), `the notice names the label: ${notices[0]}`);
+  assert.ok(notices[0].includes('113'), `the notice names the exit code: ${notices[0]}`);
+});
+
+test('scheduler-leak-guard: a temp-origin argument is classed LEAK, an unreadable record UNVERIFIABLE', () => {
+  // The two class prefixes are how a human tells "your machine is poisoned"
+  // from "this observer could not see". Both fail the run.
+  const tempRoot = path.join(os.tmpdir(), 'wd-scenarios-M11');
+  const program = path.join(tempRoot, 'core', 'launcher', 'launch.js');
+  const label = 'ai.wienerdog.catchup';
+  const forRecord = (recordResult) => {
+    const calls = [];
+    return scg.assertNoLoadedSchedulerLeak(tempRoot, {
+      platform: 'darwin',
+      uid: UID,
+      notice: () => {},
+      run: makeRun(calls, { [DOMAIN]: ok(domainPrint([label])), [`${DOMAIN}/${label}`]: recordResult }),
+    });
+  };
+
+  const leak = forRecord(ok(recordPrint(label, ['/usr/bin/node', program, 'catchup'])));
+  assert.equal(leak.length, 1);
+  assert.ok(leak[0].startsWith(LEAK_PREFIX), `a temp-origin argument is a LEAK, got: ${leak[0]}`);
+
+  const unreadable = [
+    ['spawn error', { error: new Error('spawn /bin/launchctl EAGAIN'), status: null }],
+    ['non-string stdout', { status: 0, stdout: undefined, stderr: '' }],
+    ['no arguments block', ok([`${label} = {`, '\tactive count = 1', '}'].join('\n'))],
+    ['unterminated arguments block', ok([`${label} = {`, '\targuments = {', `\t\t${program}`].join('\n'))],
+  ];
+  for (const [name, recordResult] of unreadable) {
+    const out = forRecord(recordResult);
+    assert.equal(out.length, 1, `${name} must yield exactly one failure`);
+    assert.ok(out[0].startsWith(UNVERIFIABLE_PREFIX), `${name} → UNVERIFIABLE, got: ${out[0]}`);
+    assert.ok(!out[0].startsWith(LEAK_PREFIX), `${name} is not evidence of a leak`);
+  }
+});
+
+test('scheduler-leak-guard: two calls on the same canned input return identical results', () => {
+  // Idempotent and read-only. A bare deepEqual(first, second) does NOT catch a
+  // module-scope accumulator: both calls would return the SAME array object,
+  // so `first` IS `second` and the comparison passes. Hence the snapshot, the
+  // explicit cardinality, and notStrictEqual.
+  const tempRoot = path.join(os.tmpdir(), 'wd-negative-UezlJP');
+  const label = 'ai.wienerdog.catchup';
+  const program = path.join(tempRoot, 'core', 'launcher', 'launch.js');
+  const responses = {
+    [DOMAIN]: ok(domainPrint([label])),
+    [`${DOMAIN}/${label}`]: ok(recordPrint(label, ['/opt/homebrew/bin/node', program, 'catchup'])),
+  };
+
+  const callsA = [];
+  const first = scg.assertNoLoadedSchedulerLeak(tempRoot, {
+    platform: 'darwin',
+    uid: UID,
+    notice: () => {},
+    run: makeRun(callsA, responses),
+  });
+  const firstSnapshot = structuredClone(first);
+  const firstCalls = structuredClone(callsA);
+  assert.equal(firstSnapshot.length, 1);
+  assert.equal(firstSnapshot[0], expectedLeakMessage(label, program));
+
+  const callsB = [];
+  const second = scg.assertNoLoadedSchedulerLeak(tempRoot, {
+    platform: 'darwin',
+    uid: UID,
+    notice: () => {},
+    run: makeRun(callsB, responses),
+  });
+  assert.notStrictEqual(first, second, 'each call must return a FRESH array');
+  assert.equal(second.length, 1);
+  assert.deepEqual(second, firstSnapshot);
+  assert.deepEqual(callsB, firstCalls);
+});
+
+test('scheduler-leak-guard: the LEAK message equals its contracted text exactly', () => {
+  // EQUALITY, not properties of the string. Three earlier review rounds each
+  // shipped a property-shaped assertion (source grep, absence-of-&&, marker
+  // slicing) and each was evaded by a message that still stranded the user.
+  // Equality subsumes the bootstrap-first ordering AND the unconditional `;`
+  // separator without restating either, and no substring satisfiable from
+  // elsewhere in the message can defeat it.
+  const tempRoot = path.join(os.tmpdir(), 'wd-negative-UezlJP');
+  const label = 'ai.wienerdog.catchup';
+  const program = path.join(tempRoot, 'core', 'launcher', 'launch.js');
+  const calls = [];
+  const out = scg.assertNoLoadedSchedulerLeak(tempRoot, {
+    platform: 'darwin',
+    uid: UID,
+    notice: () => {},
+    run: makeRun(calls, {
+      [DOMAIN]: ok(domainPrint([label])),
+      [`${DOMAIN}/${label}`]: ok(recordPrint(label, ['/opt/homebrew/bin/node', program, 'catchup'])),
+    }),
+  });
+  assert.equal(out.length, 1);
+  assert.equal(out[0], expectedLeakMessage(label, program));
+});


### PR DESCRIPTION
Spec: docs/specs/WP-scheduler-loaded-record-tripwire.md

## What this changes

`tests/scenarios/scheduler-guard.js` gains a third fail-closed tripwire,
`assertNoLoadedSchedulerLeak`: the LOADED-RECORD observer. It enumerates the
loaded labels from the `services = {` block of `/bin/launchctl print gui/<uid>`
and reads each `ai.wienerdog.*` record's `arguments = {` block from the **same
domain**, failing the run when any argument is temp-origin (Table D's single
prefix mechanism: `tempRoot`, `os.tmpdir()` and its realpath). Both scenario
harnesses call it from inside their existing `finally` block.

**This WP does not close the incident class on its own.** It fixes the *test
harness's* observer. Its sibling `WP-scheduler-entry-identity` fixes the
*product's* health probe and heal, which mapped `launchctl print`'s exit code 0
to `loaded` and printed a green `wienerdog doctor` line throughout the incident.
The class is closed only when **both** have merged.

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

Five files changed: the four Deliverables rows plus this spec's own `status:`
flip (always allowed without listing, per `_TEMPLATE.md`).

```
 docs/specs/WP-scheduler-loaded-record-tripwire.md |   2 +-
 tests/scenarios/negative/run-negative.js          |   1 +
 tests/scenarios/run-scenarios.js                  |   1 +
 tests/scenarios/scheduler-guard.js                | 278 +++++++++-
 tests/unit/scheduler-leak-guard.test.js           | 590 ++++++++++++++++++++++
 5 files changed, 864 insertions(+), 8 deletions(-)
```

## Verification output

### Step 1 — the guard suite with the machine-checked non-vacuity gate

```
$ node tests/run.js --test-reporter=tap --test-name-pattern "scheduler-leak-guard" \
      tests/unit/scheduler-leak-guard.test.js | grep -cE "^ok [0-9]+ - scheduler-leak-guard: "
37

named passing subtests: 37     ->  37 >= 37, gate PASSES (zero slack, as specified)
```

Discrimination re-confirmed on this tree, same command with a non-matching
pattern:

```
$ node tests/run.js --test-reporter=tap --test-name-pattern "zzz-nope" \
      tests/unit/scheduler-leak-guard.test.js | grep -cE "^ok [0-9]+ - scheduler-leak-guard: "
0
probe grep exit: 1
```

The 37 is exactly the spec's derivation: 22 pre-existing named subtests + the 15
distinct test names the Mutation checks table requires. Full run of the file:

```
$ node tests/run.js tests/unit/scheduler-leak-guard.test.js
...
✔ scheduler-leak-guard: loaded-record observer FAILS on a record whose loaded argv is under the OS temp dir
✔ scheduler-leak-guard: loaded-record observer does not stop at the FIRST selected label
✔ scheduler-leak-guard: loaded-record observer inspects EVERY selected label, including the last
✔ scheduler-leak-guard: loaded-record observer invokes the loader by ABSOLUTE path (domain print and record print)
✔ scheduler-leak-guard: a print exit of 1 or 112 is a FAILURE, not a skip
✔ scheduler-leak-guard: loaded-record observer fails closed when the domain cannot be enumerated
✔ scheduler-leak-guard: a disabled services block is NOT accepted as the services block
✔ scheduler-leak-guard: loaded-record observer catches a STALE leak from another run's temp root
✔ scheduler-leak-guard: the product's neutralizer env vars do NOT silence the observer
✔ scheduler-leak-guard: the loaded-record observer reads NO scheduler artifact file
✔ scheduler-leak-guard: opts.platform 'linux' does not take the darwin arm
✔ scheduler-leak-guard: a listed-then-unloaded label is skipped WITH a notice
✔ scheduler-leak-guard: a temp-origin argument is classed LEAK, an unreadable record UNVERIFIABLE
✔ scheduler-leak-guard: two calls on the same canned input return identical results
✔ scheduler-leak-guard: the LEAK message equals its contracted text exactly
ℹ tests 37
ℹ pass 37
ℹ fail 0
```

### Step 2 — `npm test` (whole suite + golden files)

```
$ npm test
ℹ tests 1686
ℹ suites 0
ℹ pass 1681
ℹ fail 0
ℹ cancelled 0
ℹ skipped 5
ℹ todo 0
ℹ duration_ms 41961.08525
```

(Re-run after every mutation was reverted, to prove the tree is unmutated.)

### Step 3 — `npm run lint`

```
$ npm run lint
--- markdownlint ---
markdownlint-cli2 v0.23.0 (markdownlint v0.41.0)
Finding: docs/**/*.md skills/**/*.md templates/**/*.md tests/**/*.md *.md
Linting: 374 file(s)
Summary: 0 error(s)
--- shellcheck ---
--- PSScriptAnalyzer ---
--- frontmatter check ---
frontmatter check passed: 200 spec(s), 4 agent(s)

lint passed
```

### Step 4 — scenario infra has acquired no product import

```
$ grep -nE "require\(['\"](\.\./)+src/" tests/scenarios/scheduler-guard.js
grep exit: 1
OK: scheduler-guard.js imports no src/ module
```

### Step 4a — call sites checked for PLACEMENT (AC-8)

```
$ awk '/^  \} finally \{$/{inb=1} inb{print} inb && /^  \}$/{exit}' tests/scenarios/run-scenarios.js \
    | grep -nE "^[[:space:]]*if \(root\) failures\.push\(\.\.\.scg\.assertNoLoadedSchedulerLeak\(root\)\);"
18:    if (root) failures.push(...scg.assertNoLoadedSchedulerLeak(root));

$ awk '/^  \} finally \{$/{inb=1} inb{print} inb && /^  \}$/{exit}' tests/scenarios/negative/run-negative.js \
    | grep -nE "^[[:space:]]*if \(root\) failures\.push\(\.\.\.scg\.assertNoLoadedSchedulerLeak\(root\)\);"
9:    if (root) failures.push(...scg.assertNoLoadedSchedulerLeak(root));
```

(The line numbers are offsets *within the extracted `finally` body*, which is the
point of the range scoping.)

### Step 4b — placement, signature, and the scoped no-`opts.env` property

```
$ grep -oE "^function [A-Za-z0-9_]+" tests/scenarios/scheduler-guard.js | tail -1
function assertNoLoadedSchedulerLeak
last top-level function: function assertNoLoadedSchedulerLeak      -> (i) OK

$ grep -nE "^function assertNoLoadedSchedulerLeak\(tempRoot, opts = \{\}\) \{$" tests/scenarios/scheduler-guard.js
418:function assertNoLoadedSchedulerLeak(tempRoot, opts = {}) {   -> (ii) OK

$ awk '/^function assertNoLoadedSchedulerLeak\(/{inf=1} inf{print} /^module\.exports/{if(inf) exit}' \
    tests/scenarios/scheduler-guard.js | grep -nE "opts\.env"
scoped opts.env grep exit: 1
OK: assertNoLoadedSchedulerLeak is defined last and never reads opts.env   -> (iii) OK
```

### Step 5 — both stale module-header claims are gone

```
$ grep -n "No \`child_process\` here" tests/scenarios/scheduler-guard.js
child_process claim grep exit: 1
OK: the module header records the new child_process fact

$ grep -n "adds two fail-closed tripwires" tests/scenarios/scheduler-guard.js
two-tripwires grep exit: 1
OK: the module header's tripwire count is current

$ grep -n "assertNoLoadedSchedulerLeak" tests/scenarios/scheduler-guard.js | head -1
19:// (`assertNoLoadedSchedulerLeak`).
```

### Step 6 — real-machine sanity, macOS, read-only, GUI login session

Run on macOS 26.5 (darwin 25.5.0) from a GUI login session, as Definition of
done item 2 requires:

```
$ node -e '...the spec's step-6 script verbatim...'
OK: the gui/<uid> domain was enumerated and no loaded Wienerdog record
    executes anything under the OS temp dir
```

Exit 0, no `LEAK` results and no `UNVERIFIABLE` results. The `gui/<uid>` domain
was genuinely reachable and enumerated — Table A's enumerate rows would have
turned an unreachable domain into an `UNVERIFIABLE` failure rather than an empty
array, which is what makes this green line usable as evidence. (The maintainer's
hijacked `ai.wienerdog.catchup` record was repaired by hand before this spec was
written; this run confirms the machine is currently clean.)

### Mutation checks

Every mutation was applied on top of this branch, the named check was run, and
the mutation was reverted. Runner: `node tests/run.js --test-reporter=tap
--test-name-pattern "<name>" tests/unit/scheduler-leak-guard.test.js`, never a
bare `node --test`. "RED" means exit != 0 **and** the TAP stream carried at least
one `not ok N - scheduler-leak-guard: <name>` line — the file wrapper counting as
a pass is not accepted as evidence.

| # | Mutation | Must turn red | Result |
|---|----------|---------------|--------|
| M1 | `isTempOrigin` never matches a temp prefix | `…FAILS on a record whose loaded argv is under the OS temp dir` | **RED** (exit 1, not-ok 1) |
| M1b | `labels.slice(0, 1)` | `…does not stop at the FIRST selected label` | **RED** (exit 1, not-ok 1) |
| M1c | `labels.slice(0, 2)` | `…inspects EVERY selected label, including the last` | **RED** (exit 1, not-ok 1) |
| M2 | `LAUNCHCTL_PATH` -> bare `'launchctl'` | `…invokes the loader by ABSOLUTE path (domain print and record print)` | **RED** (exit 1, not-ok 1) — see Discovered issue 1 for the pattern escaping |
| M3 | any non-zero per-record print exit is a skip | `a print exit of 1 or 112 is a FAILURE, not a skip` | **RED** (exit 1, not-ok 1) |
| M3b | return `[]` when the domain print exits non-zero | `…fails closed when the domain cannot be enumerated` | **RED** (exit 1, not-ok 1) |
| M3c | opener matched with `trim().includes(...)` | `a disabled services block is NOT accepted as the services block` | **RED** (exit 1, not-ok 1) |
| M4 | prefixes from `tempRoot` only | `…catches a STALE leak from another run's temp root` | **RED** (exit 1, not-ok 1) |
| M5 | early-return `[]` when `WIENERDOG_TEST_NO_REAL_SCHEDULER` is set | `the product's neutralizer env vars do NOT silence the observer` | **RED** (exit 1, not-ok 1) |
| M6 | read `~/Library/LaunchAgents/<label>.plist` and skip on no temp path | `the loaded-record observer reads NO scheduler artifact file` | **RED** (exit 1, not-ok 1) |
| M7 | `(opts.platform \|\| process.platform === 'darwin')` | `opts.platform 'linux' does not take the darwin arm` | **RED** (exit 1, not-ok 1) |
| M8 | comment out the call in `run-negative.js` | verification step 4a's range grep | **RED** — grep exit 1, empty stdout |
| M8b | move the call in `run-scenarios.js` one line above `} finally {` | verification step 4a's range grep | **RED** — grep exit 1, empty stdout; whole-file `grep -c` still reports 1 occurrence, which is exactly why the check is range-scoped |
| M9 | drop the exit-113 notice | `a listed-then-unloaded label is skipped WITH a notice` | **RED** (exit 1, not-ok 1) |
| M10 | `const env = opts.env \|\| process.env;` inside the new function | verification step 4b's scoped range check | **RED** — scoped grep exits 0 (`2:  const env = opts.env \|\| process.env;`), i.e. the check takes its FAIL branch |
| M11 | `LEAK` prefix -> `UNVERIFIABLE` | `a temp-origin argument is classed LEAK, an unreadable record UNVERIFIABLE` | **RED** (exit 1, not-ok 1) |
| M12 | swap the repair steps so `bootout` is first | `the LEAK message equals its contracted text exactly` | **RED** (exit 1, not-ok 1) |
| M12b | quote the marker in the preamble, rename the real heading | same test | **RED** (exit 1, not-ok 1) |
| M13 | repair separator `;` -> `&&` | same test | **RED** (exit 1, not-ok 1) |
| M13b | repair separator `;` -> `\|\|` | same test | **RED** (exit 1, not-ok 1) |
| M13c | `\|\|` **plus** a reference line carrying the contracted `;` sequence | same test | **RED** (exit 1, not-ok 1) |
| M14 | hoist the `failures` accumulator to module scope | `two calls on the same canned input return identical results` | **RED** (exit 1, not-ok 1) |

22 of 22 rows caught. Zero survivors. The tree was restored byte-for-byte after
each mutation and `npm test` was re-run afterwards (see step 2 above).

## Decisions made

The spec decided the exit-113 discriminant, the `LEAK`/`UNVERIFIABLE` split, the
single-mechanism temp-origin predicate and the repair-advice ordering; none of
those is re-litigated here. What was genuinely ambiguous and resolved with the
simpler option:

1. **One failure per offending *record*, not per offending argument.** The
   `@returns` contract says "one loud, actionable failure per offending record",
   so the argument loop `break`s after the first temp-origin argument. A record
   whose `node` binary *and* launcher were both in temp would otherwise produce
   two near-identical failures for one problem.
2. **The `services` / `arguments` block parser is one shared local helper**
   (`block(stdout, opener)`) rather than two. Both blocks have the same shape —
   exact-trimmed-equality opener, read forward to the first line trimming to `}`
   — and Table A dispositions the two failure modes ("no opener" / "never
   closed") identically for both stages, so one parameterised reader was the
   smaller change. It is a `const` arrow inside the observer, so it does not
   disturb verification step 4b's "last top-level `function`" check.
3. **The `LEAK` message is built inline in the observer, not factored into a
   helper.** The spec permits a helper but requires it be defined *above* the
   observer; four lines inline is simpler and removes the placement hazard
   entirely.
4. **Empty rows inside a parsed block are skipped, not treated as data.** A
   blank line in a `services` or `arguments` block would otherwise produce the
   label/argument `''`, which the anchored `LOADED_LABEL_PATTERN` rejects anyway
   for labels but which would have needed its own guard for arguments.
5. **The `UNVERIFIABLE` message texts** are not contracted (only the prefix is),
   so they were written to name the observed exit codes and to state explicitly
   that they are not evidence of a leak.
6. **Fifteen new tests, exactly the fifteen names the Mutation checks table
   requires** — no extra names. Everything AC-1 … AC-7 and AC-11/AC-12 demand
   beyond those fifteen (the clean-case converses, the exhaustive per-record and
   enumerate branch lists, the `win32` arm, the `wd-dev` half of AC-3) is folded
   in as additional assertions inside those tests. This keeps step 1's floor
   equal to the spec's derivation (22 + 15 = 37) rather than silently exceeding
   it, so the gate stays as tight as the spec intends.
7. **`opts.uid: 501` is injected in every unit test**, so no test calls
   `process.getuid()` and the canned `run` map keys are deterministic. The
   injected `run` throws on an unstubbed target, so a test can never silently
   pass over a call it did not expect.

## Discovered issues (out of scope, not fixed)

1. **The M2 row's test name contains regex metacharacters, so the spec's own
   literal mutation command is vacuous for it.** `--test-name-pattern` takes a
   **regex**, and the contracted name
   `scheduler-leak-guard: loaded-record observer invokes the loader by ABSOLUTE path (domain print and record print)`
   has unescaped `(` … `)`. Passing it verbatim matches nothing: the run exits 0
   with zero named subtests, so M2 reports as a *survivor* even against a
   correctly-implemented guard — the exact "a zero-match pattern reports pass"
   trap the spec warns about elsewhere. Reproduced here: with the verbatim name,
   `exit=0, not-ok=0, ok-named=0`; with the pattern
   `"invokes the loader by ABSOLUTE path"` the same mutation gives
   `not ok 1 - scheduler-leak-guard: loaded-record observer invokes the loader by ABSOLUTE path (domain print and record print)`,
   `exit=1`. The test name is contractual (AC-9 counts it), so it was **not**
   renamed and the mutation was run with the escaped pattern instead. A future
   spec pass should either escape the parens in the Mutation checks table's
   command or drop them from the name. No code change made.
2. **Verification step 1's gate has no lower bound on named subtests other than
   the floor**, so a pattern typo that selects *more* than 37 (e.g. a broader
   prefix) would still pass. Not a problem here — the pattern is the file-wide
   `scheduler-leak-guard` prefix by design — but the gate proves "at least 37",
   not "exactly the expected set". Noted, not changed.

Nothing else was touched. No `src/` file, no ADR, no logbook entry, no
`memory/lessons/inbox.md`.

## Dogfooding lessons

- WP-scheduler-loaded-record-tripwire: `--test-name-pattern` is a **regex**, not
  a literal. A contracted test name containing `(`, `)`, `[`, `.` or `+` makes
  the spec's own mutation command select zero tests and exit 0 — which reads as
  "mutation survived" against correct code, or worse as "test passed" against
  broken code. Always confirm the reporter emitted a `not ok N - <the test name>`
  line, never just the exit code.
- WP-scheduler-loaded-record-tripwire: a mutation whose only effect is to change
  a *condition* often is not red, because the code falls through to a later
  fail-closed branch and produces the same shaped output. M3b had to be written
  as an injected `return [];` rather than as `if (false)`, because with the
  condition disabled the `status: 112, stdout: ''` fixture still failed on the
  missing `services = {` opener and the test stayed green. Design the mutation
  against the *fixture*, not against the source line.
- WP-scheduler-loaded-record-tripwire: this repo's worktree tooling refuses
  multi-command shell one-liners with loops and `||`-chained exits, so the
  spec's `for f in …; do … done` verification steps had to be run one file at a
  time. Same evidence, but worth writing verification steps as independent
  single commands where possible.
- WP-scheduler-loaded-record-tripwire: `grep -c` exits **1** on a zero count.
  It is fine as the *positive* half of a gate (`… | grep -c pattern` → 37, exit
  0) but it silently doubles as a failure signal, so a step that pipes it into
  `[ "$n" -ge N ]` under `set -e` would die before the comparison ever ran.
- WP-scheduler-loaded-record-tripwire: monkeypatching `fs.readFileSync` /
  `readdirSync` / `openSync` on the shared `node:fs` module object is a sound way
  to assert "this function reads no file", but only because the function under
  test is fully synchronous — the spy window is exactly the call. Restore in a
  `finally`, and keep permitted metadata calls (`fs.realpathSync`) deliberately
  outside the spied set, with a comment saying why.

---
Generated-by: claude-opus-5
