### PR TITLE
fix(scheduler): verify loaded entry identity, not presence (WP-scheduler-entry-identity)

### DIFF
--- a/docs/specs/WP-scheduler-entry-identity.md
+++ b/docs/specs/WP-scheduler-entry-identity.md
@@ -1,7 +1,7 @@
 ---
 id: WP-scheduler-entry-identity
 title: Verify a scheduler entry's LOADED program identity, not its presence, in the product health probe and heal
-status: Ready
+status: In-Review
 model: opus
 size: M
 depends_on: []

--- a/src/cli/doctor.js
+++ b/src/cli/doctor.js
@@ -399,8 +399,11 @@ async function run(_argv) {
   );
 
   // Scheduler-load health: one line per registered entry via a LIVE read-only
-  // probe (authoritative — catches even the all-jobs-unloaded case). A missing
-  // entry is a warn (actionable), never a hard fail; doctor never mutates.
+  // probe of what the OS will ACTUALLY run (authoritative — catches a hijacked or
+  // stale loaded record, which a file check cannot see). A missing or
+  // unverifiable entry is a warn (actionable); an entry registered to run a
+  // program outside this install — or one that no longer exists — is a hard fail
+  // (exit 1), because it cannot work. doctor never mutates.
   const { doctorSchedulerChecks } = require('../scheduler/status');
   for (const c of doctorSchedulerChecks(paths)) check(c.status, c.msg);
 

--- a/src/cli/dream.js
+++ b/src/cli/dream.js
@@ -379,6 +379,9 @@ async function run(argv, opts = {}) {
         updateLine: renderUpdateLine(paths),
         identityApprovals: identityApprovals.approvalsMap(idReg),
         quarantineLine,
+        // Cache-only (no probe, no spawn, no heal): without this the nightly
+        // rewrite would wipe the scheduler callout sync wrote (ADR-0023 class).
+        schedulerLine: require('../scheduler/status').renderSchedulerStatusLine(paths),
         secretQuarantine: listSecretQuarantine(paths.state), // EP4 pending-review banner (WP-125)
         // Insecure-modes awareness banner (WP-126, OWNER-APPROVED): the nightly
         // path only READS modes — repair is sync's attended job, never here.

--- a/src/cli/schedule.js
+++ b/src/cli/schedule.js
@@ -22,10 +22,36 @@ function defaultLoader(argv) {
   return schedulerSpawn(argv);
 }
 
+/** The statuses a heal re-registers (WP-scheduler-entry-identity Table A): a
+ *  record that runs the wrong program, or one whose identity could not be read
+ *  back, is healed exactly like an absent one. */
+const HEAL_SET = new Set(['missing', 'mismatched', 'unverified']);
+
 /** Absolute path to the out-of-tree launcher the OS entries invoke (WP-157).
+ *  Delegates to generators.launcherPath — the single source, so the health
+ *  probe's expectation and the registered entry can never drift apart.
  *  @param {import('../core/paths').WienerdogPaths} paths @returns {string} */
 function launcherPathFor(paths) {
-  return path.join(paths.core, 'launcher', 'launch.js');
+  return gen.launcherPath(paths);
+}
+
+/**
+ * Replace a launchd registration. BOOTSTRAP FIRST — it is non-destructive and
+ * succeeds outright when nothing is loaded under the label (the `missing` case,
+ * one spawn, no teardown). ONLY when bootstrap fails (which is what launchd does
+ * for an already-loaded label) do we tear the existing record down and bootstrap
+ * again. Never boots out a record it has not first proven bootstrap-blocked, so a
+ * working-but-unverifiable entry is never destroyed by a heal that then fails.
+ * The bootout's status is ignored on purpose: correctness must not depend on
+ * which error launchd returns.
+ * @param {(argv:string[])=>{status:number}} loader
+ * @param {number} uid @param {string} label @param {string} plistPath
+ * @returns {boolean} true when the final bootstrap exited 0
+ */
+function darwinReplaceEntry(loader, uid, label, plistPath) {
+  if (loader(['launchctl', 'bootstrap', `gui/${uid}`, plistPath]).status === 0) return true;
+  loader(['launchctl', 'bootout', `gui/${uid}/${label}`]);
+  return loader(['launchctl', 'bootstrap', `gui/${uid}`, plistPath]).status === 0;
 }
 
 /**
@@ -604,7 +630,10 @@ function repairCatchup(paths, manifest, opts = {}) {
     const uid = process.getuid();
     const plistPath = path.join(gen.launchAgentsDir(paths.home), 'ai.wienerdog.catchup.plist');
     const probeArgv = gen.deriveProbeArgv(plistPath, platform);
-    if (!probeArgv || probe(probeArgv) !== 'missing') return {};
+    const idn = gen.deriveIdentityArgv(plistPath, platform);
+    const expect = idn ? { launcher: gen.launcherPath(paths), kind: idn.kind, identityArgv: idn.argv } : null;
+    const observed = probeArgv ? probe(probeArgv, expect, { run: opts.run }) : null;
+    if (!probeArgv || !HEAL_SET.has(observed)) return {};
     const content = gen.catchupPlist({
       node: gen.nodePath(),
       launcher: launcherPathFor(paths),
@@ -615,15 +644,23 @@ function repairCatchup(paths, manifest, opts = {}) {
       logDir: path.join(paths.logs, 'catchup'),
     });
     if (!writeCanonicalSchedule(plistPath, content) || !manifestLib.withinSchedulerRoot(plistPath, roots)) return {};
-    const loaded = loader(['launchctl', 'bootstrap', `gui/${uid}`, plistPath]).status === 0;
-    return loaded ? { notice: 'restored the missing catch-up registration.' } : { notice: "catch-up entry rewritten but the OS scheduler did not accept it — run 'wienerdog doctor'." };
+    // Pre-destructive durable marker — UNCONDITIONAL, before the replacement call
+    // (the same rule as reloadMissing: an observed `missing` can be a transient
+    // presence-query failure on a label darwinReplaceEntry will then boot out).
+    require('../scheduler/status').refreshSchedulerStatus(paths, opts);
+    const loaded = darwinReplaceEntry(loader, uid, 'ai.wienerdog.catchup', plistPath);
+    if (!loaded) return { notice: "catch-up entry rewritten but the OS scheduler did not accept it — run 'wienerdog doctor'." };
+    return successNotice(observed);
   }
 
   // win32
   const userId = gen.windowsCurrentUserId();
   const xmlPath = gen.windowsTaskFile(paths, 'catchup');
   const probeArgv = gen.deriveProbeArgv(xmlPath, platform);
-  if (!probeArgv || probe(probeArgv) !== 'missing') return {};
+  const idn = gen.deriveIdentityArgv(xmlPath, platform);
+  const expect = idn ? { launcher: gen.launcherPath(paths), kind: idn.kind, identityArgv: idn.argv } : null;
+  const observed = probeArgv ? probe(probeArgv, expect, { run: opts.run }) : null;
+  if (!probeArgv || !HEAL_SET.has(observed)) return {};
   const launchArgs = ['--catch-up', '--expect-digest', catchupExpectDigest(paths)];
   if (jobDigests) launchArgs.push('--job-digests', jobDigests);
   const argline = gen.windowsCmdArguments({
@@ -635,8 +672,21 @@ function repairCatchup(paths, manifest, opts = {}) {
   });
   const content = gen.windowsTaskXmlBytes(gen.windowsCatchupTaskXml({ command: gen.windowsCmdExePath(), argline, userId }));
   if (!writeCanonicalSchedule(xmlPath, content) || !manifestLib.withinSchedulerRoot(xmlPath, roots)) return {};
+  require('../scheduler/status').refreshSchedulerStatus(paths, opts); // pre-destructive marker
   const loaded = loader(['schtasks', '/create', '/tn', gen.windowsTaskName('catchup'), '/xml', xmlPath, '/f']).status === 0;
-  return loaded ? { notice: 'restored the missing catch-up registration.' } : { notice: "catch-up task rewritten but the OS scheduler did not accept it — run 'wienerdog doctor'." };
+  if (!loaded) return { notice: "catch-up task rewritten but the OS scheduler did not accept it — run 'wienerdog doctor'." };
+  return successNotice(observed);
+}
+
+/** The success notice for a repaired catch-up entry. Only an observed `missing`
+ *  gets the shipped "restored the missing …" string: emitting it for a hijacked
+ *  or unreadable entry would state something false, and `wienerdog adopt` turns
+ *  ANY notice into a user-facing adoption failure (adopt.js's rebindFailed
+ *  heuristic) — which on Windows, where any task round-trip deviation grades
+ *  `unverified`, would report failure on a healthy install.
+ *  @param {string|null} observed @returns {{notice?:string}} */
+function successNotice(observed) {
+  return observed === 'missing' ? { notice: 'restored the missing catch-up registration.' } : {};
 }
 
 /** The known scheduler roots for `paths` (LaunchAgents / systemd user dir /
@@ -711,7 +761,7 @@ function reloadJob(paths, job, loader, platform) {
     const content = gen.launchdPlist({ name: job.name, hour, minute, node, launcher: b.launcher, descriptor: b.descriptor, expectDigest: b.expectDigest, home: paths.home, core: paths.core, logDir });
     if (!writeCanonicalSchedule(plistPath, content)) return false;
     if (!manifestLib.withinSchedulerRoot(plistPath, roots)) return false;
-    return loader(['launchctl', 'bootstrap', `gui/${uid}`, plistPath]).status === 0;
+    return darwinReplaceEntry(loader, uid, label, plistPath);
   }
 
   if (platform === 'linux') {
@@ -965,4 +1015,4 @@ async function run(argv, { loader = defaultLoader, profile } = {}) {
   }
 }
 
-module.exports = { run, defaultLoader, repointSchedules, ensureDreamSchedule, registerPlatform, reloadJob };
+module.exports = { run, defaultLoader, repointSchedules, ensureDreamSchedule, registerPlatform, reloadJob, repairCatchup };

--- a/src/scheduler/generators.js
+++ b/src/scheduler/generators.js
@@ -32,6 +32,17 @@ function wienerdogBin(paths) {
 }
 
 /**
+ * Absolute path to the out-of-tree launcher every OS scheduler entry invokes
+ * (WP-157): `<core>/launcher/launch.js`. THE single source — src/cli/schedule.js's
+ * launcherPathFor now delegates here so the two can never drift.
+ * @param {import('../core/paths').WienerdogPaths} paths
+ * @returns {string}
+ */
+function launcherPath(paths) {
+  return path.join(paths.core, 'launcher', 'launch.js');
+}
+
+/**
  * macOS LaunchAgents dir.
  * @param {string} home
  * @returns {string}
@@ -138,6 +149,37 @@ function deriveProbeArgv(schedulePath, platform = process.platform, env = proces
   }
   if ((m = base.match(/^wienerdog-([a-z0-9][a-z0-9-]*)\.xml$/))) {
     return ['schtasks', '/query', '/tn', `\\Wienerdog\\${m[1]}`];
+  }
+  return null;
+}
+
+/**
+ * Re-derive the READ-ONLY query whose STDOUT carries a registered entry's LOADED
+ * EXEC IDENTITY — what the OS will actually run, as the OS itself reports it.
+ * Basename-shape derivation, fully anchored, exactly like deriveProbeArgv
+ * (ADR-0027: never read an argv out of the manifest). `platform` selects only the
+ * basename separator flavor.
+ * Returns `{kind, argv:null}` for a RECOGNIZED scheduler kind whose identity
+ * query is DECLARED UNIMPLEMENTED (systemd today — WP-scheduler-entry-identity
+ * Table B, Residual 1); returns `null` only for a basename this function does not
+ * recognize at all, so "systemd, deliberately not verified" stays distinguishable
+ * from "a fourth scheduler someone forgot to add here".
+ * @param {string} schedulePath
+ * @param {NodeJS.Platform} [platform]  basename separator flavor (default host)
+ * @returns {{argv:string[]|null, kind:'launchd'|'systemd'|'schtasks'}|null}
+ */
+function deriveIdentityArgv(schedulePath, platform = process.platform) {
+  const base = (platform === 'win32' ? path.win32 : path.posix).basename(schedulePath);
+  let m;
+  if ((m = base.match(/^(ai\.wienerdog\.[a-z0-9][a-z0-9-]*)\.plist$/))) {
+    if (typeof process.getuid !== 'function') return null;
+    return { kind: 'launchd', argv: ['launchctl', 'print', `gui/${process.getuid()}/${m[1]}`] };
+  }
+  if (/^wienerdog-[a-z0-9][a-z0-9-]*\.timer$/.test(base)) {
+    return { kind: 'systemd', argv: null }; // identity query declared unimplemented
+  }
+  if ((m = base.match(/^wienerdog-([a-z0-9][a-z0-9-]*)\.xml$/))) {
+    return { kind: 'schtasks', argv: ['schtasks', '/query', '/tn', `\\Wienerdog\\${m[1]}`, '/xml'] };
   }
   return null;
 }
@@ -630,6 +672,150 @@ function parseWindowsTaskExec(xml) {
   };
 }
 
