### PR TITLE
fix(secret-scan): two-tier entropy candidates and contextual severity (WP-secret-fence-two-tier-detector)

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -74,7 +74,13 @@ Canonical names. Use these exact terms in code, docs, specs, and prompts — nev
   persistence points in the dream lifecycle: transcript input, the brain's
   staged output, the durable log/alert/email path, and each digest section
   (ADR-0024). Returns sanitized text plus metadata-only findings (`{label,
-  severity, count}`) — a finding never stores the matched secret bytes. Two
+  severity, count}`) — a finding never stores the matched secret bytes. The
+  labelled format rules all emit `quarantine` severity. Behind them sits a
+  two-tier entropy pass: a long enough run drawn from the narrow alphabet, at
+  or above the entropy floor, is `redact` and needs no context at all; the same
+  run widened to include `/` is `quarantine` only when a sensitive keyword
+  binds to it through a separator on the same line. Both tiers write the same
+  `[REDACTED:high-entropy]` token. Two
   severities, `redact` and `quarantine`, but the *persistence* gates (staged
   output, digest section) withhold on **any** finding of either severity; the
   input and log/alert paths use `redactOnly` (inline redaction of every

--- a/docs/specs/WP-secret-fence-two-tier-detector.md
+++ b/docs/specs/WP-secret-fence-two-tier-detector.md
@@ -1,7 +1,7 @@
 ---
 id: WP-secret-fence-two-tier-detector
 title: Make the secret detector two-tier — a slash-tiered entropy alphabet, separator-bound context, and quarantine severity on every labelled rule
-status: Ready
+status: In-Review
 model: opus
 size: M
 depends_on: []

--- a/scripts/measure-secret-fp.js
+++ b/scripts/measure-secret-fp.js
@@ -10,12 +10,12 @@
  * the command line.
  *
  * IT PRINTS COUNTS, RULE LABELS AND STRUCTURAL DESCRIPTIONS ONLY — never a
- * matched run, never a line of vault prose, never a filename, and NEVER THE
- * VAULT PATH ITSELF. Its output is meant to be pasted into a PR body, so treat
- * every byte of it as public: the documented invocation writes `~/Obsidian/…`,
- * but the shell expands that to an absolute path carrying the developer's
- * username and the vault's location, so the report prints a fixed placeholder
- * instead of echoing the argument.
+ * matched run, never a line of vault prose, never a filename outside the
+ * vault-relative form, and NEVER THE VAULT PATH ITSELF. Its output is meant to
+ * be pasted into a PR body, so treat every byte of it as public: the documented
+ * invocation writes `~/Obsidian/…`, but the shell expands that to an absolute
+ * path carrying the developer's username and the vault's location, so the
+ * report prints a fixed placeholder instead of echoing the argument.
  *
  * The `today` column is the SHIPPED detector, REPRODUCED IN ITS OWN ORDER:
  * the labelled rules run FIRST and replace their matches, and only what
@@ -24,6 +24,14 @@
  * entropy hit as well, which corrupts M1's source breakdown and its occurrence
  * totals. The labelled half is observed through the shared module minus the one
  * label this WP ADDS (`basic-auth`); the entropy half is the lines below.
+ *
+ * THE EMULATION IS A PREVIOUS VERSION OF A PIPELINE, SO EVERY RULE THE CURRENT
+ * VERSION ADDS IS A SOURCE OF ERROR. It runs the module's CURRENT labelled
+ * stage, which includes `basic-auth` — a rule the shipped detector did not
+ * have. Where that rule matches, it consumes a body the shipped entropy pass
+ * would have been handed, and every M1 figure would be understated. This script
+ * therefore REFUSES TO EMIT any measurement on such a corpus rather than
+ * printing a caveat beside one: a number that is printed will be quoted.
  */
 'use strict';
 
@@ -138,7 +146,8 @@ function measure(vaultPath) {
   let proposedWithheld = 0;
   let proposedScrubbed = 0;
   let proposedUntouched = 0;
-  let addedLabelOccurrences = 0;
+  /** @type {string[]} vault-relative paths of notes the ADDED rule matched */
+  const addedLabelNotes = [];
 
   for (const file of notes) {
     const text = fs.readFileSync(file, 'utf8');
@@ -149,8 +158,8 @@ function measure(vaultPath) {
     const labelled = findings.filter(
       (f) => f.label !== 'high-entropy' && f.label !== ADDED_BY_THIS_WP,
     );
-    for (const f of findings) {
-      if (f.label === ADDED_BY_THIS_WP) addedLabelOccurrences += f.count;
+    if (findings.some((f) => f.label === ADDED_BY_THIS_WP)) {
+      addedLabelNotes.push(path.relative(vaultPath, file));
     }
     const runs = shippedEntropyRuns(afterLabelledRules(text));
     for (const run of runs) distinctRuns.add(run);
@@ -169,6 +178,34 @@ function measure(vaultPath) {
     if (findings.some((f) => f.severity === 'quarantine')) proposedWithheld += 1;
     else if (findings.length > 0) proposedScrubbed += 1;
     else proposedUntouched += 1;
+  }
+
+  // REFUSE TO EMIT, before a single figure is printed. `basic-auth` is a rule
+  // this WP ADDS; the shipped detector had none, so wherever it matched it
+  // consumed a body the shipped entropy pass would have been handed. Every M1
+  // figure below would be understated, and a warning beside a printed number
+  // does not make the number reproducible — it makes it quotable.
+  if (addedLabelNotes.length > 0) {
+    console.error('FAIL: the M1 baseline is NOT reproducible on this corpus.');
+    console.error('');
+    console.error(
+      `      The '${ADDED_BY_THIS_WP}' rule that this WP ADDS matched in ${addedLabelNotes.length} note(s).`,
+    );
+    console.error('      The shipped detector had no such rule, so it would have handed those');
+    console.error('      bodies to its entropy pass — but this emulation runs the module\'s');
+    console.error('      CURRENT labelled stage, which consumes them first. The note counts, the');
+    console.error('      source breakdown, the occurrence totals and the distinct-run count would');
+    console.error('      all be understated, so NOTHING is printed: there is no partial result to');
+    console.error('      quote.');
+    console.error('');
+    console.error('      Notes, vault-relative:');
+    for (const rel of addedLabelNotes) console.error(`        ${rel}`);
+    console.error('');
+    console.error('      Measuring THIS corpus needs a shipped-rule-only path: a labelled stage');
+    console.error('      built from the rules that pre-date this WP rather than from the module\'s');
+    console.error('      current one. That is deliberately NOT built here — it would be an');
+    console.error('      unpinned second copy of the rule list, checked by nothing.');
+    return 3;
   }
 
   const pct = notes.length ? ((100 * anyFindingToday) / notes.length).toFixed(1) : '0.0';
@@ -195,14 +232,6 @@ function measure(vaultPath) {
   console.log('Interim, with EP2 still keying on findings.length > 0 (this leg alone)');
   console.log(row('notes REVERTED by EP2, today', anyFindingToday));
   console.log(row('notes REVERTED by EP2, after this leg', proposedWithheld + proposedScrubbed));
-  if (addedLabelOccurrences > 0) {
-    console.log('');
-    console.log(
-      `NOTE: the '${ADDED_BY_THIS_WP}' rule this WP adds fired ${addedLabelOccurrences} time(s), so it`,
-    );
-    console.log("      consumed bodies the SHIPPED entropy pass would have seen. Today's");
-    console.log('      entropy figures above are understated by that much.');
-  }
   return 0;
 }
 

--- a/scripts/measure-secret-fp.js
+++ b/scripts/measure-secret-fp.js
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+/**
+ * Reproduce the secret-scanner false-positive measurements M1 and M5 of
+ * `docs/specs/WP-secret-fence-two-tier-detector.md` against a real vault.
+ *
+ *   node scripts/measure-secret-fp.js ~/Obsidian/<name>
+ *
+ * OPT-IN AND OFFLINE. It is not run by `npm test`, is not wired into any job,
+ * reads the vault and writes nothing. The vault path is developer-supplied on
+ * the command line.
+ *
+ * IT PRINTS COUNTS, RULE LABELS AND STRUCTURAL DESCRIPTIONS ONLY — never a
+ * matched run, never a line of vault prose, never a path outside the
+ * vault-relative form. Its output is meant to be pasted into a PR body, so
+ * treat every byte of it as public.
+ *
+ * The `today` column is the SHIPPED detector: the same labelled rules this WP
+ * keeps (it changes their severity only, which a "does it fire" count cannot
+ * see) plus a CONTEXT-FREE entropy pass over `[A-Za-z0-9+/=]{24,}` at the same
+ * floor. The labelled half is observed through the shared module minus the one
+ * label this WP ADDS (`basic-auth`); the entropy half is the twenty lines below.
+ */
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { scanAndRedact } = require('../src/core/secret-scan');
+
+const SKIP_DIRS = new Set(['.git', '.obsidian', '.trash']);
+const ADDED_BY_THIS_WP = 'basic-auth';
+
+// --- the shipped, context-free entropy pass ---------------------------------
+
+const SHIPPED_MIN_LEN = 24;
+const SHIPPED_MIN_BITS_PER_CHAR = 3.5;
+const SHIPPED_CANDIDATE = new RegExp(`[A-Za-z0-9+/=]{${SHIPPED_MIN_LEN},}`, 'g');
+
+/** @param {string} run @returns {number} Shannon entropy in bits per character */
+function bitsPerChar(run) {
+  const freq = new Map();
+  for (let i = 0; i < run.length; i += 1) {
+    const ch = run[i];
+    freq.set(ch, (freq.get(ch) || 0) + 1);
+  }
+  let bits = 0;
+  for (const n of freq.values()) {
+    const p = n / run.length;
+    bits -= p * Math.log2(p);
+  }
+  return bits;
+}
+
+/** The runs the SHIPPED detector would have replaced. @param {string} text @returns {string[]} */
+function shippedEntropyRuns(text) {
+  return (text.match(SHIPPED_CANDIDATE) || []).filter(
+    (run) => bitsPerChar(run) >= SHIPPED_MIN_BITS_PER_CHAR,
+  );
+}
+
+// --- corpus walk ------------------------------------------------------------
+
+/** @param {string} dir @param {string[]} acc @returns {string[]} absolute .md paths */
+function collectNotes(dir, acc = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (SKIP_DIRS.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) collectNotes(full, acc);
+    else if (entry.name.endsWith('.md')) acc.push(full);
+  }
+  return acc;
+}
+
+// --- report -----------------------------------------------------------------
+
+/** @param {string} label @param {number|string} value @returns {string} */
+function row(label, value) {
+  return `${label.padEnd(48)}${String(value).padStart(5)}`;
+}
+
+/** @param {string} vaultPath @returns {number} process exit code */
+function measure(vaultPath) {
+  const notes = collectNotes(vaultPath);
+
+  let anyFindingToday = 0;
+  let entropyOnly = 0;
+  let labelledOnly = 0;
+  let both = 0;
+  let entropyOccurrences = 0;
+  const distinctRuns = new Set();
+  /** @type {Map<string, number>} */
+  const labelledOccurrences = new Map();
+
+  let proposedWithheld = 0;
+  let proposedScrubbed = 0;
+  let proposedUntouched = 0;
+
+  for (const file of notes) {
+    const text = fs.readFileSync(file, 'utf8');
+    const { findings } = scanAndRedact(text);
+
+    // today
+    const labelled = findings.filter(
+      (f) => f.label !== 'high-entropy' && f.label !== ADDED_BY_THIS_WP,
+    );
+    const runs = shippedEntropyRuns(text);
+    for (const run of runs) distinctRuns.add(run);
+    entropyOccurrences += runs.length;
+    for (const f of labelled) {
+      labelledOccurrences.set(f.label, (labelledOccurrences.get(f.label) || 0) + f.count);
+    }
+    const hasEntropy = runs.length > 0;
+    const hasLabelled = labelled.length > 0;
+    if (hasEntropy || hasLabelled) anyFindingToday += 1;
+    if (hasEntropy && hasLabelled) both += 1;
+    else if (hasEntropy) entropyOnly += 1;
+    else if (hasLabelled) labelledOnly += 1;
+
+    // proposed
+    if (findings.some((f) => f.severity === 'quarantine')) proposedWithheld += 1;
+    else if (findings.length > 0) proposedScrubbed += 1;
+    else proposedUntouched += 1;
+  }
+
+  const pct = notes.length ? ((100 * anyFindingToday) / notes.length).toFixed(1) : '0.0';
+  const byRule = [`high-entropy ${entropyOccurrences} occurrences`]
+    .concat([...labelledOccurrences].sort().map(([l, n]) => `${l} ${n}`))
+    .join('  |  ');
+
+  console.log(`vault: ${vaultPath}`);
+  console.log('');
+  console.log('M1 — where the false positives come from (SHIPPED detector)');
+  console.log(row('notes scanned', notes.length));
+  console.log(`${row('notes with ANY finding (EP2 reverts today)', anyFindingToday)}   (${pct}%)`);
+  console.log(row('    high-entropy ONLY', entropyOnly));
+  console.log(row('    a labelled rule ONLY', labelledOnly));
+  console.log(row('    both', both));
+  console.log(`findings by rule:  ${byRule}`);
+  console.log(row('distinct high-entropy runs', distinctRuns.size));
+  console.log('');
+  console.log('M5 — the whole design, end to end (PROPOSED detector)');
+  console.log(row('notes WITHHELD (a quarantine finding)', proposedWithheld));
+  console.log(row('notes SCRUBBED in place (redact only)', proposedScrubbed));
+  console.log(row('notes untouched (no finding)', proposedUntouched));
+  console.log('');
+  console.log('Interim, with EP2 still keying on findings.length > 0 (this leg alone)');
+  console.log(row('notes REVERTED by EP2, today', anyFindingToday));
+  console.log(row('notes REVERTED by EP2, after this leg', proposedWithheld + proposedScrubbed));
+  return 0;
+}
+
+function main() {
+  const vaultPath = process.argv[2];
+  if (!vaultPath) {
+    console.error('usage: node scripts/measure-secret-fp.js <vault-path>');
+    return 2;
+  }
+  let stat;
+  try {
+    stat = fs.statSync(vaultPath);
+  } catch {
+    console.error(`not a readable path: ${vaultPath}`);
+    return 2;
+  }
+  if (!stat.isDirectory()) {
+    console.error(`not a directory: ${vaultPath}`);
+    return 2;
+  }
+  return measure(vaultPath);
+}
+
+process.exit(main());

--- a/scripts/measure-secret-fp.js
+++ b/scripts/measure-secret-fp.js
@@ -10,25 +10,32 @@
  * the command line.
  *
  * IT PRINTS COUNTS, RULE LABELS AND STRUCTURAL DESCRIPTIONS ONLY — never a
- * matched run, never a line of vault prose, never a path outside the
- * vault-relative form. Its output is meant to be pasted into a PR body, so
- * treat every byte of it as public.
+ * matched run, never a line of vault prose, never a filename, and NEVER THE
+ * VAULT PATH ITSELF. Its output is meant to be pasted into a PR body, so treat
+ * every byte of it as public: the documented invocation writes `~/Obsidian/…`,
+ * but the shell expands that to an absolute path carrying the developer's
+ * username and the vault's location, so the report prints a fixed placeholder
+ * instead of echoing the argument.
  *
- * The `today` column is the SHIPPED detector: the same labelled rules this WP
- * keeps (it changes their severity only, which a "does it fire" count cannot
- * see) plus a CONTEXT-FREE entropy pass over `[A-Za-z0-9+/=]{24,}` at the same
- * floor. The labelled half is observed through the shared module minus the one
- * label this WP ADDS (`basic-auth`); the entropy half is the twenty lines below.
+ * The `today` column is the SHIPPED detector, REPRODUCED IN ITS OWN ORDER:
+ * the labelled rules run FIRST and replace their matches, and only what
+ * survives reaches a CONTEXT-FREE entropy pass over `[A-Za-z0-9+/=]{24,}` at
+ * the same floor. Getting that order wrong counts a labelled credential as an
+ * entropy hit as well, which corrupts M1's source breakdown and its occurrence
+ * totals. The labelled half is observed through the shared module minus the one
+ * label this WP ADDS (`basic-auth`); the entropy half is the lines below.
  */
 'use strict';
 
 const fs = require('node:fs');
 const path = require('node:path');
 
-const { scanAndRedact } = require('../src/core/secret-scan');
+const { scanAndRedact, ScanLimits } = require('../src/core/secret-scan');
 
 const SKIP_DIRS = new Set(['.git', '.obsidian', '.trash']);
 const ADDED_BY_THIS_WP = 'basic-auth';
+// Never echo the argument: the documented invocation is a private absolute path.
+const VAULT_LABEL = '<the path given on the command line>';
 
 // --- the shipped, context-free entropy pass ---------------------------------
 
@@ -51,10 +58,47 @@ function bitsPerChar(run) {
   return bits;
 }
 
-/** The runs the SHIPPED detector would have replaced. @param {string} text @returns {string[]} */
-function shippedEntropyRuns(text) {
-  return (text.match(SHIPPED_CANDIDATE) || []).filter(
+/** The runs the SHIPPED entropy pass would have replaced, given the text AS THAT
+ *  PASS SEES IT — i.e. after the labelled rules have run.
+ *  @param {string} afterLabelled @returns {string[]} */
+function shippedEntropyRuns(afterLabelled) {
+  return (afterLabelled.match(SHIPPED_CANDIDATE) || []).filter(
     (run) => bitsPerChar(run) >= SHIPPED_MIN_BITS_PER_CHAR,
+  );
+}
+
+// --- the pipeline order -----------------------------------------------------
+
+// `scanAndRedact` runs the labelled rules first and the entropy pass second,
+// reading the entropy FLOOR from `ScanLimits` on every candidate. Putting the
+// floor out of reach therefore turns the entropy stage into a no-op and leaves
+// exactly the intermediate text the shipped entropy pass would have been handed:
+// labelled matches already replaced, nothing else touched. That is a use of the
+// module's own ordering rather than a second copy of eighteen rules — but it
+// depends on the floor being read at call time, so `assertEntropyIsSuppressible`
+// below proves it on a known-high-entropy probe and refuses to report if it ever
+// stops holding.
+
+/** @param {string} text @returns {string} the text after the labelled rules only */
+function afterLabelledRules(text) {
+  const floor = ScanLimits.ENTROPY_MIN_BITS_PER_CHAR;
+  ScanLimits.ENTROPY_MIN_BITS_PER_CHAR = Infinity;
+  try {
+    return scanAndRedact(text).text;
+  } finally {
+    ScanLimits.ENTROPY_MIN_BITS_PER_CHAR = floor;
+  }
+}
+
+/** @returns {boolean} true iff `afterLabelledRules` really suppresses the entropy stage */
+function assertEntropyIsSuppressible() {
+  const probe = 'blob q7PmXz4KvR9tWc2LbN8dYfGh end';
+  const suppressed = afterLabelledRules(probe);
+  const normal = scanAndRedact(probe);
+  return (
+    suppressed === probe &&
+    normal.findings.some((f) => f.label === 'high-entropy') &&
+    ScanLimits.ENTROPY_MIN_BITS_PER_CHAR === SHIPPED_MIN_BITS_PER_CHAR
   );
 }
 
@@ -94,16 +138,21 @@ function measure(vaultPath) {
   let proposedWithheld = 0;
   let proposedScrubbed = 0;
   let proposedUntouched = 0;
+  let addedLabelOccurrences = 0;
 
   for (const file of notes) {
     const text = fs.readFileSync(file, 'utf8');
     const { findings } = scanAndRedact(text);
 
-    // today
+    // today — the labelled rules run FIRST, and only what survives them reaches
+    // the shipped entropy pass.
     const labelled = findings.filter(
       (f) => f.label !== 'high-entropy' && f.label !== ADDED_BY_THIS_WP,
     );
-    const runs = shippedEntropyRuns(text);
+    for (const f of findings) {
+      if (f.label === ADDED_BY_THIS_WP) addedLabelOccurrences += f.count;
+    }
+    const runs = shippedEntropyRuns(afterLabelledRules(text));
     for (const run of runs) distinctRuns.add(run);
     entropyOccurrences += runs.length;
     for (const f of labelled) {
@@ -127,7 +176,7 @@ function measure(vaultPath) {
     .concat([...labelledOccurrences].sort().map(([l, n]) => `${l} ${n}`))
     .join('  |  ');
 
-  console.log(`vault: ${vaultPath}`);
+  console.log(`vault: ${VAULT_LABEL}`);
   console.log('');
   console.log('M1 — where the false positives come from (SHIPPED detector)');
   console.log(row('notes scanned', notes.length));
@@ -146,6 +195,14 @@ function measure(vaultPath) {
   console.log('Interim, with EP2 still keying on findings.length > 0 (this leg alone)');
   console.log(row('notes REVERTED by EP2, today', anyFindingToday));
   console.log(row('notes REVERTED by EP2, after this leg', proposedWithheld + proposedScrubbed));
+  if (addedLabelOccurrences > 0) {
+    console.log('');
+    console.log(
+      `NOTE: the '${ADDED_BY_THIS_WP}' rule this WP adds fired ${addedLabelOccurrences} time(s), so it`,
+    );
+    console.log("      consumed bodies the SHIPPED entropy pass would have seen. Today's");
+    console.log('      entropy figures above are understated by that much.');
+  }
   return 0;
 }
 
@@ -159,11 +216,21 @@ function main() {
   try {
     stat = fs.statSync(vaultPath);
   } catch {
-    console.error(`not a readable path: ${vaultPath}`);
+    console.error('not a readable path: the path given on the command line');
     return 2;
   }
   if (!stat.isDirectory()) {
-    console.error(`not a directory: ${vaultPath}`);
+    console.error('not a directory: the path given on the command line');
+    return 2;
+  }
+  if (!assertEntropyIsSuppressible()) {
+    console.error(
+      'the entropy stage can no longer be suppressed through ScanLimits, so the',
+    );
+    console.error(
+      "labelled rules cannot be isolated and today's figures would be wrong. Refusing",
+    );
+    console.error('to report. Reproduce the shipped pipeline another way; do not guess.');
     return 2;
   }
   return measure(vaultPath);

--- a/src/core/secret-scan.js
+++ b/src/core/secret-scan.js
@@ -22,6 +22,7 @@ const ScanLimits = {
   SCAN_MAX_BYTES: 256 * 1024, // a text longer than this is NOT regex-scanned
   ENTROPY_MIN_LEN: 24, // a contextual high-entropy candidate must be at least this long
   ENTROPY_MIN_BITS_PER_CHAR: 3.5, // Shannon bits/char over the candidate to count as high-entropy
+  ENTROPY_CTX_FILLER_MAX: 20, // chars a sensitive keyword may sit before the separator it binds through
 };
 
 /** @typedef {'redact'|'quarantine'} Severity
@@ -52,19 +53,10 @@ const SPECIFIC_KEY_LABELS = new Set([
   'access_token',
 ]);
 
-// AWS *secret* material has no safe partial redaction context → hard finding.
-const QUARANTINE_KEYS = new Set(['aws_secret_access_key', 'aws_session_token']);
-
 /** @param {string} key matched sensitive key @returns {string} finding label */
 function labelForKey(key) {
   const normalized = key.toLowerCase().replace(/-/g, '_');
   return SPECIFIC_KEY_LABELS.has(normalized) ? normalized : 'generic-secret';
-}
-
-/** @param {string} key matched sensitive key @returns {Severity} */
-function severityForKey(key) {
-  const normalized = key.toLowerCase().replace(/-/g, '_');
-  return QUARANTINE_KEYS.has(normalized) ? SEVERITY.QUARANTINE : SEVERITY.REDACT;
 }
 
 /**
@@ -93,22 +85,22 @@ const RULES = [
   ),
   // No leading \b anywhere below: a token glued to a preceding word character
   // must still match (the audit's explicit bypass case).
-  simpleRule(/sk-ant-[A-Za-z0-9\-_]{20,}/g, 'anthropic-key', SEVERITY.REDACT),
-  simpleRule(/sk-proj-[A-Za-z0-9_]{16,}/g, 'openai-key', SEVERITY.REDACT),
-  simpleRule(/sk-[A-Za-z0-9_]{20,}/g, 'openai-key', SEVERITY.REDACT),
-  simpleRule(/AKIA[0-9A-Z]{12,}/g, 'aws-key', SEVERITY.REDACT),
-  simpleRule(/gh[pousr]_[A-Za-z0-9]{36,}/g, 'github-token', SEVERITY.REDACT),
-  simpleRule(/xox[baprs]-[A-Za-z0-9-]{10,}/g, 'slack-token', SEVERITY.REDACT),
-  simpleRule(/ya29\.[A-Za-z0-9\-_]+/g, 'google-oauth', SEVERITY.REDACT),
+  simpleRule(/sk-ant-[A-Za-z0-9\-_]{20,}/g, 'anthropic-key', SEVERITY.QUARANTINE),
+  simpleRule(/sk-proj-[A-Za-z0-9_]{16,}/g, 'openai-key', SEVERITY.QUARANTINE),
+  simpleRule(/sk-[A-Za-z0-9_]{20,}/g, 'openai-key', SEVERITY.QUARANTINE),
+  simpleRule(/AKIA[0-9A-Z]{12,}/g, 'aws-key', SEVERITY.QUARANTINE),
+  simpleRule(/gh[pousr]_[A-Za-z0-9]{36,}/g, 'github-token', SEVERITY.QUARANTINE),
+  simpleRule(/xox[baprs]-[A-Za-z0-9-]{10,}/g, 'slack-token', SEVERITY.QUARANTINE),
+  simpleRule(/ya29\.[A-Za-z0-9\-_]+/g, 'google-oauth', SEVERITY.QUARANTINE),
   simpleRule(
     /eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}/g,
     'jwt',
-    SEVERITY.REDACT,
+    SEVERITY.QUARANTINE,
   ),
   // HTTP auth headers: "Authorization: Bearer <token>" (space-separated form)
   (text, add) =>
     text.replace(/\b(bearer)\s+[A-Za-z0-9_\-.~+/]{12,}=*/gi, (_m, kw) => {
-      add('bearer-token', SEVERITY.REDACT);
+      add('bearer-token', SEVERITY.QUARANTINE);
       return `${kw} [REDACTED:bearer-token]`;
     }),
   // Legacy sensitive key=value / key: value assignments (keeps key, redacts value)
@@ -116,11 +108,22 @@ const RULES = [
     text.replace(
       /\b(api[_-]?key|secret|token|password|passwd|bearer)(["']?\s*[:=]\s*["']?)[A-Za-z0-9_\-]{12,}/gi,
       (_m, key, sep) => {
-        add('generic-secret', SEVERITY.REDACT);
+        add('generic-secret', SEVERITY.QUARANTINE);
         return `${key}${sep}[REDACTED:generic-secret]`;
       },
     ),
   // --- A5 additive coverage (runs only on what the legacy pass left) ---
+  // Table A row A16: "Authorization: Basic <base64>" — the one published
+  // credential class the two-tier entropy pass would otherwise stop catching at
+  // all (the word `Basic` sits between the separator and the candidate, so no
+  // context binds, and a standard-base64 body fragments on its slashes). FIRST
+  // rule of the A5 additive block, so the legacy pipeline above stays
+  // byte-compatible for every input it already covered.
+  (text, add) =>
+    text.replace(/\b(authorization:[ \t]*basic)[ \t]+[A-Za-z0-9+/]{8,}={0,2}/gi, (_m, kw) => {
+      add('basic-auth', SEVERITY.QUARANTINE);
+      return `${kw} [REDACTED:basic-auth]`;
+    }),
   // Structured JSON string values under a sensitive key: "client_secret":"…"
   (text, add) =>
     text.replace(
@@ -128,7 +131,7 @@ const RULES = [
       (match, key, sep, value) => {
         if (value.includes('[REDACTED:')) return match; // already handled upstream
         const label = labelForKey(key);
-        add(label, severityForKey(key));
+        add(label, SEVERITY.QUARANTINE);
         return `"${key}"${sep}"[REDACTED:${label}]"`;
       },
     ),
@@ -139,20 +142,70 @@ const RULES = [
       new RegExp(`(${SENSITIVE_KEYS})(["']?\\s*[:=]\\s*["']?)[A-Za-z0-9_\\-./+=~]{12,}`, 'gi'),
       (_m, key, sep) => {
         const label = labelForKey(key);
-        add(label, severityForKey(key));
+        add(label, SEVERITY.QUARANTINE);
         return `${key}${sep}[REDACTED:${label}]`;
       },
     ),
   // New provider prefixes (after the key-context rules so a key-labelled
   // finding wins when both would match).
-  simpleRule(/GOCSPX-[A-Za-z0-9\-_]{16,}/g, 'google-client-secret', SEVERITY.REDACT),
-  simpleRule(/1\/\/0[A-Za-z0-9\-_=]{8,}/g, 'google-refresh-token', SEVERITY.REDACT),
-  simpleRule(/AIza[A-Za-z0-9\-_]{30,}/g, 'google-api-key', SEVERITY.REDACT),
+  simpleRule(/GOCSPX-[A-Za-z0-9\-_]{16,}/g, 'google-client-secret', SEVERITY.QUARANTINE),
+  simpleRule(/1\/\/0[A-Za-z0-9\-_=]{8,}/g, 'google-refresh-token', SEVERITY.QUARANTINE),
+  simpleRule(/AIza[A-Za-z0-9\-_]{30,}/g, 'google-api-key', SEVERITY.QUARANTINE),
   simpleRule(/(?:sk|rk)_live_[A-Za-z0-9]{10,}/g, 'stripe-secret-key', SEVERITY.QUARANTINE),
-  simpleRule(/pk_live_[A-Za-z0-9]{10,}/g, 'stripe-key', SEVERITY.REDACT),
+  simpleRule(/pk_live_[A-Za-z0-9]{10,}/g, 'stripe-key', SEVERITY.QUARANTINE),
 ];
 
-const ENTROPY_CANDIDATE = new RegExp(`[A-Za-z0-9+/=]{${ScanLimits.ENTROPY_MIN_LEN},}`, 'g');
+/** The ONE declaration of the entropy candidate alphabet. Tier 2 is Tier 1 plus
+ *  `/`; both regexes are DERIVED from these two constants and are never written
+ *  out by hand. `-` and `_` are absent from both, deliberately and as today. */
+const ENTROPY_CORE_CLASS = 'A-Za-z0-9+=';
+const ENTROPY_WIDE_EXTRA = '/';
+
+// Tier 1 (A2): a delimiter-free run. Tier 2 (A3): the same run allowed to span
+// `/`, i.e. exactly today's candidate. Both built from the two constants above.
+const TIER1_CANDIDATE = new RegExp(
+  `[${ENTROPY_CORE_CLASS}]{${ScanLimits.ENTROPY_MIN_LEN},}`,
+  'g',
+);
+const TIER2_CANDIDATE = new RegExp(
+  `[${ENTROPY_CORE_CLASS}${ENTROPY_WIDE_EXTRA}]{${ScanLimits.ENTROPY_MIN_LEN},}`,
+  'g',
+);
+
+/** The ONE declaration of the separator TOKEN set — Table A row A8a decides its
+ *  members; this line only spells them. Ordered LONGEST-FIRST as a DEFENSIVE
+ *  convention, not because the current predicate needs it: `hasBoundContext`'s
+ *  regex is END-ANCHORED, so when the one-character alternative matches the
+ *  first character of a two-character token the trailing `$` fails and the
+ *  engine backtracks into the longer form. The order becomes load-bearing the
+ *  moment the alternation is used anywhere the anchor does not force that
+ *  backtrack — a forward scan, a `g`/`y` match, or a `SEP` reused outside this
+ *  one predicate — so keep it. Do NOT reorder, and do NOT claim in review that
+ *  reordering is a fail-open bug; it is not. The vertical bar is deliberately
+ *  absent, and so are gitleaks' comma and logical-or members.
+ *  Written as a regex literal + `.source` rather than a quoted string so the
+ *  parser checks it and so it carries ONE backslash, not two.
+ *  Interpolated into `hasBoundContext`'s regex inside `(?: … )`, exactly once. */
+const SEP = /:{1,3}=|=>|\?=|[:=>]/.source;
+
+// A8: how far back the binder may look — the longest keyword (21 characters,
+// `aws_secret_access_key`), the filler bound, and 12 characters of slack for the
+// separator token, the two optional quote/backtick slots and the optional
+// whitespace on each side. DERIVED from ScanLimits and never a literal.
+const CTX_LOOKBACK_MAX = 21 + ScanLimits.ENTROPY_CTX_FILLER_MAX + 12;
+
+// A7/A8/A8a, spelled once: a sensitive keyword (the shipped SENSITIVE_KEYS
+// constant plus `authorization`, matched case-insensitively), then bounded
+// filler from gitleaks' own class, then at most one quote or backtick, optional
+// whitespace, exactly one separator token, optional whitespace, at most one
+// quote or backtick — and then the candidate, which the `$` anchor forces to
+// follow directly.
+const CTX_BINDER = new RegExp(
+  `(?:${SENSITIVE_KEYS}|authorization)` +
+    `[ \\t\\w.-]{0,${ScanLimits.ENTROPY_CTX_FILLER_MAX}}` +
+    `["'\`]?\\s*(?:${SEP})\\s*["'\`]?$`,
+  'i',
+);
 
 /** Shannon entropy in bits per character over the run. @param {string} run */
 function bitsPerChar(run) {
@@ -169,19 +222,46 @@ function bitsPerChar(run) {
   return bits;
 }
 
+/** True iff a sensitive keyword BINDS to the candidate starting at `idx`.
+ *  Implements Table A rows A7, A8 and A8a EXACTLY — that table decides the
+ *  keyword list, the filler bound and the separator set; this function does not
+ *  get to differ from it. Same line only: the search never crosses a `\n`.
+ *  @param {string} text @param {number} idx @returns {boolean} */
+function hasBoundContext(text, idx) {
+  const back = text.slice(Math.max(0, idx - CTX_LOOKBACK_MAX), idx);
+  const line = back.slice(back.lastIndexOf('\n') + 1);
+  return CTX_BINDER.test(line);
+}
+
 /**
- * Contextual high-entropy pass: a base64/hex run of >= ENTROPY_MIN_LEN chars
- * with >= ENTROPY_MIN_BITS_PER_CHAR that no labelled rule already replaced is
- * an unstructured secret candidate — no safe partial redaction, so QUARANTINE.
+ * Two-tier high-entropy pass (Table A rows A5, A6, A9).
+ *  - Tier 2 — a run over the wide alphabet, at or above the entropy floor, with
+ *    a sensitive keyword bound to it through a separator on the same line: no
+ *    safe partial redaction, so QUARANTINE, whole candidate replaced.
+ *  - Tier 1 — any sub-run of a non-quarantined tier-2 candidate that is long
+ *    enough and at or above the floor, over the NARROW alphabet: a bare pasted
+ *    key with no keyword near it, so the accidental case, replaced at REDACT.
+ * The tier-1 scan runs unconditionally on every non-quarantined candidate and
+ * is never gated on the tier-2 bits check: entropy is not monotone, so a
+ * low-entropy wide run can contain a high-entropy narrow sub-run.
  * @param {string} text
  * @param {(label:string, severity:Severity)=>void} add
  * @returns {string}
  */
 function entropyPass(text, add) {
-  return text.replace(ENTROPY_CANDIDATE, (run) => {
-    if (bitsPerChar(run) < ScanLimits.ENTROPY_MIN_BITS_PER_CHAR) return run;
-    add('high-entropy', SEVERITY.QUARANTINE);
-    return '[REDACTED:high-entropy]';
+  return text.replace(TIER2_CANDIDATE, (cand, offset) => {
+    if (
+      bitsPerChar(cand) >= ScanLimits.ENTROPY_MIN_BITS_PER_CHAR &&
+      hasBoundContext(text, offset)
+    ) {
+      add('high-entropy', SEVERITY.QUARANTINE);
+      return '[REDACTED:high-entropy]';
+    }
+    return cand.replace(TIER1_CANDIDATE, (sub) => {
+      if (bitsPerChar(sub) < ScanLimits.ENTROPY_MIN_BITS_PER_CHAR) return sub;
+      add('high-entropy', SEVERITY.REDACT);
+      return '[REDACTED:high-entropy]';
+    });
   });
 }
 
@@ -210,8 +290,11 @@ function scanAndRedact(text) {
     const findings = new Map();
     const add = (label, severity) => {
       const existing = findings.get(label);
-      if (existing) existing.count += 1;
-      else findings.set(label, { label, severity, count: 1 });
+      if (existing) {
+        existing.count += 1;
+        // A15: severity is the MAXIMUM over a label's occurrences, never the first.
+        if (severity === SEVERITY.QUARANTINE) existing.severity = SEVERITY.QUARANTINE;
+      } else findings.set(label, { label, severity, count: 1 });
     };
     let out = text;
     for (const rule of RULES) out = rule(out, add);

--- a/tests/fixtures/secret-corpus.js
+++ b/tests/fixtures/secret-corpus.js
@@ -1,0 +1,307 @@
+'use strict';
+
+/**
+ * Corpora for the secret-fence tests (WP-secret-fence-two-tier-detector).
+ *
+ * DATA AND PURE FUNCTIONS ONLY — no assertions live here. Every count is
+ * asserted against Table C3 row C3-0 by `tests/unit/secret-fence.test.js`, not
+ * hard-coded in this file.
+ *
+ *  - `CREDENTIALS` — Table C1: one generator per row of that table and no
+ *    others. Each is `(rng) => string` drawing from an EXPLICIT alphabet; there
+ *    are no literal sample tokens, because a single hand-written sample passes
+ *    while the rule behind it leaks double digits of real keys.
+ *  - `PROSE` — Table C2: one entry per row, in order, ids matching. Sanitized
+ *    reproductions of measured classes plus the separator and A8-clause
+ *    controls. No real credential and no verbatim sentence from any vault.
+ *  - `CONTEXTS` — the four wrappers Table C1 names.
+ *  - `caughtByShippedDetector` — the `today` column of the FN matrix.
+ */
+
+// --- the PRNG (Table C1, copy verbatim) -------------------------------------
+
+/** @param {number} seed @returns {() => number} */
+function makeRng(seed) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s + 0x9e3779b9) >>> 0;
+    let z = s;
+    z = Math.imul(z ^ (z >>> 16), 0x21f0aaad) >>> 0;
+    z = Math.imul(z ^ (z >>> 15), 0x735a2d97) >>> 0;
+    return ((z ^ (z >>> 15)) >>> 0) / 4294967296;
+  };
+}
+
+/** Table C1's seed. One fresh RNG instance per matrix cell. */
+const SEED = 0xc0ffee;
+
+// --- explicit alphabets -----------------------------------------------------
+
+const DIGIT = '0123456789';
+const LOWER = 'abcdefghijklmnopqrstuvwxyz';
+const UPPER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const ALNUM = UPPER + LOWER + DIGIT; // [A-Za-z0-9]
+const B64URL = ALNUM + '_-'; // [A-Za-z0-9_-]
+const B64STD = UPPER + LOWER + DIGIT + '+/'; // the 64-char standard-base64 alphabet
+const HEX = DIGIT + 'abcdef';
+const BASE32 = UPPER + '234567'; // [A-Z2-7]
+const UPPERNUM = UPPER + DIGIT; // [A-Z0-9]
+
+/** @param {() => number} rng @param {string} alphabet @param {number} n @returns {string} */
+function draw(rng, alphabet, n) {
+  let out = '';
+  for (let i = 0; i < n; i += 1) out += alphabet[Math.floor(rng() * alphabet.length)];
+  return out;
+}
+
+// --- Table C1 — the credential fixtures -------------------------------------
+
+/**
+ * @typedef {{id:string, slash:boolean, gen:(rng:()=>number)=>string}} Credential
+ * `slash` is Table C1's `/`? column: does the fixture's entropy-visible tail
+ * draw from an alphabet containing `/`? Only a `slash` fixture can regress.
+ */
+
+/** @type {Credential[]} */
+const CREDENTIALS = [
+  { id: 'anthropic-api-key', slash: false, gen: (r) => `sk-ant-api03-${draw(r, B64URL, 93)}AA` },
+  {
+    id: 'openai-legacy',
+    slash: false,
+    gen: (r) => `sk-${draw(r, ALNUM, 20)}T3BlbkFJ${draw(r, ALNUM, 20)}`,
+  },
+  {
+    id: 'openai-proj',
+    slash: false,
+    gen: (r) => `sk-proj-${draw(r, B64URL, 74)}T3BlbkFJ${draw(r, B64URL, 74)}`,
+  },
+  { id: 'github-pat', slash: false, gen: (r) => `ghp_${draw(r, ALNUM, 36)}` },
+  { id: 'github-oauth', slash: false, gen: (r) => `gho_${draw(r, ALNUM, 36)}` },
+  { id: 'github-fine-grained', slash: false, gen: (r) => `github_pat_${draw(r, B64URL, 82)}` },
+  { id: 'gitlab-pat', slash: false, gen: (r) => `glpat-${draw(r, B64URL, 20)}` },
+  { id: 'gitlab-oauth-secret', slash: false, gen: (r) => `gloas-${draw(r, B64URL, 64)}` },
+  {
+    id: 'slack-bot-token',
+    slash: false,
+    gen: (r) => `xoxb-${draw(r, DIGIT, 12)}-${draw(r, DIGIT, 12)}-${draw(r, ALNUM, 24)}`,
+  },
+  { id: 'aws-access-key-id', slash: false, gen: (r) => `AKIA${draw(r, BASE32, 16)}` },
+  { id: 'google-api-key', slash: false, gen: (r) => `AIza${draw(r, B64URL, 35)}` },
+  { id: 'google-oauth-ya29', slash: false, gen: (r) => `ya29.${draw(r, B64URL, 60)}` },
+  { id: 'google-client-secret', slash: false, gen: (r) => `GOCSPX-${draw(r, B64URL, 28)}` },
+  { id: 'google-refresh-token', slash: false, gen: (r) => `1//0${draw(r, B64URL, 60)}` },
+  { id: 'stripe-secret', slash: false, gen: (r) => `sk_live_${draw(r, ALNUM, 24)}` },
+  { id: 'sendgrid', slash: false, gen: (r) => `SG.${draw(r, B64URL, 66)}` },
+  { id: 'twilio-key-sid', slash: false, gen: (r) => `SK${draw(r, HEX, 32)}` },
+  { id: 'mailgun-private', slash: false, gen: (r) => `key-${draw(r, HEX, 32)}` },
+  { id: 'npm-token', slash: false, gen: (r) => `npm_${draw(r, ALNUM, 36)}` },
+  { id: 'pypi-token', slash: false, gen: (r) => `pypi-AgEIcHlwaS5vcmc${draw(r, B64URL, 60)}` },
+  { id: 'vault-service', slash: false, gen: (r) => `hvs.${draw(r, B64URL, 90)}` },
+  { id: 'atlassian', slash: false, gen: (r) => `ATATT3${draw(r, `${ALNUM}_=-`, 186)}` },
+  { id: 'databricks', slash: false, gen: (r) => `dapi${draw(r, HEX, 32)}` },
+  { id: 'doppler', slash: false, gen: (r) => `dp.pt.${draw(r, ALNUM, 43)}` },
+  { id: 'linear', slash: false, gen: (r) => `lin_api_${draw(r, ALNUM, 40)}` },
+  { id: 'postman', slash: false, gen: (r) => `PMAK-${draw(r, HEX, 24)}-${draw(r, HEX, 34)}` },
+  { id: 'shopify', slash: false, gen: (r) => `shpat_${draw(r, HEX, 32)}` },
+  { id: 'square', slash: false, gen: (r) => `EAAA${draw(r, B64URL, 56)}` },
+  {
+    id: 'telegram-bot',
+    slash: false,
+    gen: (r) => `${draw(r, DIGIT, 10)}:A${draw(r, B64URL, 34)}`,
+  },
+  {
+    id: 'jwt',
+    slash: false,
+    gen: (r) => `eyJ${draw(r, B64URL, 20)}.eyJ${draw(r, B64URL, 30)}.${draw(r, B64URL, 40)}`,
+  },
+  {
+    id: 'private-key-block',
+    slash: false,
+    gen: (r) =>
+      `-----BEGIN RSA PRIVATE KEY-----\n${draw(r, ALNUM, 60)}\n-----END RSA PRIVATE KEY-----`,
+  },
+  // The bold rows: an entropy-visible tail drawn from an alphabet with `/`.
+  { id: 'aws-secret-access-key', slash: true, gen: (r) => draw(r, B64STD, 40) },
+  { id: 'aws-secret-access-key-64', slash: true, gen: (r) => draw(r, B64STD, 64) },
+  {
+    id: 'authress-client-key',
+    slash: true,
+    gen: (r) =>
+      `sc_${draw(r, `${LOWER}${DIGIT}`, 12)}.${draw(r, `${LOWER}${DIGIT}`, 5)}` +
+      `.acc_${draw(r, `${LOWER}${DIGIT}-`, 16)}.${draw(r, `${LOWER}${DIGIT}+/_=-`, 30)}`,
+  },
+  { id: 'grafana-cloud-token', slash: true, gen: (r) => `glc_${draw(r, B64STD, 32)}` },
+  { id: 'kraken-access-token', slash: true, gen: (r) => draw(r, `${LOWER}${DIGIT}/=_+-`, 88) },
+  {
+    id: 'jwt-standard-base64',
+    slash: true,
+    gen: (r) => `eyJ${draw(r, B64STD, 20)}.eyJ${draw(r, B64STD, 30)}.${draw(r, B64STD, 40)}`,
+  },
+  {
+    id: 'slack-webhook-url',
+    slash: true,
+    gen: (r) =>
+      `https://hooks.slack.com/services/T${draw(r, UPPERNUM, 8)}` +
+      `/B${draw(r, UPPERNUM, 8)}/${draw(r, ALNUM, 24)}`,
+  },
+  {
+    id: 'authorization-basic',
+    slash: true,
+    gen: (r) => `Authorization: Basic ${draw(r, B64STD, 40)}`,
+  },
+];
+
+// --- the four contexts (Table C1) -------------------------------------------
+
+/** @type {{id:string, wrap:(t:string)=>string}[]} */
+const CONTEXTS = [
+  { id: 'bare', wrap: (t) => `blob ${t} end` },
+  { id: 'assign', wrap: (t) => `secret=${t}` },
+  { id: 'prose', wrap: (t) => `the key is ${t} ok` },
+  { id: 'table', wrap: (t) => `| token | ${t} | ok |` },
+];
+
+// --- Table C2 — the prose corpus --------------------------------------------
+
+// Rows 26, 27, 28 and 34 are markdown table rows ABOUT markdown table rows: the
+// vertical bars below are single unescaped characters, and row 34 carries two
+// adjacent ones. Rows 36, 41 and 44 carry real backtick/quote bytes — the quote
+// characters the rows exist to count. Row 38 carries one real newline.
+
+/** @typedef {{id:number, text:string}} ProseRow */
+
+/** @type {ProseRow[]} */
+const PROSE = [
+  { id: 1, text: 'see [[01-Projects/wienerdog/current-state]] for detail' },
+  { id: 2, text: 'the note lives at 02-Areas/second-brain/tooling-notes now' },
+  { id: 3, text: 'path /Users/example/Documents/Claude_Projects/thing here' },
+  { id: 4, text: 'binary /opt/homebrew/bin/example-cli --profile default' },
+  { id: 5, text: 'agent /Library/LaunchAgents/com.example.job.plist loaded' },
+  { id: 6, text: 'script koltsegvetes/analysis/scripts/fetch_sheet ran' },
+  { id: 7, text: 'config deployment/daemon/trading_daemon_configuration' },
+  { id: 8, text: 'release github.com/example/project/releases/tag/v0.9.1' },
+  { id: 9, text: 'docs docs/marketing/articles/hackernews-launch.md edited' },
+  { id: 10, text: 'ID-token signature verification (aud/iss/exp/verified/exact-domain) ok' },
+  { id: 11, text: 'the refresh_token path self-heals (damaged/missing/broken/ok)' },
+  {
+    id: 12,
+    text:
+      'the wienerdog Google-token (drive.readonly) is primary — ' +
+      'koltsegvetes/analysis/scripts/x',
+  },
+  { id: 13, text: 'a credential bug: PATH omits ~/.local/bin, not /opt/homebrew/bin/claude' },
+  { id: 14, text: 'Train 5 independent GradientBoostingClassifier models per horizon' },
+  { id: 15, text: 'call generateCodeVerifierAsync before the redirect' },
+  { id: 16, text: 'session 019f819d-6aea-7950-b28e-9f26b7718c08 resumed' },
+  { id: 17, text: 'json {"uuid":"b593bdb9-a85e-431b-b9fe-8f564994c09b","tokens":20685}' },
+  { id: 18, text: 'daily note 05-Daily/2026/07/2026-07-24-morning-review saved' },
+  { id: 19, text: 'env order is WIENERDOG_HOME+HOME+CLAUDE_CONFIG_DIR+CODEX_HOME' },
+  { id: 20, text: 'see Documentation=RepositoryConfiguration end' },
+  { id: 21, text: 'the constant ABCDEFGHABCDEFGHABCDEFGHABCDEFGH appears in prose' },
+  { id: 22, text: 'padding deadbeefdeadbeefdeadbeefdeadbeefdeadbeef end' },
+  { id: 23, text: '[REDACTED:aws_secret_access_key] [REDACTED:high-entropy]' },
+  { id: 24, text: 'source https://www.example.gov/releases/consumerpriceinflationukjuly2025' },
+  { id: 25, text: 'run id 7KpQm2XvR9tWcZbN4dYfGh3L logged' },
+  { id: 26, text: '| secret | Projects/example/wienerdog/current-state |' },
+  {
+    id: 27,
+    text:
+      '| `shasum -a 256 src/core/secret-scan.js` | ' +
+      '`be54813a2602a78822e939663ab31c3eff164261` |',
+  },
+  { id: 28, text: '| modify | src/core/secret-scan.js | one canonical alphabet declaration |' },
+  { id: 29, text: 'apiKey := "q7PmXz4KvR9tWc2LbN8dYfGhJ3xA5uEw"' },
+  { id: 30, text: "'secret_key' => 'Kf3nQ8xW2mZr7Ld5Vp1Ty9Bc4Hs6Jg0A'" },
+  { id: 31, text: 'API_TOKEN ?= Zx4Qm8LpR2vT7yNb5Wc1KdJ9Hs3Ag6Ue' },
+  {
+    id: 32,
+    text:
+      "const TOKEN_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+      "abcdefghijklmnopqrstuvwxyz0123456789+/='",
+  },
+  { id: 33, text: 'the session token, q7PmXz4KvR9tWc2LbN8dYfGh, expires on Friday' },
+  { id: 34, text: '| secret || be54813a2602a78822e939663ab31c3eff164261 |' },
+  { id: 35, text: 'the token rotation runbook lives here: Rt6Yh2Nk9Pw4Jm7Vx3Bq5Zd8' },
+  { id: 36, text: 'credential ("legacy"): `Projects/example/wienerdog/current-state`' },
+  {
+    id: 37,
+    text:
+      'the authorization runbook and its rotation checklist here: ' +
+      'Kb7Wm3Qx9Ld5Tz2Ph8Nr4Vg6',
+  },
+  {
+    id: 38,
+    text:
+      'rotate the authorization token before Friday:\n' +
+      'Projects/example/wienerdog/current-state is unaffected',
+  },
+  { id: 39, text: 'the authorization checklist: see Jd4Vn8Sc2Mq6Bx1Zt5Wf9Hk3 for detail' },
+  { id: 40, text: 'the authorization digest of the file == Kb7Wm3Qx9Ld5Tz2Ph8Nr4Vg6' },
+  { id: 41, text: 'the authorization value: `"Kb7Wm3Qx9Ld5Tz2Ph8Nr4Vg6"` documented' },
+  { id: 42, text: 'credential_path: Projects/example/wienerdog/current-state' },
+  { id: 43, text: 'token_id: 019f819d6aea7950b28e9f26b7718c08' },
+  { id: 44, text: 'the authorization quoted JSON sample `": Kb7Wm3Qx9Ld5Tz2Ph8Nr4Vg6' },
+];
+
+// --- the `today` column of the FN matrix (Table C3 row C3-7) -----------------
+
+// The shipped detector at `efd1489` = the same eighteen labelled rules this WP
+// keeps (it changes their SEVERITY only, which a catch RATE cannot see) plus a
+// CONTEXT-FREE entropy pass over `[A-Za-z0-9+/=]{24,}` at the same floor. The
+// labelled half is therefore observed through the shared module, minus the one
+// label this WP ADDS (`basic-auth`, Table A row A16); the entropy half is the
+// four lines below. Nothing here regenerates a baseline from a fixture corpus —
+// the numbers this reference reproduces are Table C3 row C3-3's transcribed
+// constants, which the test checks it against.
+
+const SHIPPED_ENTROPY_MIN_LEN = 24;
+const SHIPPED_ENTROPY_MIN_BITS_PER_CHAR = 3.5;
+const SHIPPED_CANDIDATE = new RegExp(
+  `[A-Za-z0-9+/=]{${SHIPPED_ENTROPY_MIN_LEN},}`,
+  'g',
+);
+
+/** Shannon entropy in bits per character over the run. @param {string} run @returns {number} */
+function bitsPerChar(run) {
+  const freq = new Map();
+  for (let i = 0; i < run.length; i += 1) {
+    const ch = run[i];
+    freq.set(ch, (freq.get(ch) || 0) + 1);
+  }
+  let bits = 0;
+  for (const n of freq.values()) {
+    const p = n / run.length;
+    bits -= p * Math.log2(p);
+  }
+  return bits;
+}
+
+/** True iff the SHIPPED context-free entropy pass fires on `text`.
+ *  @param {string} text @returns {boolean} */
+function shippedEntropyFires(text) {
+  const matches = String(text).match(SHIPPED_CANDIDATE) || [];
+  return matches.some((run) => bitsPerChar(run) >= SHIPPED_ENTROPY_MIN_BITS_PER_CHAR);
+}
+
+/** True iff the shipped detector produced ANY finding for `text`.
+ *  @param {import('../../src/core/secret-scan').Finding[]} proposedFindings
+ *         `scanAndRedact(text).findings` under THIS WP
+ *  @param {string} text
+ *  @returns {boolean} */
+function caughtByShippedDetector(proposedFindings, text) {
+  const labelled = proposedFindings.some(
+    (f) => f.label !== 'high-entropy' && f.label !== 'basic-auth',
+  );
+  return labelled || shippedEntropyFires(text);
+}
+
+module.exports = {
+  makeRng,
+  SEED,
+  CREDENTIALS,
+  CONTEXTS,
+  PROSE,
+  bitsPerChar,
+  shippedEntropyFires,
+  caughtByShippedDetector,
+};

--- a/tests/unit/secret-fence.test.js
+++ b/tests/unit/secret-fence.test.js
@@ -1,0 +1,408 @@
+'use strict';
+
+/**
+ * The secret fence — WP-secret-fence-two-tier-detector.
+ *
+ * Every number asserted below is decided in Table C3 of that spec and is
+ * transcribed here as a named constant; nothing is regenerated and nothing is
+ * restated from anywhere else. The `today` column of the FN matrix is Table C3
+ * row C3-7's transcribed baseline, observed through the fixture module's
+ * shipped-detector reference rather than through a checked-in oracle corpus.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const {
+  scanAndRedact,
+  redactOnly,
+  hasHardFinding,
+  SEVERITY,
+} = require('../../src/core/secret-scan');
+const {
+  makeRng,
+  SEED,
+  CREDENTIALS,
+  CONTEXTS,
+  PROSE,
+  caughtByShippedDetector,
+} = require('../fixtures/secret-corpus');
+
+const SOURCE_PATH = require.resolve('../../src/core/secret-scan');
+const SOURCE = fs.readFileSync(SOURCE_PATH, 'utf8');
+
+// --- Table C3, transcribed --------------------------------------------------
+
+/** C3-0 — corpus sizes. */
+const C3_0 = { fixtures: 39, proseRows: 44, contexts: 4, cells: 156 };
+
+/** C3-1 — tier membership over the 95 printable-ASCII characters (32–126),
+ *  ABSOLUTE. Both literals are hand-written here and are NOT derived from
+ *  `src/`, nor either one from the other. */
+const C3_1_PRINTABLE_FROM = 32;
+const C3_1_PRINTABLE_TO = 126;
+const C3_1_TIER1 = '+0123456789=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+const C3_1_TIER2 = '+/0123456789=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+
+/** C3-2 — the FN matrix draw count. */
+const C3_2_DRAWS = 2000;
+const C3_2_NON_REGRESSING_CELLS = 138;
+
+/** C3-3 — the permitted regressions, complete: 6 fixtures × 3 contexts.
+ *  `today` is C3-7's transcribed constant; `floor` is the CI gate on the
+ *  proposed rate and sits ~5 points below the 2026-07-26 measurement. */
+const C3_3_CONTEXTS = ['bare', 'prose', 'table'];
+const C3_3 = [
+  { id: 'aws-secret-access-key', today: 100, floor: 80 },
+  { id: 'aws-secret-access-key-64', today: 100, floor: 95 },
+  { id: 'authress-client-key', today: 38.1, floor: 18 },
+  { id: 'grafana-cloud-token', today: 100, floor: 72 },
+  { id: 'kraken-access-token', today: 91.3, floor: 68 },
+  { id: 'jwt-standard-base64', today: 100, floor: 92 },
+];
+
+/** C3-4 — the fixtures a LABELLED rule covers at 100% `quarantine` in all four
+ *  contexts. An equality on the id set. */
+const C3_4 = [
+  'anthropic-api-key',
+  'openai-legacy',
+  'github-pat',
+  'github-oauth',
+  'slack-bot-token',
+  'aws-access-key-id',
+  'google-api-key',
+  'google-oauth-ya29',
+  'google-client-secret',
+  'google-refresh-token',
+  'stripe-secret',
+  'jwt',
+  'private-key-block',
+  'authorization-basic',
+];
+
+/** C3-5 — the C2 rows that reach `quarantine`. An equality, not a ceiling. */
+const C3_5 = [29, 30, 31, 32, 42, 43];
+
+/** C3-6 — the C2 rows that land at `redact`. An equality, not an upper bound. */
+const C3_6 = [14, 15, 20, 24, 25, 27, 33, 34, 35, 37, 39, 40, 41, 44];
+
+/** C3-8 — `SEVERITY.REDACT` producers in the module, counted as OCCURRENCES. */
+const C3_8_REDACT_PRODUCERS = 1;
+
+// --- helpers ----------------------------------------------------------------
+
+/** @param {string} text @returns {'clean'|'redact'|'quarantine'} */
+function disposition(text) {
+  const { findings } = scanAndRedact(text);
+  if (findings.some((f) => f.severity === SEVERITY.QUARANTINE)) return 'quarantine';
+  return findings.length ? 'redact' : 'clean';
+}
+
+/** The C2 corpus partitioned by outcome, so a failure prints WHICH rows moved
+ *  rather than only that some did. @returns {{quarantine:number[], redact:number[], clean:number[]}} */
+function proseDispositions() {
+  const out = { quarantine: [], redact: [], clean: [] };
+  for (const row of PROSE) out[disposition(row.text)].push(row.id);
+  return out;
+}
+
+/** One FN-matrix cell. @param {object} fixture @param {object} context
+ *  @returns {{today:number, proposed:number, labelled:number}} percentages */
+function cell(fixture, context) {
+  const rng = makeRng(SEED);
+  let today = 0;
+  let proposed = 0;
+  let labelled = 0;
+  for (let i = 0; i < C3_2_DRAWS; i += 1) {
+    const text = context.wrap(fixture.gen(rng));
+    const { findings } = scanAndRedact(text);
+    if (findings.length) proposed += 1;
+    if (caughtByShippedDetector(findings, text)) today += 1;
+    if (findings.some((f) => f.label !== 'high-entropy' && f.severity === SEVERITY.QUARANTINE)) {
+      labelled += 1;
+    }
+  }
+  const pct = (n) => (100 * n) / C3_2_DRAWS;
+  return { today: pct(today), proposed: pct(proposed), labelled: pct(labelled) };
+}
+
+/** The whole matrix, computed once and shared by the C3-2/C3-3/C3-4 tests. */
+let MATRIX = null;
+/** @returns {Map<string, {today:number, proposed:number, labelled:number}>} */
+function matrix() {
+  if (MATRIX) return MATRIX;
+  MATRIX = new Map();
+  for (const fixture of CREDENTIALS) {
+    for (const context of CONTEXTS) {
+      MATRIX.set(`${fixture.id}/${context.id}`, cell(fixture, context));
+    }
+  }
+  return MATRIX;
+}
+
+// --- C3-0: the corpora are the size Table C decides -------------------------
+
+test('C3-0: corpus sizes, cell count and id shapes (AC-11)', () => {
+  assert.equal(CREDENTIALS.length, C3_0.fixtures);
+  assert.equal(PROSE.length, C3_0.proseRows);
+  assert.equal(CONTEXTS.length, C3_0.contexts);
+  assert.equal(CREDENTIALS.length * CONTEXTS.length, C3_0.cells);
+  // ids are unique, and C2's rows are in order, numbered 1..44
+  assert.equal(new Set(CREDENTIALS.map((f) => f.id)).size, C3_0.fixtures);
+  assert.deepEqual(
+    PROSE.map((r) => r.id),
+    Array.from({ length: C3_0.proseRows }, (_, i) => i + 1),
+  );
+});
+
+// --- A1/A2/A3 + C3-1: the two alphabets -------------------------------------
+
+test('AC-1: the entropy pass carries exactly two character-class literals (A1)', () => {
+  assert.equal(
+    (SOURCE.match(/^const ENTROPY_CORE_CLASS = 'A-Za-z0-9\+=';$/gm) || []).length,
+    1,
+  );
+  assert.equal((SOURCE.match(/^const ENTROPY_WIDE_EXTRA = '\/';$/gm) || []).length, 1);
+  assert.ok(
+    !SOURCE.includes('[A-Za-z0-9+/=]'),
+    "today's hand-written entropy alphabet literal is still in the module",
+  );
+});
+
+test('AC-2 / C3-1: tier membership is ABSOLUTE over printable ASCII, observed through scanAndRedact', () => {
+  // C3-1's probe. `authorization` carries the tier-2 half because it is the one
+  // A7 keyword that is NOT in SENSITIVE_KEYS, so no labelled rule consumes it.
+  const tier1 = [];
+  const tier2 = [];
+  for (let code = C3_1_PRINTABLE_FROM; code <= C3_1_PRINTABLE_TO; code += 1) {
+    const c = String.fromCharCode(code);
+    const run = `ABCDEFGHIJKL${c}MNOPQRSTUVWX`;
+    assert.equal(run.length, 25);
+
+    const wide = scanAndRedact(`authorization: ${run}`).findings;
+    const wideHit = wide.find((f) => f.label === 'high-entropy');
+    if (wideHit && wideHit.severity === SEVERITY.QUARANTINE) tier2.push(c);
+
+    const narrow = scanAndRedact(`blob ${run} end`).findings;
+    const narrowHit = narrow.find((f) => f.label === 'high-entropy');
+    if (narrowHit && narrowHit.severity === SEVERITY.REDACT) tier1.push(c);
+  }
+  // ABSOLUTE — against the hand-written literals, never against each other.
+  assert.equal(tier1.join(''), C3_1_TIER1);
+  assert.equal(tier2.join(''), C3_1_TIER2);
+  assert.equal(tier1.length, 64);
+  assert.equal(tier2.length, 65);
+  // The derived facts are asserted IN ADDITION, never instead.
+  const extra = tier2.filter((c) => !tier1.includes(c));
+  assert.deepEqual(extra, ['/']);
+  assert.deepEqual(
+    tier1.filter((c) => !tier2.includes(c)),
+    [],
+  );
+});
+
+// --- A5/A6: what each tier does ---------------------------------------------
+
+test('AC-3: a tier-2 candidate at the floor WITH bound context quarantines (A5)', () => {
+  // `authorization` is the carrier for the same reason C3-1's probe uses it:
+  // it is the one A7 keyword that is not in SENSITIVE_KEYS, so no labelled rule
+  // consumes the assignment before the entropy pass sees it.
+  const { text, findings } = scanAndRedact('authorization: Projects/example/wienerdog/current');
+  assert.ok(text.includes('[REDACTED:high-entropy]'), text);
+  const hit = findings.find((f) => f.label === 'high-entropy');
+  assert.ok(hit, JSON.stringify(findings));
+  assert.equal(hit.severity, SEVERITY.QUARANTINE);
+  assert.equal(hasHardFinding(findings), true);
+});
+
+test('AC-4: the same candidate WITHOUT bound context redacts its tier-1 sub-runs only (A6)', () => {
+  const bound = 'Projects/example/wienerdog/current';
+  const { findings } = scanAndRedact(`see ${bound} for detail`);
+  // path-shaped: no tier-1 sub-run reaches the floor, so nothing at all
+  assert.deepEqual(findings, []);
+
+  // a bare pasted key: no keyword anywhere, still scrubbed, at redact
+  const bare = scanAndRedact('blob q7PmXz4KvR9tWc2LbN8dYfGh end');
+  assert.ok(bare.text.includes('[REDACTED:high-entropy]'), bare.text);
+  const hit = bare.findings.find((f) => f.label === 'high-entropy');
+  assert.equal(hit.severity, SEVERITY.REDACT);
+  assert.equal(hasHardFinding(bare.findings), false);
+
+  // entropy is not monotone: a LOW-entropy wide run containing a high-entropy
+  // narrow sub-run still yields the redact finding.
+  const wide = `q7PmXz4KvR9tWc2LbN8dYfGh${'/'.repeat(120)}`;
+  const low = scanAndRedact(`blob ${wide} end`);
+  const lowHit = low.findings.find((f) => f.label === 'high-entropy');
+  assert.ok(lowHit, JSON.stringify(low.findings));
+  assert.equal(lowHit.severity, SEVERITY.REDACT);
+});
+
+// --- A10/A11/A13: severity of the labelled rules ----------------------------
+
+test('AC-5: every labelled rule emits quarantine; severityForKey and QUARANTINE_KEYS are gone (A10, A11)', () => {
+  assert.ok(!SOURCE.includes('severityForKey'), 'severityForKey still exists');
+  assert.ok(!SOURCE.includes('QUARANTINE_KEYS'), 'QUARANTINE_KEYS still exists');
+  const samples = [
+    ['-----BEGIN RSA PRIVATE KEY-----\nAAAA1234\n-----END RSA PRIVATE KEY-----', 'private-key'],
+    ['noise xsk-ant-0123456789abcdef0123 tail', 'anthropic-key'],
+    ['key sk-abcdefghijklmnopqrstuvwxyz123456 end', 'openai-key'],
+    ['id AKIAIOSFODNN7EXAMPLE end', 'aws-key'],
+    [`tok ghp_${'a1B2'.repeat(10)} end`, 'github-token'],
+    ['slack=xoxb-1234567890-abcdefghij end', 'slack-token'],
+    ['t ya29.a0AbCdEfGhIjKl end', 'google-oauth'],
+    ['jwt eyJhbGciOiJIUzI1.eyJzdWIiOiIxMjM0NTY3.SflKxwRJSMeKKF2QT4 end', 'jwt'],
+    ['Authorization: Bearer abcdefghijklmnop', 'bearer-token'],
+    ['password=hunter2secret1234567', 'generic-secret'],
+    ['{"client_secret":"abcdefghijklmnop"}', 'client_secret'],
+    ['REFRESH_TOKEN=1//0abcDEFghiJKLmno-_pqr', 'refresh_token'],
+    ['export CLIENT_SECRET=GOCSPX-abcd1234efgh5678ijkl', 'client_secret'],
+    ['saved 1//0gAbCdEfGhIjKlMnOpQrStUv to disk', 'google-refresh-token'],
+    ['k AIzaSyA1bC2dE3fG4hI5jK6lM7nO8pQ9rS0tUvW end', 'google-api-key'],
+    ['s sk_live_a1b2c3d4e5f6g7h8 end', 'stripe-secret-key'],
+    ['p pk_live_a1b2c3d4e5f6g7h8 end', 'stripe-key'],
+    ['Authorization: Basic YWxhZGRpbjpvcGVuc2VzYW1l', 'basic-auth'],
+  ];
+  for (const [input, label] of samples) {
+    const { findings } = scanAndRedact(input);
+    const hit = findings.find((f) => f.label === label);
+    assert.ok(hit, `no '${label}' finding for ${JSON.stringify(input)}: ${JSON.stringify(findings)}`);
+    assert.equal(hit.severity, SEVERITY.QUARANTINE, `${label} is not quarantine`);
+  }
+});
+
+test('AC-6 / C3-8: exactly one SEVERITY.REDACT producer in the module (A13)', () => {
+  const occurrences = SOURCE.split('SEVERITY.REDACT').length - 1;
+  assert.equal(occurrences, C3_8_REDACT_PRODUCERS);
+});
+
+// --- A16: the nineteenth labelled rule --------------------------------------
+
+test('AC-21: the basic-auth rule (A16) behaves exactly as Table A says', () => {
+  const body = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY';
+  for (const id of ['bare', 'prose', 'table']) {
+    const context = CONTEXTS.find((c) => c.id === id);
+    const input = context.wrap(`Authorization: Basic ${body}`);
+    const { text, findings } = scanAndRedact(input);
+    assert.deepEqual(
+      findings.map((f) => [f.label, f.severity]),
+      [['basic-auth', SEVERITY.QUARANTINE]],
+      `${id}: ${JSON.stringify(findings)}`,
+    );
+    assert.ok(text.includes('Authorization: Basic [REDACTED:basic-auth]'), text);
+    assert.ok(!text.includes(body), text);
+  }
+
+  // assign: the shipped legacy assignment rule runs FIRST and consumes
+  // `secret=Authorization`, so basic-auth never sees the input. Assert the
+  // quarantine finding's LABEL and severity, never the array length — a tier-1
+  // redact on the residual body MAY accompany it, depending on the body.
+  const assign = scanAndRedact(`secret=Authorization: Basic ${body}`);
+  const hard = assign.findings.filter((f) => f.severity === SEVERITY.QUARANTINE);
+  assert.deepEqual(hard.map((f) => f.label), ['generic-secret'], JSON.stringify(assign.findings));
+
+  // Bearer is unaffected and never becomes basic-auth.
+  const bearer = scanAndRedact(`Authorization: Bearer ${body}`);
+  assert.ok(bearer.findings.some((f) => f.label === 'bearer-token'), JSON.stringify(bearer.findings));
+  assert.ok(!bearer.findings.some((f) => f.label === 'basic-auth'), JSON.stringify(bearer.findings));
+
+  assert.ok(C3_4.includes('authorization-basic'));
+});
+
+// --- C3-2 / C3-3: the FN regression matrix ----------------------------------
+
+test('AC-11 / C3-2 / C3-3: the FN matrix regresses on exactly C3-3\'s cells, each above its floor', () => {
+  const m = matrix();
+  assert.equal(m.size, C3_0.cells);
+
+  const regressing = [];
+  for (const [key, rates] of m) {
+    if (rates.proposed < rates.today) regressing.push(key);
+  }
+  const expected = [];
+  for (const row of C3_3) for (const ctx of C3_3_CONTEXTS) expected.push(`${row.id}/${ctx}`);
+  assert.deepEqual(regressing.slice().sort(), expected.slice().sort());
+  assert.equal(m.size - regressing.length, C3_2_NON_REGRESSING_CELLS);
+
+  // never `assign`, and only fixtures whose entropy-visible tail carries `/`
+  for (const key of regressing) {
+    const [id, ctx] = key.split('/');
+    assert.notEqual(ctx, 'assign');
+    assert.equal(CREDENTIALS.find((f) => f.id === id).slash, true);
+  }
+
+  // C3-3's set is derived from exactly the C1 intersection its cell names
+  const derived = CREDENTIALS.filter(
+    (f) => f.slash && f.id !== 'slack-webhook-url' && f.id !== 'authorization-basic',
+  ).map((f) => f.id);
+  assert.deepEqual(derived.slice().sort(), C3_3.map((r) => r.id).slice().sort());
+
+  // the transcribed `today` column reproduces, and every proposed rate clears
+  // its C3-3 floor
+  for (const row of C3_3) {
+    for (const ctx of C3_3_CONTEXTS) {
+      const rates = m.get(`${row.id}/${ctx}`);
+      // C3-3 states `today` to one decimal place, so the transcribed constant
+      // is compared at that resolution rather than bit-for-bit.
+      assert.ok(
+        Math.abs(rates.today - row.today) < 0.1,
+        `${row.id}/${ctx}: today measures ${rates.today}%, C3-3 transcribes ${row.today}%`,
+      );
+      assert.ok(
+        rates.proposed >= row.floor,
+        `${row.id}/${ctx}: proposed ${rates.proposed}% is below the C3-3 floor ${row.floor}%`,
+      );
+    }
+  }
+});
+
+test('AC-12 / C3-4: the labelled-rule fixture set is exactly C3-4\'s id set', () => {
+  const m = matrix();
+  const covered = CREDENTIALS.filter((f) =>
+    CONTEXTS.every((c) => m.get(`${f.id}/${c.id}`).labelled === 100),
+  ).map((f) => f.id);
+  assert.deepEqual(covered.slice().sort(), C3_4.slice().sort());
+});
+
+// --- C3-5 / C3-6: the false-positive corpus ---------------------------------
+
+test('AC-13 / C3-5 / C3-6: the C2 corpus lands on exactly the id sets Table C3 decides', () => {
+  const got = proseDispositions();
+  const shown = JSON.stringify(got);
+  assert.deepEqual(got.quarantine, C3_5, `quarantine set moved — ${shown}`);
+  assert.deepEqual(got.redact, C3_6, `redact set moved — ${shown}`);
+  // rows 1–28 are the destructive-outcome promise: none of them may withhold
+  for (const id of got.quarantine) assert.ok(id > 28, `C2 row ${id} withholds — ${shown}`);
+  // the partition is total
+  assert.equal(
+    got.quarantine.length + got.redact.length + got.clean.length,
+    C3_0.proseRows,
+  );
+});
+
+// --- A15 / C3-9: severity escalation ----------------------------------------
+
+test('AC-18 / C3-9: severity is the MAXIMUM over a label\'s occurrences, in BOTH line orders', () => {
+  const bound = 'authorization: wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY9c';
+  const bare = 'call generateCodeVerifierAsync before the redirect';
+  for (const input of [`${bound}\n${bare}\n`, `${bare}\n${bound}\n`]) {
+    const { findings } = scanAndRedact(input);
+    const hits = findings.filter((f) => f.label === 'high-entropy');
+    assert.equal(hits.length, 1, JSON.stringify(findings));
+    assert.equal(hits[0].severity, SEVERITY.QUARANTINE, JSON.stringify(findings));
+    assert.equal(hits[0].count, 2, JSON.stringify(findings));
+    assert.equal(hasHardFinding(findings), true);
+  }
+});
+
+// --- A14 / AC-17: the EP1/EP3/EP4 loosening is asserted, not assumed --------
+
+test('AC-17: redactOnly leaves a path-shaped run byte-unchanged and reports no finding (A14)', () => {
+  const prose = 'see Projects/wienerdog/current for detail';
+  assert.equal(redactOnly(prose), prose);
+  assert.equal(scanAndRedact(prose).findings.length, 0);
+  // and the contract between the two helpers is unchanged
+  for (const input of [prose, 'password=hunter2secret1234567', '']) {
+    assert.equal(redactOnly(input), scanAndRedact(input).text);
+  }
+});

--- a/tests/unit/secret-scan.test.js
+++ b/tests/unit/secret-scan.test.js
@@ -36,7 +36,7 @@ test('scanAndRedact: uppercase CLIENT_SECRET assignment (worked example)', () =>
   assert.ok(!text.includes('GOCSPX-abcd1234'), text);
   const finding = findingByLabel(findings, 'client_secret') || findingByLabel(findings, 'generic-secret');
   assert.ok(finding, JSON.stringify(findings));
-  assert.equal(finding.severity, SEVERITY.REDACT);
+  assert.equal(finding.severity, SEVERITY.QUARANTINE);
   assert.equal(finding.count, 1);
 });
 