+/** The launchd `arguments = { … }` block of a `launchctl print` record, one
+ *  TRIMMED argument per line. null when the block never opened or never closed
+ *  (an indeterminate record — we refuse to guess). PURE: string work only.
+ *  @param {string} stdout @returns {string[]|null} */
+function launchdLoadedArgs(stdout) {
+  const lines = String(stdout).split('\n');
+  const start = lines.findIndex((l) => l.trim() === 'arguments = {');
+  if (start === -1) return null;
+  const args = [];
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const t = lines[i].trim();
+    if (t === '}') return args;
+    args.push(t);
+  }
+  return null; // no closing brace → the block did not parse
+}
+
+/** Table B1 consumer 1 — split a cmd.exe inner command chain at each ` & ` that
+ *  lies OUTSIDE a double-quoted region (the only delimiter windowsCmdArguments
+ *  emits). An ODD total `"` count is unparseable → null (fail closed). A ` & `
+ *  inside a `set "VAR=…"` value or a quoted exec argument is never a split point,
+ *  which is what keeps a home like `C:\Users\Bob & Alice` working.
+ *  @param {string} inner @returns {string[]|null} */
+function splitCmdChain(inner) {
+  if ((inner.match(/"/g) || []).length % 2 !== 0) return null;
+  const segs = [];
+  let cur = '';
+  let inQuote = false;
+  for (let i = 0; i < inner.length; i += 1) {
+    const ch = inner[i];
+    if (ch === '"') {
+      inQuote = !inQuote;
+      cur += ch;
+      continue;
+    }
+    if (!inQuote && inner.startsWith(' & ', i)) {
+      segs.push(cur);
+      cur = '';
+      i += 2;
+      continue;
+    }
+    cur += ch;
+  }
+  segs.push(cur);
+  return segs;
+}
+
+/**
+ * Table B condition (c0): is everything before the exec segment EXACTLY the
+ * canonical env-binding set — bound by NAME and, where derivable, by VALUE, never
+ * by the syntactic shape of a `set` command? A shape test would admit
+ * `set "NODE_OPTIONS=--require C:\evil.js"`, which loads attacker code inside the
+ * launcher's own node process before launch.js's first line (the very hazard
+ * scheduledEnvPairs scrubs).
+ * The expected name list and the scrubbed-to-empty set are READ FROM
+ * `scheduledEnvPairs` rather than restated, so the checker cannot drift from the
+ * writer. Rule 4a mirrors `assertSafeOverride`'s component scan
+ * (src/core/paths.js) — same split regex, same two component tests — because our
+ * writer provably cannot emit a `WIENERDOG_HOME` bind with a `.`/`..` component.
+ * @param {string[]} binds  every chain segment except the last
+ * @param {string} expectLauncher  `<core>\launcher\launch.js`
+ * @returns {boolean}
+ */
+function canonicalWindowsBinds(binds, expectLauncher) {
+  const pairs = scheduledEnvPairs('H', 'C'); // sentinel home/core: only names + emptiness matter
+  const expectedNames = [...pairs.map(([k]) => k), 'USERPROFILE'];
+  const scrubbed = new Set(pairs.filter(([, v]) => v === '').map(([k]) => k));
+  if (binds.length !== expectedNames.length) return false; // rule 2 (no extras, none missing)
+  const bound = new Map();
+  for (let i = 0; i < binds.length; i += 1) {
+    const m = binds[i].match(/^set "([A-Za-z_][A-Za-z0-9_]*)=([^"]*)"$/); // rule 1
+    if (!m) return false;
+    if (m[1] !== expectedNames[i]) return false; // rule 2 (in order)
+    if (scrubbed.has(m[1]) && m[2] !== '') return false; // rule 3
+    bound.set(m[1], m[2]);
+  }
+  // rule 4 — WIENERDOG_HOME must be a value our own writer could have emitted AND
+  // name the same core as the expectation (the launcher is <core>\launcher\launch.js).
+  const captured = bound.get('WIENERDOG_HOME');
+  const core = path.win32.dirname(path.win32.dirname(expectLauncher));
+  const comps = captured.split(/[\\/]+/); // 4a — BEFORE any normalization
+  if (comps.includes('..') || comps.includes('.')) return false;
+  if (!path.win32.isAbsolute(captured)) return false; // 4b
+  if (path.win32.resolve(captured) !== path.win32.resolve(core)) return false; // 4c
+  // rule 5 — the generator binds HOME and USERPROFILE to the one `o.home`.
+  const home = bound.get('HOME');
+  return home !== '' && home === bound.get('USERPROFILE');
+}
+
+/**
+ * Decide whether a LOADED scheduler record runs OUR launcher, and report the
+ * program the OS will actually START. `stdout` is the raw output of
+ * deriveIdentityArgv().argv.
+ *
+ * PURE: parses, compares, never executes, never touches the filesystem (no fs
+ * call of any kind — the existence check on `exec` belongs to status.js's
+ * defaultProbe step 8b), and never derives a path FROM THE PARSED TEXT. It does
+ * derive the expected core from `expectLauncher`, which is code-owned input.
+ * `verdict` is decided by the LAUNCHER position; `exec` is the EXECUTION
+ * position, reported and never compared — a record graded `match` may still start
+ * any program that exists, provided our launcher is its first argument
+ * (WP-scheduler-entry-identity Residual 9).
+ * NEVER THROWS — any internal throw (e.g. cmdQuotedToken on a `"` in
+ * expectLauncher) is returned as `{verdict:'indeterminate', exec:null}`.
+ * @param {string} stdout
+ * @param {'launchd'|'systemd'|'schtasks'} kind
+ * @param {string} expectLauncher  an absolute path (generators.launcherPath)
+ * @returns {{verdict:'match'|'mismatch'|'indeterminate', exec:string|null}}
+ */
+function loadedEntryTargets(stdout, kind, expectLauncher) {
+  try {
+    if (kind === 'launchd') {
+      const args = launchdLoadedArgs(stdout);
+      if (!args) return { verdict: 'indeterminate', exec: null };
+      const exec = args.length >= 1 ? args[0] : null;
+      if (args.length < 2) return { verdict: 'indeterminate', exec };
+      return { verdict: args[1] === expectLauncher ? 'match' : 'mismatch', exec };
+    }
+    if (kind !== 'schtasks') return { verdict: 'indeterminate', exec: null }; // systemd: never called
+    // Evaluation order is part of the contract: (0) → (a) → (b) → split → (c) →
+    // (d) → (c0). Only (d) can produce `mismatch`; (d) outranks (c0) so a foreign
+    // launcher stays the loudest verdict even when the bind chain is also foreign.
+    if ((String(stdout).match(/<Exec\b/g) || []).length !== 1) return { verdict: 'indeterminate', exec: null }; // (0)
+    const parsed = parseWindowsTaskExec(stdout);
+    if (!parsed) return { verdict: 'indeterminate', exec: null };
+    if (parsed.command !== windowsCmdExePath()) return { verdict: 'indeterminate', exec: null }; // (a)
+    const envelope = parsed.arguments.match(/^\/d \/s \/v:off \/c "([\s\S]*)"$/); // (b)
+    if (!envelope) return { verdict: 'indeterminate', exec: null };
+    const segs = splitCmdChain(envelope[1]);
+    if (!segs) return { verdict: 'indeterminate', exec: null };
+    // (c) Table B1's END-ANCHORED exec grammar. BARE is cmdArgToken's own bare
+    // charset (see cmdArgToken above) — widening one without the other is exactly
+    // the writer/checker drift the closure family in the tests pins down.
+    const m = segs[segs.length - 1].match(/^"([^"]*)" "([^"]*)"((?: (?:"[^"]*"|[A-Za-z0-9:._-]+))*)$/);
+    if (!m) return { verdict: 'indeterminate', exec: null };
+    const exec = m[1];
+    if (m[2] !== cmdQuotedToken(expectLauncher)) return { verdict: 'mismatch', exec }; // (d)
+    if (!canonicalWindowsBinds(segs.slice(0, -1), expectLauncher)) return { verdict: 'indeterminate', exec }; // (c0)
+    return { verdict: 'match', exec };
+  } catch {
+    return { verdict: 'indeterminate', exec: null };
+  }
+}
+
 /**
  * Render the daily Windows dream task XML. The task's <Command> is the absolute
  * `cmd.exe` and its <Arguments> carry the COMPLETE authorization command bound
@@ -810,12 +996,15 @@ function teardownCatchup(paths, manifest, opts = {}) {
 module.exports = {
   nodePath,
   wienerdogBin,
+  launcherPath,
   launchAgentsDir,
   systemdUserDir,
   launchdLabel,
   systemdUnitBase,
   deriveUnloadArgv,
   deriveProbeArgv,
+  deriveIdentityArgv,
+  loadedEntryTargets,
   parseAt,
   xmlEscape,
   launchdPlist,

--- a/src/scheduler/status.js
+++ b/src/scheduler/status.js
@@ -67,36 +67,100 @@ function describeEntry(entry, platform = process.platform) {
 }
 
 /**
- * Default read-only probe: run `argv` and map the exit code. Honors the test
- * seams so a test NEVER touches the real OS scheduler:
- *   - WIENERDOG_LOADER_NOOP set        → 'unknown' (neutralized, mirrors the loader)
- *   - WIENERDOG_TEST_NO_REAL_SCHEDULER → 'unknown' (WP-071's guard; read-only, so
- *                                        we skip rather than throw)
- * Otherwise spawnSync (read-only): exit 0 → 'loaded'; any other exit / spawn error
- *   → 'missing'. Never throws.
- * @param {string[]} argv
- * @returns {'loaded'|'missing'|'unknown'}
+ * @typedef {'loaded'|'missing'|'mismatched'|'unverified'|'unknown'} EntryStatus
  */
-function defaultProbe(argv) {
-  if (process.env.WIENERDOG_LOADER_NOOP) return 'unknown';
-  if (process.env.WIENERDOG_TEST_NO_REAL_SCHEDULER) return 'unknown';
-  const r = spawnSync(argv[0], argv.slice(1), { stdio: 'ignore' });
-  if (r.error) return 'missing';
-  return r.status === 0 ? 'loaded' : 'missing';
+
+/**
+ * @typedef {{launcher:string, kind:'launchd'|'systemd'|'schtasks',
+ *            identityArgv:string[]|null}} IdentityExpectation
+ */
+
+/** The statuses a `sync`-time heal re-registers. `loaded` and `unknown` are left
+ *  alone: one is healthy, the other claims nothing. */
+const HEAL_SET = new Set(['missing', 'mismatched', 'unverified']);
+
+/** The real read-only spawn behind `defaultProbe`. Captures stdout (the identity
+ *  query's output IS the answer) instead of the old `stdio:'ignore'`.
+ *  @param {string[]} a @returns {{status:number|null, stdout?:string, error?:Error}} */
+function defaultRun(a) {
+  return spawnSync(a[0], a.slice(1), { encoding: 'utf8' });
+}
+
+/**
+ * Read-only probe of ONE registered entry. A scheduler entry's health is the
+ * IDENTITY of the program the OS will actually execute, not the fact that a
+ * record exists: `launchctl print` exits 0 for a hijacked record, which is how a
+ * catch-up agent fired 76 times against a deleted launcher while this probe
+ * reported `loaded` (WP-scheduler-entry-identity).
+ *
+ * `expect` carries the identity query and the launcher this install owns; it is
+ * MANDATORY — omitting it yields 'unverified', never 'loaded'. There is
+ * deliberately NO presence-only mode and no default for `expect`: a probe that
+ * cannot say WHAT will run must not claim health.
+ * `opts.run` is the TEST-ONLY spawn seam so the identity logic is unit-testable
+ * with canned scheduler output and NEVER touches a real scheduler. No production
+ * caller passes it, which is why the two neutralizer checks below are gated on it
+ * being absent: injecting the read seam IS the neutralization, so no test has to
+ * delete WIENERDOG_TEST_NO_REAL_SCHEDULER and the mutation backstop stays armed.
+ * Never throws.
+ * @param {string[]} argv  the presence-probe argv (generators.deriveProbeArgv)
+ * @param {IdentityExpectation|null} [expect]
+ * @param {{run?: (argv:string[]) => {status:number|null, stdout?:string, error?:Error}}} [opts]
+ * @returns {EntryStatus}
+ */
+function defaultProbe(argv, expect, opts = {}) {
+  const run = typeof opts.run === 'function' ? opts.run : null;
+  const RUN = run || defaultRun; // bound ONCE — steps 3 and 7 must use the SAME one
+  if (!run && process.env.WIENERDOG_LOADER_NOOP) return 'unknown'; // 1
+  if (!run && process.env.WIENERDOG_TEST_NO_REAL_SCHEDULER) return 'unknown'; // 2
+  const r = RUN(argv); // 3
+  if (r.error || r.status !== 0) return 'missing'; // 4
+  if (!expect || !expect.kind || !expect.launcher) return 'unverified'; // 5 — fail CLOSED
+  if (expect.identityArgv == null) return 'unknown'; // 6 — kind recognized, query unimplemented
+  const r2 = RUN(expect.identityArgv); // 7 — the SAME RUN, never a bare run(…)
+  if (r2.error || r2.status !== 0 || typeof r2.stdout !== 'string') return 'unverified';
+  const { verdict, exec } = generators.loadedEntryTargets(r2.stdout, expect.kind, expect.launcher); // 8
+  if (verdict === 'mismatch') return 'mismatched';
+  if (verdict === 'indeterminate') return 'unverified';
+  // 8b — a `match` proves only that OUR launcher sits in the launcher position.
+  // The program the OS will actually START is `exec`; when it no longer exists
+  // (a `brew upgrade node && brew cleanup` deletes the version-pinned execPath
+  // the entry was registered with) every fire dies in posix_spawn before a line
+  // of Wienerdog code runs. That is a definite failure, so it is `mismatched`
+  // (heal + doctor fail), not `loaded` and not `unverified`. existsSync never
+  // throws — it returns false on every error, the fail-closed direction.
+  if (typeof exec === 'string' && exec !== '' && fs.existsSync(exec)) return 'loaded';
+  return 'mismatched';
+}
+
+/** Build the identity expectation for one schedule file. null when the basename
+ *  is one `deriveIdentityArgv` does not recognize — `defaultProbe` step 5 then
+ *  fails closed to 'unverified' rather than claiming health.
+ *  @param {import('../core/paths').WienerdogPaths} paths @param {string} schedulePath
+ *  @param {NodeJS.Platform} platform @returns {IdentityExpectation|null} */
+function identityExpectation(paths, schedulePath, platform) {
+  const idn = generators.deriveIdentityArgv(schedulePath, platform);
+  if (!idn) return null;
+  return { launcher: generators.launcherPath(paths), kind: idn.kind, identityArgv: idn.argv };
 }
 
 /**
  * Probe every registered scheduler entry. Read-only. The probe argv is
  * RE-DERIVED from each entry's basename identity (never the stored `unload` —
  * ADR-0027), and every entry is gated behind a scheduler-root containment check,
- * so an out-of-root poisoned entry is never probed. `opts.probe` is the injected
- * seam (default defaultProbe). `WIENERDOG_SCHEDULER_PROBE` — a JSON map
- * `{ "<name>": "loaded"|"missing"|"unknown" }` — overrides by name (subprocess
- * test seam, mirrors WIENERDOG_UPDATE_FETCH_CMD). Never throws.
+ * so an out-of-root poisoned entry is never probed. Each entry's IDENTITY
+ * expectation is built here (the launcher this install owns + the re-derived
+ * identity query) and passed to the probe — the line whose absence reproduced the
+ * incident. `opts.probe` is the injected seam (default defaultProbe) and
+ * `opts.run` is defaultProbe's read seam, forwarded unchanged.
+ * `WIENERDOG_SCHEDULER_PROBE` — a JSON map `{ "<name>": <EntryStatus> }` —
+ * overrides by name (subprocess test seam, mirrors WIENERDOG_UPDATE_FETCH_CMD);
+ * its values are used verbatim and are not validated. Never throws.
  * @param {import('../core/paths').WienerdogPaths} paths
- * @param {{probe?: (argv:string[])=>('loaded'|'missing'|'unknown'),
+ * @param {{probe?: (argv:string[], expect:IdentityExpectation|null, opts:object)=>EntryStatus,
+ *          run?: (argv:string[])=>{status:number|null, stdout?:string, error?:Error},
  *          platform?: NodeJS.Platform}} [opts]
- * @returns {Array<{name:string, scheduler:string, status:'loaded'|'missing'|'unknown'}>}
+ * @returns {Array<{name:string, scheduler:string, status:EntryStatus}>}
  */
 function probeAll(paths, opts = {}) {
   const platform = opts.platform || process.platform;
@@ -112,9 +176,10 @@ function probeAll(paths, opts = {}) {
     if (!lexicallyInRoot(e.path, roots, platform)) continue; // out-of-root → no probe
     const d = describeEntry(e, platform);
     if (!d) continue;
+    const expect = identityExpectation(paths, e.path, platform);
     const status = envMap && Object.prototype.hasOwnProperty.call(envMap, d.name)
       ? envMap[d.name]
-      : probe(d.probe);
+      : probe(d.probe, expect, { run: opts.run });
     out.push({ name: d.name, scheduler: d.scheduler, status });
   }
   return out;
@@ -125,7 +190,7 @@ function probeAll(paths, opts = {}) {
  * Atomic temp+rename (mirrors update-check.writeState). No-op-safe when there are
  * no scheduler entries.
  * @param {import('../core/paths').WienerdogPaths} paths
- * @param {{probe?: (argv:string[])=>('loaded'|'missing'|'unknown')}} [opts]
+ * @param {{probe?: Function, run?: Function, platform?: NodeJS.Platform}} [opts]
  * @returns {void}
  */
 function refreshSchedulerStatus(paths, opts = {}) {
@@ -149,34 +214,67 @@ function readSchedulerStatus(paths) {
   } catch { return { entries: [] }; }
 }
 
+/** Whole-word pluralization helpers for the callout templates. Never per-character
+ *  suffixes — a broken safety message is the WP-068 false-reassurance class.
+ *  @param {string[]} names @returns {{names:string, one:boolean}} */
+function nameList(names) {
+  return { names: names.map((n) => `"${n}"`).join(', '), one: names.length === 1 };
+}
+
 /**
- * Fixed-template digest callout from the cache (control-plane text only, no
- * untrusted input — the names are our own `[a-z0-9-]` job names). '' when no
- * entry is 'missing'. Mirrors renderUpdateLine (cache-only, no probe).
+ * Fixed-template digest callouts from the cache (control-plane text only, no
+ * untrusted input — the names are our own `[a-z0-9-]` job names). One callout per
+ * non-empty bucket, in the order mismatched (F), unverified (U), missing (M),
+ * joined by a BLANK LINE: consecutive `>` lines separated by a single newline are
+ * ONE Obsidian blockquote, which would merge three different remediations under
+ * one title. '' when all three buckets are empty. Mirrors renderUpdateLine
+ * (cache-only, no probe).
  * @param {import('../core/paths').WienerdogPaths} paths
  * @returns {string}
  */
 function renderSchedulerStatusLine(paths) {
-  const missing = readSchedulerStatus(paths).entries.filter((e) => e.status === 'missing').map((e) => e.name);
-  if (missing.length === 0) return '';
-  const names = missing.map((n) => `"${n}"`).join(', ');
-  // Select whole words for the noun/verb/pronoun so pluralization can't drift on
-  // spacing (a broken safety message is the WP-068 false-reassurance failure class).
-  const noun = missing.length === 1 ? 'job' : 'jobs';
-  const verb = missing.length === 1 ? 'is' : 'are';
-  const pronoun = missing.length === 1 ? 'it' : 'them';
-  return `> [!warning] Wienerdog: the scheduled ${noun} ${names} ${verb} ` +
-    `set up but not currently active in your computer's scheduler. Run 'wienerdog sync' to reactivate ` +
-    `${pronoun}. (This can happen after some system updates.)`;
+  const entries = readSchedulerStatus(paths).entries;
+  const bucket = (s) => entries.filter((e) => e.status === s).map((e) => e.name);
+  const out = [];
+
+  const f = bucket('mismatched');
+  if (f.length > 0) {
+    const { names, one } = nameList(f);
+    out.push(`> [!warning] Wienerdog: the scheduled ${one ? 'job' : 'jobs'} ${names} ` +
+      `${one ? 'is' : 'are'} registered in your computer's scheduler, but the program ` +
+      `${one ? 'it' : 'they'} would run is either not part of this Wienerdog installation or no longer ` +
+      `on this computer, so ${one ? 'it' : 'they'} cannot run. Run 'wienerdog sync' to re-register ` +
+      `${one ? 'it' : 'them'} from this installation.`);
+  }
+
+  const u = bucket('unverified');
+  if (u.length > 0) {
+    const { names, one } = nameList(u);
+    out.push('> [!warning] Wienerdog: Wienerdog could not read back what your computer\'s scheduler will ' +
+      `actually run for the scheduled ${one ? 'job' : 'jobs'} ${names}, so it cannot confirm ` +
+      `${one ? 'it is' : 'they are'} still wired to this installation. Run 'wienerdog sync' to re-register ` +
+      `${one ? 'it' : 'them'}, then run 'wienerdog doctor'.`);
+  }
+
+  const m = bucket('missing');
+  if (m.length > 0) {
+    const { names, one } = nameList(m);
+    out.push(`> [!warning] Wienerdog: the scheduled ${one ? 'job' : 'jobs'} ${names} ${one ? 'is' : 'are'} ` +
+      'set up but not currently active in your computer\'s scheduler. Run \'wienerdog sync\' to reactivate ' +
+      `${one ? 'it' : 'them'}. (This can happen after some system updates.)`);
+  }
+
+  return out.join('\n\n');
 }
 
 /**
  * doctor lines: one per registered entry, LIVE read-only probe. 'loaded' → ok,
- * 'missing' → warn (actionable, NOT a hard fail), 'unknown' → omitted (can't
- * determine — unsupported platform or neutralized). Read-only.
+ * 'missing'/'unverified' → warn (actionable), 'mismatched' → FAIL (the entry
+ * cannot work — a foreign launcher, or an execution position that no longer
+ * exists), 'unknown' → omitted (no verdict is attempted by design). Read-only.
  * @param {import('../core/paths').WienerdogPaths} paths
- * @param {{probe?: (argv:string[])=>('loaded'|'missing'|'unknown')}} [opts]
- * @returns {Array<{status:'ok'|'warn', msg:string}>}
+ * @param {{probe?: Function, run?: Function, platform?: NodeJS.Platform}} [opts]
+ * @returns {Array<{status:'ok'|'warn'|'fail', msg:string}>}
  */
 function doctorSchedulerChecks(paths, opts = {}) {
   const out = [];
@@ -187,6 +285,20 @@ function doctorSchedulerChecks(paths, opts = {}) {
       out.push({
         status: 'warn',
         msg: `scheduled job '${e.name}' is configured but NOT loaded in ${e.scheduler} — run 'wienerdog sync' to reload it`,
+      });
+    } else if (e.status === 'mismatched') {
+      out.push({
+        status: 'fail',
+        msg: `scheduled job '${e.name}' is registered in ${e.scheduler} but the program it would run is not ` +
+          'this Wienerdog install\'s, or no longer exists on this computer, so it cannot work — ' +
+          'run \'wienerdog sync\' to re-register it from this install',
+      });
+    } else if (e.status === 'unverified') {
+      out.push({
+        status: 'warn',
+        msg: `scheduled job '${e.name}' is registered in ${e.scheduler} but Wienerdog could not read back ` +
+          'the program it runs, so it cannot confirm the entry belongs to this install — ' +
+          'run \'wienerdog sync\' to re-register it, then \'wienerdog doctor\' again',
       });
     } // 'unknown' → no line
   }
@@ -229,9 +341,13 @@ function canonicalProbePath(paths, name, platform) {
  *      path (the verify→register reopen race is an accepted A12 residual).
  * The catch-up registration is NOT a configured job, so it is excluded here
  * ENTIRELY [R5/R6] — its repair/teardown is owned solely by `repointSchedules`.
+ *
+ * The heal set is `{missing, mismatched, unverified}`: a record that exists but
+ * runs the wrong program is exactly as broken as an absent one, and on darwin the
+ * replacement is bootstrap-first, so a working-but-unverifiable entry is only torn
+ * down after launchd itself refuses the bootstrap.
  * @param {import('../core/paths').WienerdogPaths} paths
- * @param {{loader?: (argv:string[])=>{status:number},
- *          probe?: (argv:string[])=>('loaded'|'missing'|'unknown'),
+ * @param {{loader?: (argv:string[])=>{status:number}, probe?: Function, run?: Function,
  *          platform?: NodeJS.Platform}} [opts]
  * @returns {{reloaded:string[], failed:string[]}}
  */
@@ -245,16 +361,28 @@ function reloadMissing(paths, opts = {}) {
   /** @type {string[]} */ const reloaded = [];
   /** @type {string[]} */ const failed = [];
   let jobs;
+  let markerAttempted = false;
   try { jobs = jobsLib.listJobs(paths); } catch { return { reloaded, failed }; }
   for (const job of jobs) {
     const canonical = canonicalProbePath(paths, job.name, platform);
     if (!canonical) continue; // unsupported platform → nothing to probe/heal
     const probeArgv = generators.deriveProbeArgv(canonical, platform);
     if (!probeArgv) continue; // unrecognized identity → never healed
+    const expect = identityExpectation(paths, canonical, platform);
     const status = envMap && Object.prototype.hasOwnProperty.call(envMap, job.name)
       ? envMap[job.name]
-      : probe(probeArgv);
-    if (status !== 'missing') continue;
+      : probe(probeArgv, expect, { run: opts.run });
+    if (!HEAL_SET.has(status)) continue;
+    // Pre-destructive durable marker (ADR-0018, 2026-07-25 amendment decision 2),
+    // UNCONDITIONAL and once per call, before the FIRST replacement call. The
+    // observed status does not predict whether a destructive step is reached: a
+    // TRANSIENT presence-query failure grades a still-loaded label `missing`, and
+    // the replacement then boots it out. BEST-EFFORT — refreshSchedulerStatus
+    // swallows every write error, hence `markerAttempted`, never `markerWritten`.
+    if (!markerAttempted) {
+      refreshSchedulerStatus(paths, opts);
+      markerAttempted = true;
+    }
     let ok = false;
     try { ok = schedule.reloadJob(paths, job, loader, platform); } catch { ok = false; }
     if (ok) reloaded.push(job.name);

--- a/tests/unit/scheduler-entry-identity.test.js
+++ b/tests/unit/scheduler-entry-identity.test.js
@@ -1,0 +1,835 @@
+'use strict';
+
+// WP-scheduler-entry-identity — a scheduler entry's health is the IDENTITY of the
+// program the OS will actually execute, not the fact that a record exists.
+//
+// AUTHORITATIVE ARTIFACT for every assertion in this file: the OS scheduler's own
+// record of what it will run (`launchctl print` / `schtasks /query … /xml`
+// output), fed in as canned stdout through the read seam. The schedule FILE on
+// disk is deliberately never read as evidence — in the incident the file was
+// perfectly correct for weeks while the loaded record was poisoned, so a file
+// check is exactly the wrong artifact.
+//
+// No test here deletes WIENERDOG_TEST_NO_REAL_SCHEDULER (Table C R1): injecting
+// `opts.run` is what gets past defaultProbe's neutralizer steps, so schedulerSpawn's
+// throw stays armed for every test and an un-stubbed heal fails loudly instead of
+// mutating the maintainer's per-user-global launchd.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const { getPaths } = require('../../src/core/paths');
+const manifestLib = require('../../src/core/manifest');
+const jobsLib = require('../../src/scheduler/jobs');
+const gen = require('../../src/scheduler/generators');
+const status = require('../../src/scheduler/status');
+const schedule = require('../../src/cli/schedule');
+
+const isPosix = process.platform !== 'win32';
+
+// Hermeticity: CI may set XDG_CONFIG_HOME to the real ~/.config, which
+// systemdUserDir() prefers over $HOME.
+delete process.env.XDG_CONFIG_HOME;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** An isolated temp core + manifest. No real ~/.wienerdog is touched.
+ *  @param {(home:string)=>object[]} [makeEntries] */
+function setup(makeEntries = () => []) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-entry-identity-'));
+  const paths = getPaths({ HOME: root, WIENERDOG_HOME: path.join(root, 'wd') });
+  fs.mkdirSync(paths.core, { recursive: true });
+  fs.mkdirSync(paths.state, { recursive: true });
+  manifestLib.save(paths, {
+    version: 1,
+    createdAt: new Date().toISOString(),
+    entries: [{ kind: 'dir', path: paths.core }, ...makeEntries(root)],
+  });
+  return { root, paths };
+}
+
+/** Minimal config so jobsLib can read/upsert jobs. */
+function withConfig(paths, jobs = []) {
+  fs.writeFileSync(paths.config, 'version: 1\nvault: /x/vault\n');
+  for (const j of jobs) jobsLib.saveJob(paths, { at: '03:30', run: 'builtin:dream', timeoutMinutes: 20, ...j });
+}
+
+const laPath = (paths, name) => path.join(gen.launchAgentsDir(paths.home), `ai.wienerdog.${name}.plist`);
+
+/** A canned `launchctl print` record. The `arguments` block is TAB-indented on a
+ *  real machine and every line must be trimmed by the parser, so it is rendered
+ *  that way here. args[0] is the EXECUTION position, args[1] the LAUNCHER. */
+function printOut(args) {
+  return [
+    'com.apple.xpc.launchd.user.domain.501.100.Aqua/ai.wienerdog.dream = {',
+    '\tactive count = 0',
+    '\targuments = {',
+    ...args.map((a) => `\t\t${a}`),
+    '\t}',
+    '\truns = 76',
+    '\tlast exit code = 1',
+    '}',
+    '',
+  ].join('\n');
+}
+
+/** A read seam that answers BOTH the presence query and the identity query with
+ *  the same canned record (on darwin the two argvs are byte-identical). */
+const cannedRun = (stdout, exitStatus = 0) => () => ({ status: exitStatus, stdout });
+
+// Windows fixture constants — every "must match" argline is built by the REAL
+// writer (gen.windowsCmdArguments), never hand-written, so a checker that drifts
+// from the writer breaks a test instead of passing quietly.
+const WIN_CORE = 'C:\\Users\\bob\\.wienerdog';
+const WIN_LAUNCHER = path.win32.join(WIN_CORE, 'launcher', 'launch.js');
+const WIN_NODE = 'C:\\Program Files\\nodejs\\node.exe';
+const WIN_HOME = 'C:\\Users\\bob';
+const WIN_LAUNCH_ARGS = [
+  'dream',
+  '--descriptor',
+  'C:\\Users\\bob\\.wienerdog\\state\\descriptors\\dream.json',
+  '--expect-digest',
+  'sha256:5ab9a40deadbeef',
+];
+
+/** Canonical `<Arguments>` from the shipping writer. */
+function argline(o = {}) {
+  const core = o.core === undefined ? WIN_CORE : o.core;
+  return gen.windowsCmdArguments({
+    node: o.node || WIN_NODE,
+    launcher: o.launcher || path.win32.join(core, 'launcher', 'launch.js'),
+    home: o.home || WIN_HOME,
+    core,
+    launchArgs: o.launchArgs || WIN_LAUNCH_ARGS,
+  });
+}
+
+const innerOf = (a) => a.match(/^\/d \/s \/v:off \/c "([\s\S]*)"$/)[1];
+const wrapInner = (inner) => `/d /s /v:off /c "${inner}"`;
+
+/** Split a canonical argline into its bind chain and its exec segment. */
+function parts(a) {
+  const inner = innerOf(a);
+  const i = inner.lastIndexOf(' & "');
+  return { binds: inner.slice(0, i), exec: inner.slice(i + 3) };
+}
+const rebuild = (binds, exec) => wrapInner(`${binds} & ${exec}`);
+
+/** A `schtasks /query /tn … /xml` document. Every <Command>/<Arguments> value is
+ *  XML-ESCAPED, because that is what the real tool prints and what
+ *  parseWindowsTaskExec unescapes on the way back in. */
+function taskXml(command, args, extra) {
+  const exec = (c, a) =>
+    `    <Exec>\n      <Command>${gen.windowsXmlEscape(c)}</Command>\n` +
+    `      <Arguments>${gen.windowsXmlEscape(a)}</Arguments>\n    </Exec>`;
+  const actions = extra ? `${exec(extra.command, extra.arguments)}\n${exec(command, args)}` : exec(command, args);
+  return `<?xml version="1.0" encoding="UTF-16"?>\n<Task version="1.2">\n  <Actions Context="Author">\n${actions}\n  </Actions>\n</Task>\n`;
+}
+
+const winTargets = (command, args, expectLauncher = WIN_LAUNCHER, extra) =>
+  gen.loadedEntryTargets(taskXml(command, args, extra), 'schtasks', expectLauncher);
+
+/** A recording loader (Table C R2): pushes its argv and returns a canned status
+ *  WITHOUT spawning. It also records whether state/scheduler-status.json existed
+ *  and parsed AT THE MOMENT OF THE CALL, so the pre-destructive-marker criteria
+ *  are assertions about the file at the first call, never about it afterwards. */
+function recordingLoader(paths, exitStatus = 0) {
+  /** @type {string[][]} */ const calls = [];
+  /** @type {Array<{exists:boolean, parsed:object|null}>} */ const seen = [];
+  const loader = (a) => {
+    calls.push(a);
+    let parsed = null;
+    try { parsed = JSON.parse(fs.readFileSync(status.statusPath(paths), 'utf8')); } catch { parsed = null; }
+    seen.push({ exists: fs.existsSync(status.statusPath(paths)), parsed });
+    return { status: exitStatus };
+  };
+  return { calls, seen, loader };
+}
+
+// ---------------------------------------------------------------------------
+// generators.loadedEntryTargets — launchd
+// ---------------------------------------------------------------------------
+
+test("entry-identity: launchd mismatch when arguments[1] is not this install's launcher", () => {
+  // Reads the OS's OWN loaded record (launchctl print stdout) — the artifact that
+  // was poisoned in the incident while the .plist on disk stayed correct.
+  const mine = '/Users/u/.wienerdog/launcher/launch.js';
+  const poisoned = printOut(['/opt/node/bin/node', '/var/folders/x/T/wd-negative/core/launcher/launch.js', 'dream']);
+  const bad = gen.loadedEntryTargets(poisoned, 'launchd', mine);
+  assert.equal(bad.verdict, 'mismatch');
+  assert.equal(bad.exec, '/opt/node/bin/node', 'the execution position is REPORTED even alongside a mismatch');
+
+  const good = gen.loadedEntryTargets(printOut(['/opt/node/bin/node', mine, 'dream']), 'launchd', mine);
+  assert.equal(good.verdict, 'match');
+  assert.equal(good.exec, '/opt/node/bin/node');
+
+  // Indeterminate shapes: no block, no closing brace, fewer than two arguments.
+  assert.deepEqual(gen.loadedEntryTargets('no arguments block here', 'launchd', mine), { verdict: 'indeterminate', exec: null });
+  const truncated = '\targuments = {\n\t\t/opt/node/bin/node\n';
+  assert.deepEqual(gen.loadedEntryTargets(truncated, 'launchd', mine), { verdict: 'indeterminate', exec: null });
+  const oneArg = gen.loadedEntryTargets(printOut(['/opt/node/bin/node']), 'launchd', mine);
+  assert.equal(oneArg.verdict, 'indeterminate');
+  assert.equal(oneArg.exec, '/opt/node/bin/node');
+
+  // systemd is never called (defaultProbe step 6 returns unknown first); if it is,
+  // it must still be inert.
+  assert.deepEqual(gen.loadedEntryTargets(printOut(['/a', mine]), 'systemd', mine), { verdict: 'indeterminate', exec: null });
+});
+
+// ---------------------------------------------------------------------------
+// generators.loadedEntryTargets — schtasks
+// ---------------------------------------------------------------------------
+
+test('entry-identity: schtasks does NOT match a task whose Command is not our cmd.exe and whose launcher token is only inside the set-chain', () => {
+  // The executed hijack shape (AC-1 (i)): powershell as <Command>, our launcher
+  // MENTIONED in a set "VAR=…" value, a different launcher actually executed. A
+  // substring test for the launcher token matches this; identity must not.
+  const hijack = argline({ home: WIN_LAUNCHER, launcher: 'C:\\evil\\launch.js' });
+  assert.ok(hijack.includes(WIN_LAUNCHER), 'the fixture really does mention our launcher inside the chain');
+  const r = winTargets('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe', hijack);
+  assert.equal(r.verdict, 'indeterminate', '(a) fails: the executed program is not our cmd.exe');
+
+  // (iii) two <Exec> actions — parseWindowsTaskExec pairs independently, so a
+  // multi-action task is refused by condition (0) BEFORE the parser is consulted.
+  const two = winTargets(gen.windowsCmdExePath(), argline(), WIN_LAUNCHER, {
+    command: 'C:\\evil\\first.exe',
+    arguments: '/c whatever',
+  });
+  assert.equal(two.verdict, 'indeterminate');
+
+  // (iv) an odd double-quote count in the inner string is unparseable → fail closed.
+  const odd = wrapInner(`${innerOf(argline())}"`);
+  assert.equal(winTargets(gen.windowsCmdExePath(), odd).verdict, 'indeterminate');
+
+  // Never throws, even when cmdQuotedToken would (a `"` in the expectation).
+  assert.deepEqual(
+    winTargets(gen.windowsCmdExePath(), argline(), 'C:\\ev"il\\launch.js'),
+    { verdict: 'indeterminate', exec: null }
+  );
+});
+
+test('entry-identity: schtasks (c0) binds to the canonical set, and (d) outranks it', () => {
+  const cmd = gen.windowsCmdExePath();
+  const canonical = argline();
+  assert.equal(winTargets(cmd, canonical).verdict, 'match', 'control: the writer\'s own output matches');
+
+  const { binds, exec } = parts(canonical);
+
+  // rule 3 — the poisoned-binding shape. A SHAPE-based (c0) scores this `match`
+  // while node loads the attacker's module inside the launcher's OWN process
+  // before launch.js runs, ahead of every WP-157 check.
+  const poisonedBind = binds.replace('set "NODE_OPTIONS="', 'set "NODE_OPTIONS=--require C:\\evil.js"');
+  assert.notEqual(poisonedBind, binds, 'the fixture really was rewritten');
+  assert.equal(winTargets(cmd, rebuild(poisonedBind, exec)).verdict, 'indeterminate');
+
+  // rule 2 — an EXTRA bind, and a MISSING one.
+  assert.equal(winTargets(cmd, rebuild(`${binds} & set "FOO=1"`, exec)).verdict, 'indeterminate');
+  const dropped = binds.replace(' & set "CODEX_HOME="', '');
+  assert.notEqual(dropped, binds);
+  assert.equal(winTargets(cmd, rebuild(dropped, exec)).verdict, 'indeterminate');
+
+  // rule 1 — a PREPENDED command (AC-1 (ii)). cmd.exe runs it FIRST, and every
+  // other condition still passes, so only a by-name bind check catches it.
+  assert.equal(winTargets(cmd, rebuild(`evil.exe & ${binds}`, exec)).verdict, 'indeterminate');
+  assert.equal(winTargets(cmd, rebuild(`"evil.exe" & ${binds}`, exec)).verdict, 'indeterminate');
+
+  // EVALUATION ORDER: a foreign launcher in the launcher position AND a foreign
+  // core in the bind (the incident's temp-core shape) is `mismatch`, not
+  // `indeterminate` — (d) is evaluated before (c0) so a hijack stays the loudest
+  // verdict the taxonomy has.
+  const foreignCore = 'C:\\Temp\\wd-negative-UezlJP\\core';
+  const hijacked = winTargets(cmd, argline({ core: foreignCore }), WIN_LAUNCHER);
+  assert.equal(hijacked.verdict, 'mismatch');
+
+  // rule 4c — a HEALTHY non-default core. assertSafeOverride returns WIENERDOG_HOME
+  // verbatim while launcherPath normalizes, so these two skews are real installs;
+  // a raw comparison would warn forever and re-register on every sync.
+  for (const core of ['C:\\Users\\bob\\.wienerdog\\', 'C:/Users/bob/.wienerdog']) {
+    const launcher = path.win32.join(core, 'launcher', 'launch.js');
+    assert.equal(winTargets(cmd, argline({ core, launcher }), launcher).verdict, 'match', `healthy core ${core}`);
+  }
+
+  // rule 4a — NON-CANONICAL SPELLINGS of the right directory. resolve() alone
+  // accepts these; our own writer provably cannot emit them (getPaths throws on
+  // the first and collapses the second), so `indeterminate` is the honest grade.
+  for (const core of ['C:\\Users\\bob\\.wienerdog\\child\\..', 'C:\\Users\\bob\\.wienerdog\\.\\']) {
+    const launcher = path.win32.join(core, 'launcher', 'launch.js');
+    assert.equal(launcher, WIN_LAUNCHER, 'path.win32.join collapses the component, so the EXPECTATION is canonical');
+    assert.equal(winTargets(cmd, argline({ core, launcher }), launcher).verdict, 'indeterminate', `spelling ${core}`);
+  }
+});
+
+test("entry-identity: schtasks exec grammar shares cmdArgToken's bare alphabet and rejects every unquoted operator", () => {
+  const cmd = gen.windowsCmdExePath();
+  const canonical = argline();
+  const { binds, exec } = parts(canonical);
+
+  // The CONVERSE direction: every token the writer really emits BARE (dream,
+  // --expect-digest, sha256:…) must still be accepted, so tightening BARE away
+  // from cmdArgToken breaks this rather than passing quietly.
+  assert.equal(winTargets(cmd, canonical).verdict, 'match');
+  for (const t of ['dream', '--expect-digest', 'sha256:5ab9a40deadbeef']) {
+    assert.equal(gen.cmdArgToken(t), t, `the writer emits ${t} bare`);
+    assert.ok(canonical.includes(` ${t}`), 'the canonical fixture really carries it');
+  }
+
+  // THE CLOSURE FAMILY. `"` is excluded — it is the region delimiter the split
+  // walk consumes. For every metacharacter: (1) the SHIPPING writer would never
+  // emit it bare, and (2) injecting it unquoted is rejected in both positions.
+  for (const ch of ['&', '|', '<', '>', '(', ')', '^', '%']) {
+    assert.ok(gen.cmdArgToken(ch).startsWith('"'), `cmdArgToken double-quotes ${ch} — it is outside the bare charset`);
+    assert.equal(
+      winTargets(cmd, rebuild(binds, `${exec}${ch}C:\\evil.exe`)).verdict,
+      'indeterminate',
+      `${ch} appended to the exec segment`
+    );
+    assert.equal(
+      winTargets(cmd, rebuild(binds.replace('set "CODEX_HOME="', `set "CODEX_HOME="${ch}evil`), exec)).verdict,
+      'indeterminate',
+      `${ch} injected between two binds`
+    );
+  }
+
+  // (viii) the three executed append vectors, by name. The THIRD has no operator
+  // character at all — it is what proves the fix is the END ANCHOR and not an
+  // operator filter, so it must not be dropped.
+  for (const tail of ['&C:\\evil.exe', '|C:\\evil.exe', ' C:\\evil.exe']) {
+    assert.equal(winTargets(cmd, rebuild(binds, `${exec}${tail}`)).verdict, 'indeterminate', `append ${tail}`);
+  }
+
+  // (v) a launcher AND a home containing ' & ' still match — the quote-aware split
+  // is the whole reason, and the shipping windowsLoadedTaskMatches gets this right
+  // today, so a regression here would be strictly worse than main.
+  const ampCore = 'C:\\Users\\Bob & Alice\\.wienerdog';
+  const ampLauncher = path.win32.join(ampCore, 'launcher', 'launch.js');
+  assert.equal(
+    winTargets(cmd, argline({ core: ampCore, launcher: ampLauncher, home: 'C:\\Users\\Bob & Alice' }), ampLauncher).verdict,
+    'match'
+  );
+
+  // (vi) node legitimately moves on upgrade: a DIFFERENT node path still matches,
+  // and its value is what step 8b consumes.
+  const moved = winTargets(cmd, argline({ node: 'C:\\nvm\\v22\\node.exe' }));
+  assert.equal(moved.verdict, 'match');
+  assert.equal(moved.exec, 'C:\\nvm\\v22\\node.exe');
+});
+
+test('entry-identity: schtasks reports a substituted execution position instead of judging it (Residual 9)', () => {
+  // RESIDUAL 9, stated as an executable boundary: loadedEntryTargets decides the
+  // verdict from the LAUNCHER position only. A substituted-but-existing executable
+  // in the node position still grades `match`; whether it may run is step 8b's
+  // question (existence) and nothing more. An implementer who "fixes" this to
+  // `mismatch` has silently taken a design decision routed to
+  // WP-scheduler-stable-exec-position.
+  const r = winTargets(gen.windowsCmdExePath(), argline({ node: 'C:\\evil\\fake-node.exe' }));
+  assert.deepEqual(r, { verdict: 'match', exec: 'C:\\evil\\fake-node.exe' });
+});
+
+// ---------------------------------------------------------------------------
+// generators.deriveIdentityArgv
+// ---------------------------------------------------------------------------
+
+test('entry-identity: deriveIdentityArgv returns a per-kind identity query, and null for a foreign basename', { skip: !isPosix }, () => {
+  const uid = process.getuid();
+  assert.deepEqual(gen.deriveIdentityArgv('/h/Library/LaunchAgents/ai.wienerdog.dream.plist', 'darwin'), {
+    kind: 'launchd',
+    argv: ['launchctl', 'print', `gui/${uid}/ai.wienerdog.dream`],
+  });
+  // systemd is RECOGNIZED but its identity query is declared unimplemented — that
+  // is what distinguishes it from a fourth scheduler someone forgot to add.
+  assert.deepEqual(gen.deriveIdentityArgv('/h/.config/systemd/user/wienerdog-dream.timer', 'linux'), {
+    kind: 'systemd',
+    argv: null,
+  });
+  assert.deepEqual(gen.deriveIdentityArgv('C:\\c\\schedules\\wienerdog-dream.xml', 'win32'), {
+    kind: 'schtasks',
+    argv: ['schtasks', '/query', '/tn', '\\Wienerdog\\dream', '/xml'],
+  });
+  assert.equal(gen.deriveIdentityArgv('/h/Library/LaunchAgents/com.apple.thing.plist', 'darwin'), null);
+  assert.equal(gen.deriveIdentityArgv('/h/.config/systemd/user/wienerdog-dream.service', 'linux'), null);
+  assert.equal(gen.deriveIdentityArgv('/x/foreign.txt', 'darwin'), null);
+});
+
+// ---------------------------------------------------------------------------
+// status.defaultProbe — the taxonomy
+// ---------------------------------------------------------------------------
+
+const dreamExpect = (launcher) => ({
+  launcher,
+  kind: 'launchd',
+  identityArgv: ['launchctl', 'print', 'gui/501/ai.wienerdog.dream'],
+});
+const PRESENCE = ['launchctl', 'print', 'gui/501/ai.wienerdog.dream'];
+
+test('entry-identity: defaultProbe returns mismatched for an exit-0 record naming a foreign launcher', () => {
+  const mine = '/Users/u/.wienerdog/launcher/launch.js';
+  const expect = dreamExpect(mine);
+
+  // The incident: launchctl print EXITS 0 for a hijacked record, so a presence
+  // probe reports `loaded`. Identity reports the truth.
+  const foreign = printOut([process.execPath, '/var/folders/x/T/wd-negative/core/launcher/launch.js', 'dream']);
+  assert.equal(status.defaultProbe(PRESENCE, expect, { run: cannedRun(foreign) }), 'mismatched');
+
+  // A match on a record whose execution position exists → loaded.
+  const good = printOut([process.execPath, mine, 'dream']);
+  assert.equal(status.defaultProbe(PRESENCE, expect, { run: cannedRun(good) }), 'loaded');
+
+  // A non-zero PRESENCE exit is still `missing` (unchanged semantics), and a spawn
+  // error likewise.
+  assert.equal(status.defaultProbe(PRESENCE, expect, { run: () => ({ status: 3 }) }), 'missing');
+  assert.equal(status.defaultProbe(PRESENCE, expect, { run: () => ({ status: null, error: new Error('x') }) }), 'missing');
+
+  // A FAILING identity query, and an indeterminate one, are both `unverified` —
+  // never a health claim.
+  let n = 0;
+  const failIdentity = () => (n++ === 0 ? { status: 0, stdout: '' } : { status: 1, stdout: '' });
+  assert.equal(status.defaultProbe(PRESENCE, expect, { run: failIdentity }), 'unverified');
+  assert.equal(status.defaultProbe(PRESENCE, expect, { run: cannedRun('no arguments block') }), 'unverified');
+
+  // SEAM GATING: the SAME input yields `unknown` with no run seam (the suite guard
+  // var is set, and never deleted here) and a real verdict with one.
+  assert.equal(status.defaultProbe(PRESENCE, expect, {}), 'unknown');
+  const saved = process.env.WIENERDOG_LOADER_NOOP;
+  process.env.WIENERDOG_LOADER_NOOP = '1';
+  try {
+    assert.equal(status.defaultProbe(PRESENCE, expect, {}), 'unknown');
+  } finally {
+    // Restore to ABSENT: spawn.js returns {status:0} for this var BEFORE the
+    // guard var's throw, so leaking it would disarm the backstop for every test
+    // that follows.
+    if (saved === undefined) delete process.env.WIENERDOG_LOADER_NOOP;
+    else process.env.WIENERDOG_LOADER_NOOP = saved;
+  }
+});
+
+test('entry-identity: defaultProbe with NO expectation returns unverified, never loaded', () => {
+  const good = printOut([process.execPath, '/Users/u/.wienerdog/launcher/launch.js', 'dream']);
+  const run = cannedRun(good);
+  // A probe that cannot say WHAT will run must not claim health — this is the
+  // fail-CLOSED default, and it also covers a derivation skew (a basename
+  // deriveProbeArgv recognizes and deriveIdentityArgv does not).
+  assert.equal(status.defaultProbe(PRESENCE, undefined, { run }), 'unverified');
+  assert.equal(status.defaultProbe(PRESENCE, null, { run }), 'unverified');
+  assert.equal(status.defaultProbe(PRESENCE, { kind: 'launchd', identityArgv: PRESENCE }, { run }), 'unverified');
+  assert.equal(status.defaultProbe(PRESENCE, { launcher: '/a/b', identityArgv: PRESENCE }, { run }), 'unverified');
+});
+
+test('entry-identity: a systemd entry yields unknown, not a health claim', () => {
+  // The scheduler kind is RECOGNIZED and its identity query is declared
+  // unimplemented (Residual 1) — no line, no callout, no heal, no churn.
+  const expect = { launcher: '/Users/u/.wienerdog/launcher/launch.js', kind: 'systemd', identityArgv: null };
+  assert.equal(status.defaultProbe(['systemctl', '--user', 'is-active', 'wienerdog-dream.timer'], expect, {
+    run: () => ({ status: 0, stdout: 'active\n' }),
+  }), 'unknown');
+});
+
+test('entry-identity: defaultProbe grades a record whose execution position no longer exists as mismatched', () => {
+  // Reads the OS's own record of what it will START. A `brew upgrade node && brew
+  // cleanup` deletes the version-pinned execPath the entry was registered with:
+  // the plist stays correct, args[1] stays our launcher, launchctl print still
+  // exits 0 — and every fire dies in posix_spawn before a line of our code runs.
+  const mine = '/Users/u/.wienerdog/launcher/launch.js';
+  const expect = dreamExpect(mine);
+  const gone = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-gone-node-'));
+  const goneNode = path.join(gone, 'node');
+  fs.writeFileSync(goneNode, '#!/bin/sh\n');
+  fs.rmSync(gone, { recursive: true, force: true });
+  assert.equal(fs.existsSync(goneNode), false, 'the execution position really is absent');
+
+  assert.equal(status.defaultProbe(PRESENCE, expect, { run: cannedRun(printOut([goneNode, mine, 'dream'])) }), 'mismatched');
+  // The SAME fixture with an existing execution position → loaded, so this
+  // criterion discriminates on existence alone.
+  assert.equal(status.defaultProbe(PRESENCE, expect, { run: cannedRun(printOut([process.execPath, mine, 'dream'])) }), 'loaded');
+});
+
+test('entry-identity: defaultProbe reaches the identity query with NO run seam (subprocess)', () => {
+  // Every other identity assertion runs through an injected opts.run, so all of
+  // them stay green if step 7 calls a bare `run(…)` — which is null on every
+  // PRODUCTION call. This drives the production path in a child whose env omits
+  // both neutralizers.
+  const statusModule = path.resolve(__dirname, '..', '..', 'src', 'scheduler', 'status.js');
+  const mine = '/Users/u/.wienerdog/launcher/launch.js';
+  const foreign = path.join(os.tmpdir(), 'wd-foreign', 'launcher', 'launch.js');
+
+  const build = (launcherInRecord) => {
+    const record = printOut([process.execPath, launcherInRecord, 'dream']);
+    // The child requires no CLI module, and both argvs are node one-liners, so no
+    // scheduler client is ever spawned and no mutation is reachable — which is
+    // what makes running it without the backstop inert BY CONSTRUCTION rather
+    // than by luck. (spawn.js IS in the child's require.cache, reached through
+    // status.js -> generators.js; it is loaded but never called.)
+    const SCRIPT = [
+      `const s = require(${JSON.stringify(statusModule)});`,
+      `const expect = { launcher: ${JSON.stringify(mine)}, kind: 'launchd',`,
+      `  identityArgv: [process.execPath, '-e', ${JSON.stringify(`process.stdout.write(${JSON.stringify(record)})`)}] };`,
+      "process.stdout.write(s.defaultProbe([process.execPath, '-e', 'process.exit(0)'], expect));",
+    ].join('\n');
+    const { WIENERDOG_LOADER_NOOP: _a, WIENERDOG_TEST_NO_REAL_SCHEDULER: _b, ...childEnv } = process.env;
+    return spawnSync(process.execPath, ['-e', SCRIPT], { env: childEnv, encoding: 'utf8' });
+  };
+
+  const ok = build(mine);
+  assert.equal(ok.status, 0, `child exited ${ok.status}: ${ok.stderr}`);
+  assert.equal(ok.stdout, 'loaded');
+  const bad = build(foreign);
+  assert.equal(bad.status, 0, `child exited ${bad.status}: ${bad.stderr}`);
+  assert.equal(bad.stdout, 'mismatched');
+});
+
+// ---------------------------------------------------------------------------
+// probeAll / doctor / digest
+// ---------------------------------------------------------------------------
+
+test('entry-identity: probeAll reports mismatched end-to-end for a poisoned loaded record', { skip: !isPosix }, () => {
+  // THE INCIDENT REGRESSION. The entry lives under the TEST's own LaunchAgents
+  // root (probeAll gates on lexical containment derived from paths.home), and the
+  // file itself need not exist — only the manifest record.
+  const { paths } = setup((home) => [{
+    kind: 'scheduler-entry',
+    path: path.join(gen.launchAgentsDir(home), 'ai.wienerdog.dream.plist'),
+    unload: ['launchctl', 'bootout', 'gui/501/ai.wienerdog.dream'],
+  }]);
+  const foreign = path.join(os.tmpdir(), 'wd-negative', 'core', 'launcher', 'launch.js');
+
+  const poisoned = status.probeAll(paths, { platform: 'darwin', run: cannedRun(printOut([process.execPath, foreign, 'dream'])) });
+  assert.equal(poisoned.length, 1, 'the entry is in root and IS probed');
+  assert.equal(poisoned[0].status, 'mismatched');
+
+  const healthy = status.probeAll(paths, {
+    platform: 'darwin',
+    run: cannedRun(printOut([process.execPath, gen.launcherPath(paths), 'dream'])),
+  });
+  assert.equal(healthy.length, 1);
+  assert.equal(healthy[0].status, 'loaded');
+});
+
+test('entry-identity: doctorSchedulerChecks maps mismatched to fail', { skip: !isPosix }, () => {
+  const names = ['dream', 'catchup', 'digest', 'weekly', 'triage'];
+  const { paths } = setup((home) => names.map((n) => ({
+    kind: 'scheduler-entry',
+    path: path.join(gen.launchAgentsDir(home), `ai.wienerdog.${n}.plist`),
+    unload: ['launchctl', 'bootout', `gui/501/ai.wienerdog.${n}`],
+  })));
+  const byName = { dream: 'loaded', catchup: 'missing', digest: 'mismatched', weekly: 'unverified', triage: 'unknown' };
+  const probe = (argv) => byName[argv[2].replace('gui/', '').split('/')[1].replace('ai.wienerdog.', '')];
+
+  const out = status.doctorSchedulerChecks(paths, { platform: 'darwin', probe });
+  assert.deepEqual(out, [
+    { status: 'ok', msg: "scheduled job 'dream' is loaded (launchd)" },
+    {
+      status: 'warn',
+      msg: "scheduled job 'catchup' is configured but NOT loaded in launchd — run 'wienerdog sync' to reload it",
+    },
+    {
+      status: 'fail',
+      msg: "scheduled job 'digest' is registered in launchd but the program it would run is not this Wienerdog "
+        + "install's, or no longer exists on this computer, so it cannot work — run 'wienerdog sync' to re-register "
+        + 'it from this install',
+    },
+    {
+      status: 'warn',
+      msg: "scheduled job 'weekly' is registered in launchd but Wienerdog could not read back the program it runs, "
+        + "so it cannot confirm the entry belongs to this install — run 'wienerdog sync' to re-register it, then "
+        + "'wienerdog doctor' again",
+    },
+  ], "'unknown' emits no line at all");
+});
+
+test('entry-identity: digest emits template F for a mismatched entry', { skip: !isPosix }, () => {
+  const names = ['dream', 'catchup', 'digest'];
+  const { paths } = setup((home) => names.map((n) => ({
+    kind: 'scheduler-entry',
+    path: path.join(gen.launchAgentsDir(home), `ai.wienerdog.${n}.plist`),
+    unload: ['launchctl', 'bootout', `gui/501/ai.wienerdog.${n}`],
+  })));
+  const byName = { dream: 'mismatched', catchup: 'unverified', digest: 'missing' };
+  const probe = (argv) => byName[argv[2].split('/')[2].replace('ai.wienerdog.', '')];
+  status.refreshSchedulerStatus(paths, { platform: 'darwin', probe });
+
+  const line = status.renderSchedulerStatusLine(paths);
+  const blocks = line.split('\n\n');
+  assert.equal(blocks.length, 3, 'three distinct callouts, blank-line separated (a single \\n would merge them)');
+  assert.match(blocks[0], /^> \[!warning\] Wienerdog: the scheduled job "dream" is registered in your computer's scheduler, but the program it would run is either not part of this Wienerdog installation or no longer on this computer, so it cannot run\. Run 'wienerdog sync' to re-register it from this installation\.$/);
+  assert.match(blocks[1], /^> \[!warning\] Wienerdog: Wienerdog could not read back what your computer's scheduler will actually run for the scheduled job "catchup", so it cannot confirm it is still wired to this installation\. Run 'wienerdog sync' to re-register it, then run 'wienerdog doctor'\.$/);
+  assert.match(blocks[2], /^> \[!warning\] Wienerdog: the scheduled job "digest" is set up but not currently active/);
+
+  // The single-missing output stays BYTE-IDENTICAL to today's.
+  const { paths: p2 } = setup((home) => [{
+    kind: 'scheduler-entry',
+    path: path.join(gen.launchAgentsDir(home), 'ai.wienerdog.dream.plist'),
+    unload: ['launchctl', 'bootout', 'gui/501/ai.wienerdog.dream'],
+  }]);
+  status.refreshSchedulerStatus(p2, { platform: 'darwin', probe: () => 'missing' });
+  assert.equal(
+    status.renderSchedulerStatusLine(p2),
+    '> [!warning] Wienerdog: the scheduled job "dream" is set up but not currently active in your computer\'s '
+    + "scheduler. Run 'wienerdog sync' to reactivate it. (This can happen after some system updates.)"
+  );
+
+  // Empty when every bucket is empty.
+  status.refreshSchedulerStatus(p2, { platform: 'darwin', probe: () => 'loaded' });
+  assert.equal(status.renderSchedulerStatusLine(p2), '');
+});
+
+// ---------------------------------------------------------------------------
+// The darwin replacement (Table E)
+// ---------------------------------------------------------------------------
+
+test('entry-identity: reloadJob replaces a bootstrap-blocked label (darwin)', { skip: !isPosix }, () => {
+  const { paths } = setup();
+  withConfig(paths, [{ name: 'dream' }]);
+  const uid = process.getuid();
+  const plistPath = laPath(paths, 'dream');
+
+  // launchd REFUSES a bootstrap for an already-loaded label; without a teardown a
+  // hijacked record can never be replaced and the `mismatched` remediation
+  // ("run wienerdog sync") would be a lie.
+  /** @type {string[][]} */ const calls = [];
+  const loader = (a) => (calls.push(a), { status: a[1] === 'bootstrap' && calls.length === 1 ? 1 : 0 });
+  const ok = schedule.reloadJob(paths, { name: 'dream', at: '03:30' }, loader, 'darwin');
+  assert.equal(ok, true, 'the SECOND bootstrap decides the result');
+  assert.deepEqual(calls, [
+    ['launchctl', 'bootstrap', `gui/${uid}`, plistPath],
+    ['launchctl', 'bootout', `gui/${uid}/ai.wienerdog.dream`],
+    ['launchctl', 'bootstrap', `gui/${uid}`, plistPath],
+  ]);
+
+  // repairCatchup's darwin branch uses the same replacement.
+  const cuPath = laPath(paths, 'catchup');
+  /** @type {string[][]} */ const cu = [];
+  const cuLoader = (a) => (cu.push(a), { status: a[1] === 'bootstrap' && cu.length === 1 ? 1 : 0 });
+  schedule.repairCatchup(paths, manifestLib.load(paths), { loader: cuLoader, platform: 'darwin', probe: () => 'missing' });
+  assert.deepEqual(cu, [
+    ['launchctl', 'bootstrap', `gui/${uid}`, cuPath],
+    ['launchctl', 'bootout', `gui/${uid}/ai.wienerdog.catchup`],
+    ['launchctl', 'bootstrap', `gui/${uid}`, cuPath],
+  ]);
+});
+
+test('entry-identity: reloadJob issues NO bootout when the first bootstrap succeeds', { skip: !isPosix }, () => {
+  const { paths } = setup();
+  withConfig(paths, [{ name: 'dream' }]);
+  // BOOTSTRAP FIRST: the `missing` case costs one spawn and never reaches a
+  // destructive step, so a working-but-unverifiable entry is never destroyed by a
+  // heal that then fails.
+  const { calls, loader } = recordingLoader(paths, 0);
+  assert.equal(schedule.reloadJob(paths, { name: 'dream', at: '03:30' }, loader, 'darwin'), true);
+  assert.deepEqual(calls, [['launchctl', 'bootstrap', `gui/${process.getuid()}`, laPath(paths, 'dream')]]);
+});
+
+// ---------------------------------------------------------------------------
+// reloadMissing — heal set, expect construction, pre-destructive marker
+// ---------------------------------------------------------------------------
+
+/** A run seam that answers with a canned launchd record naming `launcher`. */
+const recordRun = (launcher, exec = process.execPath) => cannedRun(printOut([exec, launcher, 'dream']));
+
+test('entry-identity: reloadMissing heals a configured job whose loaded record names a foreign launcher', { skip: !isPosix }, () => {
+  const { paths } = setup();
+  withConfig(paths, [{ name: 'dream' }]);
+  const foreign = path.join(os.tmpdir(), 'wd-negative', 'core', 'launcher', 'launch.js');
+  const { calls, loader } = recordingLoader(paths, 0);
+
+  const res = status.reloadMissing(paths, { loader, platform: 'darwin', run: recordRun(foreign) });
+
+  assert.deepEqual(calls, [['launchctl', 'bootstrap', `gui/${process.getuid()}`, laPath(paths, 'dream')]]);
+  // The return value is the RUNTIME check that opts.loader was really injected:
+  // an omitted loader hits schedulerSpawn's throw, which reloadMissing swallows
+  // into `failed`, leaving the recorded list empty rather than raising.
+  assert.deepEqual(res, { reloaded: ['dream'], failed: [] });
+});
+
+test('entry-identity: reloadMissing heals NOTHING when the loaded record names this install\'s launcher (no opts.probe)', { skip: !isPosix }, () => {
+  const { paths } = setup();
+  withConfig(paths, [{ name: 'dream' }]);
+  const { calls, loader } = recordingLoader(paths, 0);
+
+  const res = status.reloadMissing(paths, { loader, platform: 'darwin', run: recordRun(gen.launcherPath(paths)) });
+
+  // Passing a null expectation would make every entry `unverified` — which is IN
+  // the heal set — so only this NEGATIVE assertion can redden that mutation.
+  assert.deepEqual(calls, []);
+  assert.deepEqual(res, { reloaded: [], failed: [] });
+});
+
+test('entry-identity: reloadMissing heals an unverified entry', { skip: !isPosix }, () => {
+  const { paths } = setup();
+  withConfig(paths, [{ name: 'dream' }]);
+  const { calls, loader } = recordingLoader(paths, 0);
+  // opts.probe is permitted here: this exercises HEAL_SET membership, not the
+  // expectation construction.
+  const res = status.reloadMissing(paths, { loader, platform: 'darwin', probe: () => 'unverified' });
+  assert.deepEqual(calls, [['launchctl', 'bootstrap', `gui/${process.getuid()}`, laPath(paths, 'dream')]]);
+  assert.deepEqual(res, { reloaded: ['dream'], failed: [] });
+});
+
+test('entry-identity: reloadMissing writes the durable marker even for an observed missing entry', { skip: !isPosix }, () => {
+  const { paths } = setup();
+  withConfig(paths, [{ name: 'dream' }]);
+  const { calls, seen, loader } = recordingLoader(paths, 0);
+  assert.equal(fs.existsSync(status.statusPath(paths)), false, 'no cache before the call');
+
+  // Observed `missing` (a non-zero PRESENCE exit). The marker is written anyway,
+  // because that verdict can be a TRANSIENT presence-query failure on a label the
+  // very next bootout will destroy (Table E row 2).
+  const res = status.reloadMissing(paths, { loader, platform: 'darwin', run: () => ({ status: 1 }) });
+
+  assert.equal(calls.length, 1, 'the replacement really happened');
+  assert.equal(seen[0].exists, true, 'the durable marker was written BEFORE the first replacement call');
+  assert.ok(seen[0].parsed && typeof seen[0].parsed.checked_at === 'string');
+  assert.ok(seen[0].parsed && Array.isArray(seen[0].parsed.entries));
+  assert.deepEqual(res, { reloaded: ['dream'], failed: [] });
+});
+
+test('entry-identity: reloadMissing writes no marker when nothing enters the heal set', { skip: !isPosix }, () => {
+  const { paths } = setup();
+  withConfig(paths, [{ name: 'dream' }]);
+  const { calls, loader } = recordingLoader(paths, 0);
+  status.reloadMissing(paths, { loader, platform: 'darwin', probe: () => 'loaded' });
+  assert.deepEqual(calls, []);
+  // The marker is tied to a REACHABLE replacement call, not to the act of calling
+  // reloadMissing.
+  assert.equal(fs.existsSync(status.statusPath(paths)), false);
+});
+
+test('entry-identity: reloadMissing issues zero loader calls for a healthy entry', { skip: !isPosix }, () => {
+  // A gate assertion, NOT an idempotence proof: this never runs `wienerdog sync`,
+  // and the real CLI's second-run behaviour is not exercised anywhere in this WP.
+  const { paths } = setup();
+  withConfig(paths, [{ name: 'dream' }, { name: 'digest', at: '07:00' }]);
+  const { calls, loader } = recordingLoader(paths, 0);
+  const res = status.reloadMissing(paths, { loader, platform: 'darwin', probe: () => 'loaded' });
+  assert.deepEqual(calls, []);
+  assert.deepEqual(res, { reloaded: [], failed: [] });
+});
+
+// ---------------------------------------------------------------------------
+// repairCatchup — the SECOND destructive site (the entry that was hijacked)
+// ---------------------------------------------------------------------------
+
+test('entry-identity: repairCatchup writes the durable marker before its first replacement call', { skip: !isPosix }, () => {
+  const { paths } = setup();
+  withConfig(paths, [{ name: 'dream' }]);
+  const { calls, seen, loader } = recordingLoader(paths, 0);
+  assert.equal(fs.existsSync(status.statusPath(paths)), false, 'no cache before the call');
+
+  // Called DIRECTLY (not through repointSchedules, which prepends per-job loader
+  // calls and registers the catch-up entry twice, so "the first loader call" would
+  // not be an assertion about repairCatchup at all).
+  schedule.repairCatchup(paths, manifestLib.load(paths), { loader, platform: 'darwin', run: () => ({ status: 1 }) });
+
+  assert.equal(calls.length, 1, 'the replacement really happened');
+  assert.equal(seen[0].exists, true, 'the durable marker was written BEFORE the first replacement call');
+  assert.ok(seen[0].parsed && typeof seen[0].parsed.checked_at === 'string');
+});
+
+test('entry-identity: repairCatchup repairs a poisoned loaded catchup record', { skip: !isPosix }, () => {
+  const { paths } = setup();
+  withConfig(paths, [{ name: 'dream' }]);
+  const foreign = path.join(os.tmpdir(), 'wd-negative', 'core', 'launcher', 'launch.js');
+  const { calls, loader } = recordingLoader(paths, 0);
+
+  schedule.repairCatchup(paths, manifestLib.load(paths), { loader, platform: 'darwin', run: recordRun(foreign) });
+
+  assert.deepEqual(calls, [['launchctl', 'bootstrap', `gui/${process.getuid()}`, laPath(paths, 'catchup')]]);
+});
+
+test("entry-identity: repairCatchup repairs NOTHING when the loaded catchup record names this install's launcher (no opts.probe)", { skip: !isPosix }, () => {
+  const { paths } = setup();
+  withConfig(paths, [{ name: 'dream' }]);
+  const { calls, loader } = recordingLoader(paths, 0);
+
+  const r = schedule.repairCatchup(paths, manifestLib.load(paths), {
+    loader, platform: 'darwin', run: recordRun(gen.launcherPath(paths)),
+  });
+
+  assert.deepEqual(r, {});
+  assert.deepEqual(calls, [], 'the catch-up entry is the exact one that was hijacked 76 times — this is its gate');
+});
+
+test('entry-identity: repairCatchup heals every member of the heal set and nothing else', { skip: !isPosix }, () => {
+  const run = (member) => {
+    const { paths } = setup();
+    withConfig(paths, [{ name: 'dream' }]);
+    const { calls, loader } = recordingLoader(paths, 0);
+    schedule.repairCatchup(paths, manifestLib.load(paths), { loader, platform: 'darwin', probe: () => member });
+    return calls;
+  };
+  for (const member of ['missing', 'mismatched', 'unverified']) {
+    assert.equal(run(member).length, 1, `${member} is healed`);
+  }
+  for (const member of ['loaded', 'unknown']) {
+    assert.deepEqual(run(member), [], `${member} is left alone`);
+  }
+
+  // The win32 branch gates identically.
+  const runWin = (member) => {
+    const { paths } = setup();
+    withConfig(paths, [{ name: 'dream' }]);
+    const { calls, loader } = recordingLoader(paths, 0);
+    schedule.repairCatchup(paths, manifestLib.load(paths), { loader, platform: 'win32', probe: () => member });
+    return calls;
+  };
+  for (const member of ['missing', 'mismatched', 'unverified']) {
+    assert.equal(runWin(member).length, 1, `win32: ${member} is healed`);
+  }
+  for (const member of ['loaded', 'unknown']) {
+    assert.deepEqual(runWin(member), [], `win32: ${member} is left alone`);
+  }
+});
+
+test('entry-identity: repairCatchup emits the "restored the missing" notice only for an observed missing entry', { skip: !isPosix }, () => {
+  const repair = (member, exitStatus) => {
+    const { paths } = setup();
+    withConfig(paths, [{ name: 'dream' }]);
+    const { calls, loader } = recordingLoader(paths, exitStatus);
+    const r = schedule.repairCatchup(paths, manifestLib.load(paths), { loader, platform: 'darwin', probe: () => member });
+    return { r, calls };
+  };
+
+  // A SUCCESSFUL repair. The shipped string names "the MISSING catch-up
+  // registration" — emitting it for a hijacked or unreadable entry states
+  // something false, and adopt.js turns ANY notice into a user-facing adoption
+  // failure, which on Windows (where any round-trip deviation grades unverified)
+  // would report failure on a healthy install.
+  const ok = repair('missing', 0);
+  assert.deepEqual(ok.r, { notice: 'restored the missing catch-up registration.' });
+  assert.ok(ok.calls.length > 0);
+  for (const member of ['mismatched', 'unverified']) {
+    const q = repair(member, 0);
+    assert.deepEqual(q.r, {}, `${member}: no notice`);
+    assert.equal('notice' in q.r, false);
+    assert.ok(q.calls.length > 0, `${member}: the repair still HAPPENED — only the notice differs`);
+  }
+
+  // FAILURE notices are unchanged for every member: a repair the OS rejected is a
+  // real failure and adopt should still flag it.
+  for (const member of ['missing', 'mismatched', 'unverified']) {
+    assert.deepEqual(repair(member, 1).r, {
+      notice: "catch-up entry rewritten but the OS scheduler did not accept it — run 'wienerdog doctor'.",
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Drift prevention
+// ---------------------------------------------------------------------------
+
+test('entry-identity: launcherPathFor delegates to generators.launcherPath (no drift)', () => {
+  // The health probe's EXPECTATION and the path the entry is REGISTERED with must
+  // be the same string by construction — a hand-copied second join is exactly how
+  // a checker and a writer drift apart.
+  const { paths } = setup();
+  withConfig(paths, [{ name: 'dream' }]);
+  const registered = schedule.reloadJob(paths, { name: 'dream', at: '03:30' }, () => ({ status: 0 }), 'darwin');
+  assert.equal(registered, true);
+  const written = fs.readFileSync(laPath(paths, 'dream'), 'utf8');
+  assert.ok(written.includes(gen.launcherPath(paths)), 'the REGISTERED entry carries generators.launcherPath');
+  assert.equal(gen.launcherPath(paths), path.join(paths.core, 'launcher', 'launch.js'));
+});

--- a/tests/unit/scheduler-status.test.js
+++ b/tests/unit/scheduler-status.test.js
@@ -98,7 +98,7 @@ test('describeEntry returns null for an unrecognized basename (systemd .service 
 // defaultProbe — exit-code → status mapping (the incident's read-only probe)
 // ---------------------------------------------------------------------------
 
-test('defaultProbe maps exit 0 → loaded, non-zero → missing, spawn error → missing', () => {
+test('defaultProbe maps exit 0 without an expectation → unverified, non-zero → missing, spawn error → missing', () => {
   const saved = {
     noop: process.env.WIENERDOG_LOADER_NOOP,
     guard: process.env.WIENERDOG_TEST_NO_REAL_SCHEDULER,
@@ -107,7 +107,8 @@ test('defaultProbe maps exit 0 → loaded, non-zero → missing, spawn error →
   delete process.env.WIENERDOG_TEST_NO_REAL_SCHEDULER;
   try {
     const node = process.execPath; // harmless real spawn — never the OS scheduler
-    assert.equal(status.defaultProbe([node, '-e', 'process.exit(0)']), 'loaded');
+    // A probe with no identity expectation must NOT claim health (fail closed).
+    assert.equal(status.defaultProbe([node, '-e', 'process.exit(0)']), 'unverified');
     assert.equal(status.defaultProbe([node, '-e', 'process.exit(3)']), 'missing');
     assert.equal(status.defaultProbe(['wd-no-such-binary-xyz-42']), 'missing');
   } finally {


### PR DESCRIPTION
Spec: docs/specs/WP-scheduler-entry-identity.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

`node scripts/boundary-check.js docs/specs/WP-scheduler-entry-identity.md <all 7 changed files + the new test>` → exit 0.

**This WP does NOT close the incident class on its own.** It makes the product's own
health verdict and heal honest; `WP-scheduler-loaded-record-tripwire` must also merge —
that one stops the test harness creating the poisoned loaded records in the first place
and detects stale ones. Neither half closes the class alone.

## Verification output

### Step 1 — the new suite, machine-checked non-vacuity gate

```
$ npm test --silent -- --test-reporter=tap --test-name-pattern "entry-identity" \
      tests/unit/scheduler-entry-identity.test.js \
      | grep -E "^ok [0-9]+ - entry-identity: " | wc -l | tr -d ' '
28
named passing subtests: 28        # gate is -ge 28 → PASS
```

Full run of the file (28 named subtests, 0 fail, 0 skipped on this macOS host):

```
✔ entry-identity: launchd mismatch when arguments[1] is not this install's launcher
✔ entry-identity: schtasks does NOT match a task whose Command is not our cmd.exe and whose launcher token is only inside the set-chain
✔ entry-identity: schtasks (c0) binds to the canonical set, and (d) outranks it
✔ entry-identity: schtasks exec grammar shares cmdArgToken's bare alphabet and rejects every unquoted operator
✔ entry-identity: schtasks reports a substituted execution position instead of judging it (Residual 9)
✔ entry-identity: deriveIdentityArgv returns a per-kind identity query, and null for a foreign basename
✔ entry-identity: defaultProbe returns mismatched for an exit-0 record naming a foreign launcher
✔ entry-identity: defaultProbe with NO expectation returns unverified, never loaded
✔ entry-identity: a systemd entry yields unknown, not a health claim
✔ entry-identity: defaultProbe grades a record whose execution position no longer exists as mismatched
✔ entry-identity: defaultProbe reaches the identity query with NO run seam (subprocess)
✔ entry-identity: probeAll reports mismatched end-to-end for a poisoned loaded record
✔ entry-identity: doctorSchedulerChecks maps mismatched to fail
✔ entry-identity: digest emits template F for a mismatched entry
✔ entry-identity: reloadJob replaces a bootstrap-blocked label (darwin)
✔ entry-identity: reloadJob issues NO bootout when the first bootstrap succeeds
✔ entry-identity: reloadMissing heals a configured job whose loaded record names a foreign launcher
✔ entry-identity: reloadMissing heals NOTHING when the loaded record names this install's launcher (no opts.probe)
✔ entry-identity: reloadMissing heals an unverified entry
✔ entry-identity: reloadMissing writes the durable marker even for an observed missing entry
✔ entry-identity: reloadMissing writes no marker when nothing enters the heal set
✔ entry-identity: reloadMissing issues zero loader calls for a healthy entry
✔ entry-identity: repairCatchup writes the durable marker before its first replacement call
✔ entry-identity: repairCatchup repairs a poisoned loaded catchup record
✔ entry-identity: repairCatchup repairs NOTHING when the loaded catchup record names this install's launcher (no opts.probe)
✔ entry-identity: repairCatchup heals every member of the heal set and nothing else
✔ entry-identity: repairCatchup emits the "restored the missing" notice only for an observed missing entry
✔ entry-identity: launcherPathFor delegates to generators.launcherPath (no drift)
ℹ tests 28   ℹ pass 28   ℹ fail 0   ℹ skipped 0
```

### Step 2 — the touched existing suite, anchored gate

```
$ npm test --silent -- --test-reporter=tap \
      --test-name-pattern "defaultProbe|probeAll|reloadMissing|doctorSchedulerChecks" \
      tests/unit/scheduler-status.test.js \
      | grep -E "^ok [0-9]+ - (defaultProbe|probeAll|reloadMissing|doctorSchedulerChecks)" | wc -l | tr -d ' '
13
named passing subtests: 13        # gate is -ge 8 → PASS
```

### Step 3 — `npm test`

```
ℹ tests 1699
ℹ suites 0
ℹ pass 1694
ℹ fail 0
ℹ cancelled 0
ℹ skipped 5
ℹ todo 0
```

(1671 tests on `main` → 1699 here: +28 new named tests. The 5 skips are pre-existing.)

### Step 4 — `npm run lint`

```
--- markdownlint ---
markdownlint-cli2 v0.23.0 (markdownlint v0.41.0)
Finding: docs/**/*.md skills/**/*.md templates/**/*.md tests/**/*.md *.md
Linting: 374 file(s)
Summary: 0 error(s)
--- shellcheck ---
--- PSScriptAnalyzer ---
--- frontmatter check ---
frontmatter check passed: 200 spec(s), 4 agent(s)

lint passed
```

### Step 5 — structural greps (each asserted; all exited 0)

```
$ grep -n "loadedEntryTargets" src/scheduler/generators.js
784:function loadedEntryTargets(stdout, kind, expectLauncher) {
1007:  loadedEntryTargets,
$ grep -n "deriveIdentityArgv" src/scheduler/generators.js
171:function deriveIdentityArgv(schedulePath, platform = process.platform) {
767: * deriveIdentityArgv().argv.
1006:  deriveIdentityArgv,
$ grep -n "launcherPath" src/scheduler/generators.js
37: * launcherPathFor now delegates here so the two can never drift.
41:function launcherPath(paths) {
781: * @param {string} expectLauncher  an absolute path (generators.launcherPath)
999:  launcherPath,

$ grep -n "'mismatched'" src/scheduler/status.js
70,80,123,133,240,272,289
$ grep -n "'unverified'" src/scheduler/status.js
70,80,97,118,121,124,138,250,272,296
$ grep -n "opts.run" src/scheduler/status.js
100,112,155,182,374
$ grep -n "existsSync" src/scheduler/status.js
130,132

$ grep -n "darwinReplaceEntry" src/cli/schedule.js
51:function darwinReplaceEntry(loader, uid, label, plistPath) {
649,651,764

$ grep -nE "^module\.exports = \{.*\brepairCatchup\b" src/cli/schedule.js
1018:module.exports = { run, defaultLoader, repointSchedules, ensureDreamSchedule, registerPlatform, reloadJob, repairCatchup };

$ grep -n "refreshSchedulerStatus" src/cli/schedule.js
650:    require('../scheduler/status').refreshSchedulerStatus(paths, opts);
675:  require('../scheduler/status').refreshSchedulerStatus(paths, opts); // pre-destructive marker

$ grep -n "schedulerLine" src/cli/dream.js
384:        schedulerLine: require('../scheduler/status').renderSchedulerStatusLine(paths),
$ grep -n "schedulerLine" src/cli/sync.js      # REGRESSION GUARD, already on main
278:      schedulerLine: require('../scheduler/status').renderSchedulerStatusLine(paths),
```

### Step 5b — Table C R1, mechanically checked

```
$ grep -nE "delete[[:space:]]+process\.env\.WIENERDOG_TEST_NO_REAL_SCHEDULER" \
     tests/unit/scheduler-entry-identity.test.js
(no output, exit 1)
OK: the suite guard stays armed for every test in this WP
```

### Step 5c — deleted in round 5, not re-added in any form.

### Step 6 — negative grep: the presence-only mapping is gone

```
$ grep -n "return r.status === 0 ? 'loaded' : 'missing';" src/scheduler/status.js
(no output, exit 1)
OK: the presence-only status mapping is gone
```

### Step 7 — real-machine discrimination (macOS 26, READ-ONLY, no mutation)

```
OK: positive=match, negative=mismatch, truncated=indeterminate; launcher = /Users/gyulafeher/.wienerdog/launcher/launch.js ; exec = /opt/homebrew/Cellar/node/25.9.0_2/bin/node
```

All five asserts passed against the LIVE loaded record of `ai.wienerdog.dream`,
including `fs.existsSync(exec)` on the version-pinned Cellar node — i.e. step 8b's
input is healthy on this machine right now. **No real finding.**

### Step 8 — real-machine `wienerdog doctor` (READ-ONLY)

```
[ok] scheduled job 'dream' is loaded (launchd)
[warn] scheduled job 'catchup' is configured but NOT loaded in launchd — run 'wienerdog sync' to reload it
doctor exit=0
```

Exit 0, so the `[fail]`-line discriminator did not need to fire. The `catchup`
warn is the pre-existing, spec-acknowledged state of this machine ("`doctor`
currently reports `catchup` as not loaded; leave it") — not a regression, and
deliberately not repaired here.

### Step 8 (Definition of done item 8) — the ADR-0018 ratification marker, ANCHORED

```
$ grep -nE '^Status: \*\*Accepted\. OWNER-SIGNED 2026-07-26\.\*\*$' \
     docs/adr/0018-windows-scheduled-dreaming.md
204:Status: **Accepted. OWNER-SIGNED 2026-07-26.**
```

Exactly one line, `204:`. Verified, not requested; the ADR is not a deliverable and
was not edited.

### Mutation checks — all 30 applied on top of this branch, run, confirmed red, reverted

Each mutation was applied to the finished branch, the named test run through
`node tests/run.js --test-reporter=tap --test-name-pattern <escaped name> <file>`
(pattern BEFORE the path, and the selected-line count asserted to be exactly 1 so a
zero-match pattern cannot report a false pass), then the file restored byte-for-byte.

| # | Result | Test that turned red |
|---|--------|----------------------|
| M1 | RED | `entry-identity: launchd mismatch when arguments[1] is not this install's launcher` |
| M2 | RED | `entry-identity: schtasks does NOT match a task whose Command is not our cmd.exe and whose launcher token is only inside the set-chain` |
| M3 | RED | `entry-identity: defaultProbe returns mismatched for an exit-0 record naming a foreign launcher` |
| M4 | RED | `entry-identity: defaultProbe with NO expectation returns unverified, never loaded` |
| M5 | RED | `entry-identity: a systemd entry yields unknown, not a health claim` |
| M6 | RED | `entry-identity: doctorSchedulerChecks maps mismatched to fail` |
| M7 | RED | `entry-identity: reloadMissing heals an unverified entry` |
| M8 | RED | `entry-identity: reloadJob replaces a bootstrap-blocked label (darwin)` |
| M9 | RED | `entry-identity: reloadJob issues NO bootout when the first bootstrap succeeds` |
| M10 | RED | `entry-identity: reloadMissing writes the durable marker even for an observed missing entry` |
| M11 | RED | `entry-identity: digest emits template F for a mismatched entry` |
| M12 | RED | `entry-identity: probeAll reports mismatched end-to-end for a poisoned loaded record` |
| M13 | RED | `entry-identity: reloadMissing heals NOTHING when the loaded record names this install's launcher (no opts.probe)` |
| M14 | RED | verification step 5's dream.js conditional grep exits 1 (executed: with the `schedulerLine` property deleted, `grep -n "schedulerLine" src/cli/dream.js` exits 1) |
| M15 | RED | `entry-identity: launcherPathFor delegates to generators.launcherPath (no drift)` |
| M16 | RED | `entry-identity: repairCatchup repairs NOTHING when the loaded catchup record names this install's launcher (no opts.probe)` |
| M17 | RED | verification step 5b's negative grep exits 1 (executed: with the deletion appended to the test file the grep matches at line 837 and the FAIL branch fires) |
| M18 | RED | `entry-identity: schtasks (c0) binds to the canonical set, and (d) outranks it` |
| M19 | RED | `entry-identity: defaultProbe reaches the identity query with NO run seam (subprocess)` |
| M20 | RED | `entry-identity: reloadMissing heals a configured job whose loaded record names a foreign launcher` |
| M21 | RED | `entry-identity: reloadMissing writes the durable marker even for an observed missing entry` |
| M22 | RED | `entry-identity: schtasks (c0) binds to the canonical set, and (d) outranks it` |
| M23 | RED | `entry-identity: schtasks exec grammar shares cmdArgToken's bare alphabet and rejects every unquoted operator` |
| M24 | RED | `entry-identity: schtasks exec grammar shares cmdArgToken's bare alphabet and rejects every unquoted operator` |
| M25 | RED | `entry-identity: defaultProbe grades a record whose execution position no longer exists as mismatched` |
| M26 | RED | `entry-identity: repairCatchup writes the durable marker before its first replacement call` |
| M27 | RED | `entry-identity: repairCatchup writes the durable marker before its first replacement call` |
| M28 | RED | `entry-identity: repairCatchup emits the "restored the missing" notice only for an observed missing entry` |
| M29 | RED | `entry-identity: schtasks (c0) binds to the canonical set, and (d) outranks it` |
| M30 | RED | `entry-identity: schtasks (c0) binds to the canonical set, and (d) outranks it` |

Working tree restored and re-verified after the mutation pass: `npm test` 1699/1694
pass, `npm run lint` passed, `git status` shows only the seven deliverable files
plus the new test.

## Known open defect this WP ships with

**Residual 8 is a known open defect** — the pre-destructive marker RE-PROBES rather
than persisting the verdict that triggered the heal, so a *transient* presence-query
failure alone (no concurrency, no external mutation) can make it persist `loaded`
immediately before a `bootout`. Two rounds produced two accepting arguments and both
were falsified; this WP offers no third. The owner ruled on 2026-07-26: **"ship as a
known-open defect for now."** That accepts *shipping with* the defect; it does not
accept an argument that the defect is harmless, and it does not close it.
`WP-scheduler-marker-persists-verdict` (a single-entry writer in
`src/scheduler/status.js` plus an ADR-0018 amendment) remains routed.

## Owner Windows-VPS checklist (NOT performed by the implementer)

- [ ] On a real Windows install, confirm `wienerdog doctor` reports the two scheduled
      tasks as `loaded` and **not** `unverified` — i.e. that
      `schtasks /query /tn … /xml` round-trips well enough for Table B's `schtasks`
      conditions (0)/(a)/(b)/(c)/(c0)/(d). No Windows host was available here, so the
      round-trip and its encoding are specified, not verified (Residual 2). The
      fail-safe direction is `unverified` → warn + one re-register, never a false
      `mismatched` exit 1.

## Decisions made

1. **`defaultProbe`'s double spawn on darwin.** `expect.identityArgv` is
   byte-identical to the presence `argv` there, so step 7 issues one extra
   sub-millisecond read-only spawn per entry. Kept deliberately: one uniform code
   path beats an aliasing special case.
2. **`foreign` → `mismatched`.** `foreign` already means the opposite thing in this
   subsystem (`deriveProbeArgv` returns null for a "foreign basename", which means
   *silently skipped*, while a foreign *record* is the loudest failure the taxonomy
   has). `mismatched` maps 1:1 onto `loadedEntryTargets`'s `'mismatch'` and needs no
   glossary term.
3. **No new alert channel — with the CORRECTED reasoning.** The old rationale ("a
   successful run could clear a still-hijacked entry") is **false**: `clearAlerts` is
   an exact job match, so a `dream` success can never clear a `catchup` alert. The
   real reasons are (i) `digest.formatAlerts` renders every record through one
   code-owned "the X job has failed … clears automatically when the job next
   succeeds" template, which is the wrong sentence for a scheduler-identity finding;
   (ii) a record keyed under anything but a real job name is never cleared by
   anything, so it would need a new lifecycle owner; (iii)
   `state/scheduler-status.json` + the digest callout is already the durable channel.
   `alerts.jsonl`'s one real advantage — surviving the nightly digest rewrite — is
   closed by this WP's `dream.js` deliverable instead.
4. **Bootstrap-first, not bootout-first.** `launchctl bootstrap` fails on an
   already-loaded label, so without a teardown a hijacked record can never be
   replaced. But bootout-first destroys working entries: `unverified` is in the heal
   set, and on Windows any round-trip deviation on a healthy task produces
   `unverified`. Bootstrap-first is strictly better on every axis — `missing` costs
   one spawn and never reaches a destructive step, and teardown happens only after
   launchd itself proves the bootstrap blocked. It is also back-compatible with three
   existing assertions that bootout-first would have broken.
5. **Step 8b's existence check, and why it maps to `mismatched` rather than a sixth
   taxonomy member.** `verdict === 'match'` proves only that our launcher sits in the
   *launcher* position; the program the OS actually *starts* is `exec`. A
   `brew upgrade node && brew cleanup` deletes the version-pinned `process.execPath`
   the entry was registered with, leaving the plist correct, the loaded record
   correct, `args[1]` still our launcher and `launchctl print` still exiting 0 — while
   every fire dies in `posix_spawn` before a line of Wienerdog code runs. That is the
   incident with "node path" for "launcher path". It is graded `mismatched` and not a
   sixth member because ADR-0018's owner-signed amendment names exactly two new
   members; a deleted node binary is literally "a program outside this install", and
   the verdict is *definite* (the entry cannot fire) rather than unreached, which is
   what separates `mismatched` from `unverified`. If the owner reads that gloss more
   narrowly, the fix is an ADR amendment in its own pass, never an edit from a WP.
6. **`repairCatchup`'s notice discipline.** On a *successful* repair, only an observed
   `missing` returns the shipped `'restored the missing catch-up registration.'`
   string (byte-identical); observed `mismatched`/`unverified` return `{}`. Two
   independent reasons: the shipped string would state something false about a
   hijacked or unreadable entry, and `src/cli/adopt.js` turns **any** notice into a
   user-facing adoption failure — so without this rule, widening the heal set would
   make `wienerdog adopt` report failure on every healthy Windows install whose task
   round-trip deviates. Failure notices are unchanged for every member. `adopt.js` was
   deliberately not touched; the fix lives where the notice is produced.
7. **`repairCatchup` added to `module.exports`.** Structural, not an API promise:
   AC-9c / AC-12b / AC-12c are literally unwritable without it. Driving them through
   `repointSchedules` makes the per-job `ai.wienerdog.dream` bootstrap the *first*
   loader call, registers the catch-up entry twice, and does not forward `opts.run` at
   all. `package.json` declares `bin` only (no `main`, no `exports`), so nothing
   external is widened, and no behavior, signature or caller changed.
8. **Condition (c0) rule 4 — 4c's `path.win32.resolve()` normalization, bounded by
   4a's `assertSafeOverride`-mirroring component check.** A raw
   `captured === cmdQuotedToken(core)` comparison false-`indeterminate`s a healthy
   non-default `$WIENERDOG_HOME` (trailing separator, or forward slashes), giving a
   permanent `doctor` warn plus a `schtasks /create /f` on every `sync` that never
   converges — strictly worse than `main`'s shipping `windowsLoadedTaskMatches`.
   So 4c normalizes both sides with `path.win32.resolve`. But `resolve()` alone
   *over-accepts*: it maps `…\.wienerdog\child\..` and `…\.wienerdog\.\` onto the
   right directory and grades them `loaded`. **`…\.wienerdog\.\` is REJECTED even
   though it denotes the right directory**, because (c0)'s charter is "*exactly* the
   canonical env-binding set" and directory equivalence is not canonicality: every
   `windowsCmdArguments` call site passes `paths.core`, which is either an
   `assertSafeOverride`-validated override (rejects `.`/`..` components) or a
   `path.join` (collapses them), so our writer provably cannot emit that string. The
   justification is **"our writer cannot have emitted it", not "it cannot run"** — the
   vendored launcher anchors its core to its own on-disk location and overwrites
   `WIENERDOG_HOME`, so such a record *would* fire. 4a is written as a mirror of
   `src/core/paths.js`'s component scan (same split regex, same two tests); that file
   is not a deliverable and was not edited.
9. **Verification step 5c stays deleted, and the runtime guarantee replaces it.**
   Three successive forms of a per-line structural check on JavaScript source were all
   broken in both directions; a grep is not a parser and this repo has no parser. What
   replaces it is executable: Table C R1 keeps `WIENERDOG_TEST_NO_REAL_SCHEDULER` set
   for every test here (step 5b checks no test deletes it), so any call reaching
   `defaultLoader` hits `schedulerSpawn`'s throw before a scheduler process exists;
   `repairCatchup` throws outright, and `reloadMissing` swallows the throw into
   `failed`, which is why AC-5a and AC-9a additionally assert
   `{reloaded: ['dream'], failed: []}`. M20 is exactly the omitted-loader case and is
   red.
10. **`expect.identityArgv == null` instead of `=== null` in step 6.** The spec writes
    `=== null`. `probeAll`/`reloadMissing`/`repairCatchup` only ever produce an array
    or `null`, so the two are equivalent for every real caller — but a malformed
    caller passing `undefined` would make step 7 call `RUN(undefined)` and throw,
    breaking `defaultProbe`'s contracted never-throws property. Chose the loose check:
    identical behavior for `null`, fail-closed to `unknown` for `undefined`.
11. **`HEAL_SET` is a module-level const in BOTH `status.js` and `schedule.js`,
    not exported.** `status.js` and `schedule.js` require each other lazily to avoid a
    load-time cycle; exporting the set would either add an unspecified export or
    reintroduce that cycle. Two three-element literals is the simpler option.
12. **`identityExpectation()` helper in `status.js`.** `probeAll` and `reloadMissing`
    build the same expectation, so it is factored into one non-exported helper there;
    `repairCatchup` builds it inline exactly as the spec writes it, because reaching
    the helper would need a new export.
13. **The `nameList` helper for callout pluralization.** Whole-word selection only
    (`job|jobs`, `is|are`, `it|them`, `it is|they are`) — never per-character
    suffixes (the WP-068 broken-safety-message class). Templates F, U and M are joined
    with `\n\n` so Obsidian renders three callouts rather than merging three different
    remediations under F's title.

## Discovered issues (out of scope, not fixed)

1. **`docs/adr/0018-windows-scheduled-dreaming.md:297` says "`sync` remains the sole
   healer" — this is FALSE on `main`, before this WP.** `repairCatchup` is reachable
   from three attended callers: `src/cli/sync.js:222`, `src/cli/adopt.js:422`
   (`wienerdog adopt`'s existing-job rebind) and `src/cli/schedule.js:895`
   (`wienerdog schedule remove`'s catch-up teardown/rebind). Proposed follow-up slug:
   **`WP-adr-0018-healer-and-marker-precision`**. The ADR is owner-signed and
   deliberately not a deliverable — reported, not edited.
2. **ADR-0018 decision 2's "so a process killed mid-replacement leaves a pessimistic
   record rather than a stale `loaded` one" is unconditional over a best-effort
   writer.** `refreshSchedulerStatus` swallows every `mkdir`/`write`/`rename` error in
   a bare `catch {}` and returns `void`, so the marker is *attempted*, never known to
   have landed (hence `markerAttempted`, not `markerWritten`). The owner ruled on
   2026-07-26 that Reading B governs — the sentence mandates the *refresh*, not
   abandonment of the replacement when the refresh fails — so this is a wording
   imprecision for the amendment, not a blocker. Same proposed slug:
   **`WP-adr-0018-healer-and-marker-precision`**. Reported, not edited.
3. **`src/cli/run-job.js`'s `noticeIfCatchupMissing` (`:1043-1055`, called at `:984`)
   is a THIRD wrong-artifact check** — it decides catch-up health with
   `fs.accessSync(<plist path>)`, i.e. file existence, and would have printed nothing
   across all 76 fires of the incident. Named in the spec as Residual 4 and
   deliberately out of scope (best-effort stderr notice, non-durable, unattended, no
   exit code; `run-job.js` is large enough to push this WP over the file bound).
   Proposed slug: **`WP-catchup-notice-identity`**.
4. **`parseWindowsTaskExec` still pairs `<Command>` and `<Arguments>` independently**
   (`generators.js:622-631`), so on a multi-`<Exec>` document it mixes Exec₁'s command
   with Exec₂'s arguments. This WP fences the *health verdict* off from that with
   condition (0) rather than changing the parser (it also backs
   `windowsLoadedTaskMatches` at register time and is outside Deliverables), so the
   register-time path keeps the ambiguity. Proposed slug:
   **`WP-windows-task-exec-pairing`**.
5. **The execution position is authenticated for EXISTENCE only, and the entire
   launcher argument tail is not authenticated at all** (Residual 9). A record graded
   `loaded` may start any program that exists on disk, provided our launcher is its
   first argument, and may pass that launcher any arguments whatsoever — including a
   forged `--descriptor` or `--expect-digest`. Routed follow-ups:
   **`WP-scheduler-stable-exec-position`** (make the execution position comparable via
   a `<core>`-owned trampoline) and **`WP-scheduler-argument-tail-identity`** (the
   tail). Neither subsumes the other.
6. **`refreshSchedulerStatus` returns `void` and cannot report persistence**, so no
   caller can know whether the durable marker landed. Proposed slug:
   **`WP-scheduler-status-write-observable`**; it would also carry the ADR-0018
   precision amendment from items 1-2.

## Dogfooding lessons

- WP-scheduler-entry-identity: `--test-name-pattern` is a REGEX, and this WP's test
  names contain `[1]`, `(darwin)`, `(c0)` and `"…"`. An unescaped pattern silently
  selects zero subtests and the runner still exits 0 with "pass 1" (the file wrapper
  counts). Every mutation check must assert the pattern selected exactly ONE named
  line, not merely that the run failed.
- WP-scheduler-entry-identity: a mutation that introduces a SYNTAX error looks
  identical to a mutation that turns a test red, because both make the run non-zero —
  but it proves nothing. M2's first form left an unbalanced brace; the "selected
  exactly one `not ok` line for this exact name" check is what caught it. Prefer
  mutations that insert an early `return` above the original code over ones that wrap
  it in a block.
- WP-scheduler-entry-identity: `path.win32.join('C:\\x\\.\\', 'launcher', 'launch.js')`
  collapses the `.` component, so a fixture that passes the same non-canonical `core`
  to both the writer and `path.win32.join` produces a CANONICAL expectation and a
  NON-canonical bind — which is exactly the asymmetry rule 4a exists to catch. Assert
  that collapse in the test (`assert.equal(launcher, WIN_LAUNCHER)`) or the fixture
  silently stops testing what it claims.
- WP-scheduler-entry-identity: widening `defaultProbe`'s signature was safe for the
  whole existing suite only because every injected `opts.probe` ignores extra
  arguments. `probeAll` forwards `{ run: opts.run }` unconditionally, so the property
  is present-and-`undefined` on every production call — the seam test must be
  `typeof opts.run === 'function'`, never `'run' in opts`, or production takes the
  test path.
- WP-scheduler-entry-identity: building the (c0) expected-name list by reading
  `scheduledEnvPairs()` at runtime (names + which values are scrubbed to `''`) instead
  of retyping the eight names means the checker cannot drift from the writer. Same
  move as Table B1's `BARE` reusing `cmdArgToken`'s charset. When a spec says "cite,
  do not restate", a runtime read is usually available and is strictly better than a
  comment pointing at the source.
- WP-scheduler-entry-identity: the pre-destructive marker's `refreshSchedulerStatus`
  re-enters `probeAll` with the SAME `opts`, so a recording loader that reads
  `state/scheduler-status.json` at every call sees the file already written at call 1
  — but only if the injected `probe`/`run` seam is forwarded too. R4 ("a mandatory
  seam is forwarded, not just accepted") is what makes the marker assertion spawn-free;
  forgetting it would have driven a real `launchctl` under the marker.

---
Generated-by: claude-opus-5