@@ -52,7 +52,7 @@ test('scanAndRedact: JSON refresh_token value (worked example)', () => {
   assert.ok(text.includes('refresh_token'), text);
   const finding = findingByLabel(findings, 'refresh_token');
   assert.ok(finding, JSON.stringify(findings));
-  assert.equal(finding.severity, SEVERITY.REDACT);
+  assert.equal(finding.severity, SEVERITY.QUARANTINE);
 });
 
 test('scanAndRedact: PEM private key is redacted AND quarantine-flagged (worked example)', () => {
@@ -84,7 +84,7 @@ test('scanAndRedact: oversized input is withheld, not scanned (worked example)',
 test('corpus: uppercase REFRESH_TOKEN assignment', () => {
   const { text } = assertRedacted(
     'REFRESH_TOKEN=1//0abcDEFghiJKLmno-_pqr', '1//0abcDEFghiJKLmno-_pqr',
-    'refresh_token', SEVERITY.REDACT,
+    'refresh_token', SEVERITY.QUARANTINE,
   );
   assert.ok(text.includes('REFRESH_TOKEN='), text);
 });
@@ -92,7 +92,7 @@ test('corpus: uppercase REFRESH_TOKEN assignment', () => {
 test('corpus: Google refresh-token variant standalone (1//0…)', () => {
   assertRedacted(
     'saved 1//0gAbCdEfGhIjKlMnOpQrStUv to disk', '1//0gAbCdEfGhIjKlMnOpQrStUv',
-    'google-refresh-token', SEVERITY.REDACT,
+    'google-refresh-token', SEVERITY.QUARANTINE,
   );
 });
 
@@ -109,18 +109,18 @@ test('corpus: Google OAuth access token and API key', () => {
   assertRedacted('t ya29.a0AbCdEfGhIjKl end', 'ya29.a0AbCdEfGhIjKl', 'google-oauth');
   assertRedacted(
     'k AIzaSyA1bC2dE3fG4hI5jK6lM7nO8pQ9rS0tUvW end', 'AIzaSyA1bC2dE3fG4hI5jK6lM7nO8pQ9rS0tUvW',
-    'google-api-key', SEVERITY.REDACT,
+    'google-api-key', SEVERITY.QUARANTINE,
   );
 });
 
 test('corpus: Stripe live keys — secret forms quarantine, publishable redacts', () => {
   assertRedacted('s sk_live_a1b2c3d4e5f6g7h8 end', 'sk_live_a1b2c3d4e5f6g7h8', 'stripe-secret-key', SEVERITY.QUARANTINE);
   assertRedacted('r rk_live_a1b2c3d4e5f6g7h8 end', 'rk_live_a1b2c3d4e5f6g7h8', 'stripe-secret-key', SEVERITY.QUARANTINE);
-  assertRedacted('p pk_live_a1b2c3d4e5f6g7h8 end', 'pk_live_a1b2c3d4e5f6g7h8', 'stripe-key', SEVERITY.REDACT);
+  assertRedacted('p pk_live_a1b2c3d4e5f6g7h8 end', 'pk_live_a1b2c3d4e5f6g7h8', 'stripe-key', SEVERITY.QUARANTINE);
 });
 
 test('corpus: AWS key id redacts, AWS secret assignment quarantines', () => {
-  assertRedacted('id AKIAIOSFODNN7EXAMPLE end', 'AKIAIOSFODNN7EXAMPLE', 'aws-key', SEVERITY.REDACT);
+  assertRedacted('id AKIAIOSFODNN7EXAMPLE end', 'AKIAIOSFODNN7EXAMPLE', 'aws-key', SEVERITY.QUARANTINE);
   const { text } = assertRedacted(
     'aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
     'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
@@ -137,7 +137,7 @@ test('corpus: AWS key id redacts, AWS secret assignment quarantines', () => {
 test('corpus: JSON string value under a sensitive key', () => {
   const { text } = assertRedacted(
     '{"token": "abcd efgh ijkl mnop qrst"}', 'abcd efgh ijkl mnop qrst',
-    'generic-secret', SEVERITY.REDACT,
+    'generic-secret', SEVERITY.QUARANTINE,
   );
   assert.ok(text.includes('"token"'), text);
 });
@@ -150,7 +150,7 @@ test('corpus: quoted assignment values', () => {
 test('corpus: values containing / + =', () => {
   assertRedacted(
     'client_secret=abc/def+ghi=jkl.mno~pqr', 'abc/def+ghi=jkl.mno~pqr',
-    'client_secret', SEVERITY.REDACT,
+    'client_secret', SEVERITY.QUARANTINE,
   );
 });
 
@@ -171,7 +171,7 @@ test('corpus: two matches of the same label aggregate count', () => {
 
 // --- high-entropy contextual detection ---
 
-test('entropy: an unlabelled high-entropy base64 run is quarantined', () => {
+test('entropy: an unlabelled high-entropy base64 run is redacted', () => {
   const blob = 'q7PmXz4KvR9tWc2LbN8dYfGh'; // 24 chars, all distinct → ~4.58 bits/char
   assert.equal(blob.length, ScanLimits.ENTROPY_MIN_LEN);
   const { text, findings } = scanAndRedact(`blob ${blob} end`);
@@ -179,8 +179,8 @@ test('entropy: an unlabelled high-entropy base64 run is quarantined', () => {
   assert.ok(text.includes('[REDACTED:high-entropy]'), text);
   const finding = findingByLabel(findings, 'high-entropy');
   assert.ok(finding, JSON.stringify(findings));
-  assert.equal(finding.severity, SEVERITY.QUARANTINE);
-  assert.equal(hasHardFinding(findings), true);
+  assert.equal(finding.severity, SEVERITY.REDACT);
+  assert.equal(hasHardFinding(findings), false);
 });
 
 test('entropy: long low-entropy runs are NOT flagged', () => {


### PR DESCRIPTION
Spec: docs/specs/WP-secret-fence-two-tier-detector.md

**Interim behaviour, in the user's terms:** the detector is now two-tier, EP2 is
unchanged, and notes with a remaining finding are still reverted rather than
redacted.

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

Changed set, exactly the six Deliverables rows:

```
docs/GLOSSARY.md                                 (modify)
docs/specs/WP-secret-fence-two-tier-detector.md  (status: flip, always exempt)
scripts/measure-secret-fp.js                     (create)
src/core/secret-scan.js                          (modify)
tests/fixtures/secret-corpus.js                  (create)
tests/unit/secret-fence.test.js                  (create)
tests/unit/secret-scan.test.js                   (modify)
```

## Verification output

**Re-run in full at `76ccb33`, after the two P2 findings from the Codex gate leg
and the one residual from its delta review were fixed.** Everything below is from
that re-run.

The whole `## Verification steps` block was extracted from the spec and run as a
single script (`set -euo pipefail`, exit status carries the verdict).

```
$ bash verify.sh   # V-1 V-2 V-2b V-2c V-2d V-2e V-3 V-6 V-7 V-8 V-10 V-12 V-14 V-15 V-18 V-19 V-21 V-29 V-32 V-33
EXIT=0
```

Everything below is excerpted from that one run.

**V-1 — full suite through `tests/run.js`**

```
ℹ tests 1751
ℹ pass 1746
ℹ fail 0
ℹ skipped 5
```

**V-6 — the fence suite (FN matrix, FP ceiling, escalation)**

```
ℹ tests 13
ℹ pass 13
ℹ fail 0
```

**V-8 — the detector's own unit tests**

```
ℹ tests 29
ℹ pass 29
ℹ fail 0
```

**V-2 / V-2b / V-2c / V-2d / V-3 / V-12 — structural pins (silent on success)**

```
grep -c "^const ENTROPY_CORE_CLASS = 'A-Za-z0-9+=';$"        -> 1
grep -c "^const ENTROPY_WIDE_EXTRA = '/';$"                   -> 1
grep -cF '[A-Za-z0-9+/=]'                                     -> 0   (must_not, ok)
grep -o 'SEVERITY\.REDACT' | wc -l                            -> 1   (A13/C3-8)
grep -q 'existing.severity = SEVERITY.QUARANTINE'             -> ok  (A15)
grep -q "add('basic-auth', SEVERITY.QUARANTINE)"              -> ok  (A16)
grep -q 'severityForKey\|QUARANTINE_KEYS'                     -> absent (must_not, ok — A11)
grep -cxF 'const SEP = /:{1,3}=|=>|\?=|[:=>]/.source;'        -> 1
grep -c ':{1,3}='                                             -> 1
```

**V-2e — the three whole-line pins, scoped to `hasBoundContext`, plus the M-52
negative probe** (all four pins at 1, `text.slice(` occurrences = 1, and the
probe copy's slice pin goes red as required).

**V-7 — M1/M5 reproduced on the maintainer's real vault**

Re-run at `76ccb33` with the shipped pipeline reproduced **in its own order**
(labelled rules first, entropy only on what survives), with the vault path no
longer echoed, and with the emulation refusing to emit at all on a corpus it
cannot reproduce:

```
$ node scripts/measure-secret-fp.js ~/Obsidian/<name>
vault: <the path given on the command line>

M1 — where the false positives come from (SHIPPED detector)
notes scanned                                     188
notes with ANY finding (EP2 reverts today)        108   (57.4%)
    high-entropy ONLY                             107
    a labelled rule ONLY                            0
    both                                            1
findings by rule:  high-entropy 313 occurrences  |  aws-key 1
distinct high-entropy runs                        109

M5 — the whole design, end to end (PROPOSED detector)
notes WITHHELD (a quarantine finding)               1
notes SCRUBBED in place (redact only)               9
notes untouched (no finding)                      178

Interim, with EP2 still keying on findings.length > 0 (this leg alone)
notes REVERTED by EP2, today                      108
notes REVERTED by EP2, after this leg               10
```

**THE HEADLINE NUMBERS DID NOT MOVE.** 188 scanned / 108 with any finding today /
1 withheld / 9 scrubbed / 10 interim reverts are byte-identical to the pre-fix
run, and so is every line of the M1 breakdown. That is explained, not asserted:
this vault yields exactly **one** labelled finding in total — the documented
`AKIA…` placeholder, 20 characters, below the 24-character entropy floor — and it
does not overlap any entropy run, so re-ordering the two stages moves nothing
here.

**The fix is not vacuous, and that was measured rather than argued.** Codex's own
two examples both flip:

```
"api_key=q7PmXz4KvR9tWc2LbN8dYfGhJ3xA5uEw"
  labelled findings           : ["generic-secret"]
  entropy runs, RAW text (old): 1     <- counted as BOTH, and double-counted
  entropy runs, post-labelled : 0     <- correctly "a labelled rule ONLY"

"tok ghp_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6q7R8 end"
  labelled findings           : ["github-token"]
  entropy runs, RAW text (old): 1
  entropy runs, post-labelled : 0

"note AKIAIOSFODNN7EXAMPLE and a path Projects/example/wienerdog/current here"
  labelled findings           : ["aws-key"]
  entropy runs, RAW text (old): 1
  entropy runs, post-labelled : 1     <- a real "both": the run survives the rules
```

The third shape is the one this vault actually contains, which is why its single
"both" note stays a "both".

**How the ordering is reproduced, without a second copy of eighteen rules.**
`scanAndRedact` runs the labelled rules first and reads the entropy floor from
`ScanLimits` on every candidate, so putting the floor out of reach turns the
entropy stage into a no-op and returns exactly the intermediate text the shipped
entropy pass would have been handed. A startup probe asserts that property on a
known high-entropy string and **refuses to report** if it ever stops holding,
rather than silently reverting to the wrong order.

**And where the emulation CANNOT reproduce the shipped baseline, it refuses to
emit a number at all** (Codex delta-review residual, fixed in `76ccb33`). The
emulation runs the module's *current* labelled stage, which includes
`basic-auth` — a rule the shipped detector did not have. Wherever that rule
matches it consumes a body the shipped entropy pass would have been handed, so
every M1 figure would be understated; Codex's counterexample, a note containing
`Authorization: Basic <high-entropy>`, was previously reported as having *no
finding today*. The caveat line is gone and the branch is now a hard failure:

```
$ node scripts/measure-secret-fp.js <a corpus containing one such note>
FAIL: the M1 baseline is NOT reproducible on this corpus.

      The 'basic-auth' rule that this WP ADDS matched in 1 note(s).
      The shipped detector had no such rule, so it would have handed those
      bodies to its entropy pass — but this emulation runs the module's
      CURRENT labelled stage, which consumes them first. The note counts, the
      source breakdown, the occurrence totals and the distinct-run count would
      all be understated, so NOTHING is printed: there is no partial result to
      quote.

      Notes, vault-relative:
        sub/creds.md

      Measuring THIS corpus needs a shipped-rule-only path: a labelled stage
      built from the rules that pre-date this WP rather than from the module's
      current one. That is deliberately NOT built here — it would be an
      unpinned second copy of the rule list, checked by nothing.
EXIT=3
```

The check runs **before a single figure is printed**, so there is no partial
result to quote. On the maintainer's vault `basic-auth` fires zero times, which
is why V-7 above still emits normally and the figures are unchanged.

**Separately, this remains a re-measurement event, not a defect.** The vault is a
live corpus and has grown from the 182 notes M1 was measured against on
2026-07-26 to **188**. The *shape* of M5 reproduces exactly — 1 withheld, 9
scrubbed in place, and the derived interim revert count of 10 — while today's
baseline moved from 102 to 108 notes with the corpus. Per "The measurements this
design rests on", re-running V-7 and filing a dated errata amendment in ADR-0034
is the architect's act; nothing an implementer runs touches the vault and V-15 is
unaffected (it greps files on disk), which the green V-15 above confirms.

**V-10 — lint**

```
--- markdownlint ---
--- shellcheck ---
--- PSScriptAnalyzer ---
--- frontmatter check ---
frontmatter check passed: 202 spec(s), 4 agent(s)
lint passed
```

**V-14 — the interim contract.** `boundary-check.js` accepted the changed set
built from merge base → working tree plus untracked files; the leg-2 guard and
all three of its negative probes passed; `validate.js` still carries
`if (findings.length === 0) continue;` and still does not reference
`hasHardFinding`.

**V-15 / V-18 / V-21 / V-29 — digests**

```
M1_EXPECT, M5_EXPECT, E3_EXPECT, ER_EXPECT      match
SWEEP_EXPECT (residue sweep, both documents)    match
A8_EXPECT, M4E_EXPECT (V-29) + 3 negative probes match
V-18 threat-model digest                        match
V-21 Decisions digest + precedent digest        match
```

**V-19 / V-32 / V-33**

```
V-19: both glossary GATE sentences still occur exactly once; no
      'quarantine/redacted'; 'two-tier' present
V-33 ok: the shared check contracts match the cross-leg digest
V-32 ok: 128 ids defined across 27 schema-dispositioned tables (20
      corpus/measurement, registered by table) plus the acceptance-criterion,
      verification-step and accepted-residual families; 109 registered in the
      Checklist under H6's boundary form; 19 on the dated backlog and therefore
      NOT registered; 0 outside both.
```

**V-11 / Definition-of-done item 0** — ADR-0034 is in this checkout's history
(`7ef4c51`), `Status: Accepted`, carries the owner's `OWNER-SIGNED 2026-07-25`,
and no `OWNER-SIGNED` line exists in this spec. No owner line was written.

### Mutation checks — all 21 rows red, with the exact multi-row outcomes

Each row was applied to `src/`, its named command run, and the file restored.
**Rows that stayed green: 0.** The full C2 disposition delta per row, which is
what Table C3 rows C3-10 … C3-19 demand be *read* rather than inferred from an
exit code:

```
M-1       42: quarantine -> clean                            (C2 row 42 only)
M-2       1,3,4,5,6,7,8,9,10,11,12,13,26,36,38: clean -> redact   (row 2 does NOT move)
M-3       C3-6's whole id set: redact -> clean
M-4       1..13,26,36,38: clean -> quarantine; 14,15,20,24,25,27,33,34,35,37,39,40,41,44: redact -> quarantine
M-5       35: redact -> quarantine; 37: redact -> quarantine  (C3-12 — BOTH, nothing else)
M-6       no C2 row moves — AC-5/AC-6/AC-12 fail instead
M-13      36: clean -> quarantine                             (C3-13)
M-14      26: clean -> quarantine; 27: redact -> quarantine; 28 STAYS CLEAN   (C3-10)
M-15      no C2 row moves — AC-18 fails instead
M-34      20: redact -> clean
M-35      no C2 row moves — AC-21/AC-12/AC-11 fail instead
M-36      38: clean -> quarantine                             (C3-14)
M-37      39: redact -> quarantine                            (C3-15)
M-38      40: redact -> quarantine                            (C3-16)
M-39      41: redact -> quarantine; 44: redact -> quarantine  (C3-17 — BOTH slots)
M-44      44: redact -> quarantine, and row 41 does NOT move  (C3-19 — the pair discriminates)
M-40      29,30,31: quarantine -> redact                      (C3-11)
M-41      33: redact -> quarantine
M-42      29,31,32: quarantine -> redact; row 30 does NOT move (C3-5, case-insensitivity)
M-43      34: redact -> quarantine
M-52      no C2 row moves — V-2e's SLICE-SITE pin fails:
          "FAIL V-2e: the slice site does not occur EXACTLY ONCE"
M-52+M-5  35: redact -> quarantine, and row 37 does NOT       (C3-12's asymmetry:
          row 35 alone moving means the lookback is a literal — reproduced)
```

Representative failing output:

```
### M-5  (must fail: AC-13 via C3-12)
$ node tests/run.js tests/unit/secret-fence.test.js
exit status: 1
✖ AC-13 / C3-5 / C3-6: the C2 corpus lands on exactly the id sets Table C3 decides
  AssertionError: quarantine set moved — {"quarantine":[29,30,31,32,35,37,42,43], …}
ℹ tests 13  ℹ pass 12  ℹ fail 1

### M-44  (must fail: AC-13 via C3-19)
$ node tests/run.js tests/unit/secret-fence.test.js
exit status: 1
✖ AC-13 / C3-5 / C3-6: the C2 corpus lands on exactly the id sets Table C3 decides
  AssertionError: quarantine set moved — {"quarantine":[29,30,31,32,42,43,44], …}
ℹ tests 13  ℹ pass 12  ℹ fail 1

### M-6  (must fail: AC-5, AC-6, AC-12)
$ node tests/run.js tests/unit/secret-fence.test.js
exit status: 1
✖ AC-5: …  AssertionError: aws-key is not quarantine
✖ AC-6 / C3-8: …  AssertionError: 2 !== 1
✖ AC-12 / C3-4: the labelled-rule fixture set is exactly C3-4's id set
ℹ tests 13  ℹ pass 10  ℹ fail 3

### M-52  (must fail: V-2e's slice-site pin)
$ v2e
exit status: 1
FAIL V-2e: the slice site does not occur EXACTLY ONCE
```

### Measured acceptance numbers, reproduced

Every figure Table C decides reproduced on the first run, from the spec's own
PRNG and seed:

- **C3-4** — the labelled-covered set is exactly the 14 ids named, no more.
- **C3-3** — the regressing set is exactly the 6 fixtures × 3 contexts named,
  never `assign`; and the transcribed `today` column reproduces cell for cell
  (100 / 100 / 38.1 / 100 / 91.3 / 100). Proposed rates measured
  85.4 / 98.3 / 22.1 / 77.1 / 73.7 / 96.5 against floors 80 / 95 / 18 / 72 /
  68 / 92.
- **C3-2** — 138 of 156 cells non-regressing.
- **C3-5 / C3-6** — the C2 partition is `{29,30,31,32,42,43}` /
  `{14,15,20,24,25,27,33,34,35,37,39,40,41,44}`, exactly. No row in 1–28
  withholds.
- **C3-1** — tier 1 accepts exactly 64 printable-ASCII characters, tier 2
  exactly 65, differing only in `/`, both against hand-written literals.
- C1's `openai-proj` labelled rate measured 77.3%, as that row states.

## Decisions made

1. **The `today` column of the FN matrix is a small reference, not a second
   detector.** C3-7 forbids regenerating it from an oracle corpus, and Table C
   states `today` for six fixtures only, so a 156-cell comparison needed
   something. `caughtByShippedDetector` in the fixture module is the simpler
   option: it observes the labelled half through the shared module (minus
   `basic-auth`, the one label this WP adds — every other labelled rule is
   byte-identical to `efd1489`'s) and reimplements only the shipped
   *context-free* entropy pass, which is twenty lines. Its correctness is not
   assumed: the six transcribed `today` constants of C3-3 are asserted against
   it and all six reproduce.
2. **C3-3's `today` column is compared at the resolution Table C states it in**
   (`|measured − transcribed| < 0.1`), not bit-for-bit. `authress-client-key`
   measures 38.15% where C3-3 transcribes 38.1. The `proposed` side is gated on
   the C3-3 floors, as that row intends.
3. **The C2 fixture rows carry `{id, text}` only; the `Expect` column lives in
   the test as C3-5/C3-6's id sets.** Table C3 is the sole decider of those
   sets, so a third copy of each row's expected disposition in the fixture data
   would be a second decider. On failure the test prints the whole three-way
   partition, so "read which rows moved" is still possible — that output is
   what the mutation table above is built from.
4. **`scripts/measure-secret-fp.js` carries its own copy of the shipped
   context-free entropy pass rather than importing the test fixture.** A
   `scripts/` tool depending on `tests/fixtures/` is the more surprising
   coupling; both copies are self-contained and each is checked by its own
   caller.
4b. **The shipped pipeline's ORDER is reproduced through the module rather than
   by transcribing its eighteen labelled rules** (Codex P2 (1), fixed in
   `162bf49`). Suppressing the entropy floor via `ScanLimits` and calling
   `scanAndRedact` yields the post-labelled intermediate text exactly, in ~10
   lines instead of ~55, with no frozen second copy to drift. The cost is a
   dependency on the floor being read at call time, which is why the script
   proves that property at startup and refuses to report if it fails.
4c. **When `basic-auth` fires, the script REFUSES TO EMIT rather than isolating
   the shipped-only rules** (Codex delta-review residual, fixed in `76ccb33`).
   Codex named both options; this is the second. Isolating "only the shipped
   labelled rules" means reaching into the module's rule list and reproducing
   which rules pre-date this WP — exactly the unpinned second copy the
   wd-reviewer leg already flags about this file (`bitsPerChar` now exists in
   three places, and the script's copy is checked by nothing). Refusing is one
   branch, cannot drift, and is honest: the script's contract is "reproduce the
   SHIPPED pipeline's M1 baseline", and when a rule this WP adds consumes a
   candidate the shipped detector would have seen, it cannot do that — so it
   must not print a number. The alternative is named in the failure text, not
   built.
5. **The script prints no matched run at all**, not even the M2-style path
   fragments the security checklist permits as a maximum. Counts, rule labels
   and structural descriptions only, per the same checklist's first clause —
   **and, since `162bf49`, not the vault path either** (Codex P2 (2)): the
   report line and both error paths print a fixed placeholder rather than
   echoing an argument the shell has already expanded to an absolute path.
6. **AC-21's `assign` case asserts the quarantine finding's label and severity
   and does not assert the body is scrubbed.** With a fixed AWS-shaped body the
   residual `Basic <b64>` fragments below the tier-1 floor and yields no
   accompanying `redact` finding; AC-21 says such a finding "*may* accompany
   it", so asserting it would over-fit the criterion to one body.
7. **AC-3's worked example uses `authorization:` as the carrier**, for the same
   reason C3-1's probe does — `secret:` is consumed by the shipped extended
   assignment rule before the entropy pass sees the candidate.

## Accepted residual (measurement helper)

**Not a defect left unnoticed — a disposition taken knowingly.** Codex's third
pass on the refusal guard found it over-broad. The finding is correct and is
recorded verbatim:

> **[P2] Gate refusal on an entropy-qualifying Basic body —
> `scripts/measure-secret-fp.js:161-163`.** When a corpus contains a Basic body
> shorter than 24 characters or below the 3.5 entropy floor (for example,
> `Authorization: Basic AAAAAAAA`), `basic-auth` fires but the shipped entropy
> pass would not have reported that body, so the M1 figures remain reproducible.
> This unconditional label check nevertheless exits with status 3 and suppresses
> both reports; only treat a note as invalidating the baseline when the consumed
> body would satisfy the shipped candidate and entropy checks.

**Disposition: accepted residual, no code change.** Three reasons.

1. **It is OVER-refusal, i.e. the safe direction.** The guard can decline to
   print a measurement that would in fact have been valid; it can never print a
   wrong one. For a number whose whole purpose is to be quoted into a PR body
   and an ADR, "refused when it need not have" is a strictly better failure than
   "printed and understated".
2. **It fires zero times on the corpus this WP is measured against.** `basic-auth`
   matches no note in the maintainer's vault, so V-7 emits normally and every
   figure in this PR is unaffected.
3. **The precise fix is a fourth pass on a file whose every pass so far has drawn
   a new finding**, while the detector — the thing this WP actually ships — has
   been approved and untouched throughout. The cost/benefit does not favour
   another round on a developer-only, opt-in helper that is not run by `npm test`
   and is wired into no job.

**What would close it, so a future toucher inherits the fix rather than
re-deriving it:** gate the refusal on whether the body `basic-auth` consumed
would itself have satisfied the *shipped* candidate and entropy checks — i.e.
whether that body contains a `[A-Za-z0-9+/=]{24,}` run at or above 3.5 bits per
character. Only then is the M1 baseline genuinely unreproducible; otherwise the
shipped entropy pass would have reported nothing there either, and the report
should be emitted. The rule's capture group already isolates the header from the
body, so the check has everything it needs.

**Also open and deliberately not addressed on this branch:** the wd-reviewer
leg's finding 2 — `bitsPerChar` now exists in three copies (the detector, the
test fixture, and this script), and the script's copy is checked by nothing. It
belongs with whoever next touches this helper, and the leg-2 spec should pick it
up if V-7 ever acquires an assertion.

## Discovered issues (out of scope, not fixed)

1. **The vault has grown to 188 notes and M1's headline figures no longer
   reproduce.** See V-7 above. This is the re-measurement event the spec
   anticipates and assigns to the architect (re-run V-7, file a dated errata
   amendment inside ADR-0034, recompute `M1_EXPECT`/`SWEEP_EXPECT` in the same
   pass). Not touched here: `docs/adr/*` is outside the Deliverables table and
   V-15 is green.
2. **`scripts/lint.js` runs no JavaScript linter.** `npm run lint` is
   markdownlint + shellcheck + PSScriptAnalyzer + the frontmatter schema check;
   nothing checks `src/` or `tests/` JS style, so the conventions in CLAUDE.md
   for those files are held by review alone. Noted, not changed.
3. **`tests/run.js` forwards argv to `node --test` directly**, so
   `npm test -- <path>` works but there is no way to run one file *and* keep the
   scheduler guard without knowing that. The spec's implementation notes already
   warn about the bare-`node --test` trap; a wrapper flag would make the trap
   unreachable. Out of scope.

## Dogfooding lessons

- WP-secret-fence-two-tier-detector: `\s*` versus `[ \t]*` inside the
  context binder is not cosmetic — it decides whether mutation M-36 (deleting
  the same-line trim) is observable at all. With `[ \t]*` the binder cannot
  cross the newline on its own, M-36 becomes a silent no-op on C2 row 38, and
  AC-15 is violated by an implementation that looks *more* careful. The
  conservative-looking choice was the wrong one.
- WP-secret-fence-two-tier-detector: the spec's PRNG, seed and per-cell
  "one fresh RNG" rule are enough to reproduce a 156-cell measurement *exactly*
  — the labelled set, the regressing set and all six `today` constants landed
  on the first run. Pinning the generator rather than checking in sample tokens
  is what made that possible, and it is worth the extra fixture code.
- WP-secret-fence-two-tier-detector: `String.raw` and single-quoted JS
  literals are the only sane way to script mutations against a file full of
  template literals and regex sources. Two attempts at `sed`/`perl` one-liners
  produced silently non-applying mutations, which read as "the row stayed
  green" — i.e. as a spec bug. The runner now hashes the file before and after
  and reports "MUTATION DID NOT APPLY" separately from "GREEN".
- WP-secret-fence-two-tier-detector: measuring the C2 disposition *delta* per
  mutation, rather than only the exit status, is what turns C3-10 … C3-19 from
  prose into evidence. Several rows (M-5, M-39, M-44, M-42, M-52+M-5) are
  specified as exact multi-row outcomes where a weaker "some row moved" reading
  passes against a wrong implementation.
- WP-secret-fence-two-tier-detector: V-7 is the only step that reads a live
  corpus, so it is the only one that can go "red" for a reason that is not a
  defect. Reporting the drift explicitly (182 → 188 notes) beside the parts that
  *did* reproduce (M5's 1/9 split, the interim 10) is cheaper than either
  silently absorbing it or treating it as a blocker.
- WP-secret-fence-two-tier-detector: a measurement script whose output is
  designed to be pasted publicly must not echo an argument that is a private
  absolute path. The documented invocation writes `~/Obsidian/<name>`, which
  *reads* as anonymised — but the shell expands it before the script ever sees
  it, so `console.log(vaultPath)` published the developer's username and the
  vault's location into a public PR body. The intent lived in the docs and the
  leak lived in the code. Print a fixed placeholder; never the argument.
- WP-secret-fence-two-tier-detector: when a script *reproduces* a pipeline, the
  stage ORDER is part of what is being reproduced. Scanning the raw note with a
  context-free entropy pass looks equivalent to scanning it after the labelled
  rules and is not: a labelled credential gets counted twice and lands in the
  wrong bucket of the source breakdown. It went unnoticed because this corpus
  has exactly one labelled finding and it does not overlap an entropy run —
  i.e. the corpus could not discriminate the bug, which is the same failure
  mode the spec's own M4e register keeps recording about single-corpus
  evidence.
- WP-secret-fence-two-tier-detector: when a script emulates a PREVIOUS version
  of a pipeline, every rule the current version adds is a source of error, and a
  warning is not a substitute for refusing to report. The first fix printed the
  full M1 table with a caveat line underneath; the caveat would have been
  dropped the moment anyone pasted the numbers, because **a number that is
  printed will be quoted**. Emitting nothing is the only version of "this is not
  reproducible" that survives a copy-paste.
- WP-secret-fence-two-tier-detector: a guard that refuses to report should be
  gated on the condition that actually invalidates the report, not on the
  trigger that usually accompanies it. This one keys on "a rule this WP adds
  fired" when what invalidates the baseline is narrower — "a rule this WP adds
  consumed a body the shipped pass would have reported". Over-refusal is the
  safe failure and it is still a false alarm, and false alarms are what train
  people to bypass guards.

---
Generated-by: claude-opus-5




