### PR TITLE
docs(cli): describe what `wienerdog safety` shows (WP-help-text-safety-gates)

### DIFF
--- a/bin/wienerdog.js
+++ b/bin/wienerdog.js
@@ -21,7 +21,7 @@ Commands:
   gws         Read Gmail/Calendar/Drive and draft mail (Google Workspace)
   grant       Authorize a routine to send email (typed confirmation required)
   memory      Approve identity-note changes so they inject into your session (typed confirmation)
-  safety      Show the pre-use security gates (all disabled until reviewed)
+  safety      Show which sensitive actions Wienerdog allows or blocks
 
 Global options:
   --dry-run   Show what would happen; make no changes

--- a/docs/specs/WP-help-text-safety-gates.md
+++ b/docs/specs/WP-help-text-safety-gates.md
@@ -1,7 +1,7 @@
 ---
 id: WP-help-text-safety-gates
 title: Fix the stale `safety` line in `wienerdog help` — the gates are no longer all disabled
-status: Ready
+status: In-Review
 model: sonnet
 size: S
 depends_on: []


### PR DESCRIPTION
Spec: docs/specs/WP-help-text-safety-gates.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

## Verification output

Dispatch record: dispatch-time re-verification satisfied at `b3a53bc` — `src/`, `bin/`, `tests/` byte-identical to `e7c845e`, the SHA the spec's claims were verified against (gate closed 2026-08-02). Branch base verified: `git rev-parse HEAD` = `b3a53bcd036ebaa044dab04abfb2176e4defb61f`.

```
$ # V1 (AC1) — BEFORE the edit
$ grep -n "disabled until reviewed" bin/wienerdog.js
24:  safety      Show the pre-use security gates (all disabled until reviewed)
exit=0

$ # V2 (AC1) — AFTER the edit
$ grep -n "disabled until reviewed" bin/wienerdog.js
exit=1

$ # V3 (AC2)
$ node bin/wienerdog.js help | grep -n "^  safety      Show which sensitive actions Wienerdog allows or blocks$"
19:  safety      Show which sensitive actions Wienerdog allows or blocks
exit=0

$ # V4 (AC3) — alignment probe, expect a single "15"
$ node bin/wienerdog.js help | sed -n '/^Commands:$/,/^$/p' | grep '^  [a-z]' \
    | awk '{ match($0, /^  [a-z-]+ +/); print RLENGTH+1 }' | sort -u
15

$ # V5 (AC4)
$ git diff --stat -- bin/wienerdog.js
 bin/wienerdog.js | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

$ # V6 (AC5)
$ npm test
ℹ tests 1825
ℹ suites 0
ℹ pass 1820
ℹ fail 0
ℹ cancelled 0
ℹ skipped 5
ℹ todo 0
ℹ duration_ms 50629.167708

$ npm run lint
--- markdownlint ---
Linting: 386 file(s)
Summary: 0 error(s)
--- shellcheck ---
--- PSScriptAnalyzer ---
--- frontmatter check ---
frontmatter check passed: 209 spec(s), 4 agent(s)

lint passed
```

`tests/unit/broker-server.test.js` and `tests/unit/safety-cli.test.js` pass unmodified (no test file touched in this PR).

## Decisions made

none — the spec's Exact contract block gave the replacement line byte-exact; no ambiguity to resolve.

## Discovered issues (out of scope, not fixed)

- Stale gate-status claims in `docs/VISION.md:22` and `:51` — already routed by the spec as `WP-vision-gate-status-destale`.
- `docs/GLOSSARY.md:43-47` safety-profile entry reads as a current-state claim — same routing per spec.
- `src/core/safety-profile.js:65-69` refusal message wording is latent-stale (branch unreachable while all gates are allowed) — noted in spec's Out of scope.

## Lessons (memory dogfooding)

- WP-help-text-safety-gates: locating the target line by byte-exact text rather than line number paid off trivially here, but the spec's explicit warning about the second `safety` mention (dispatch table at :65) is the kind of disambiguation that prevents a wrong one-line edit.
- WP-help-text-safety-gates: the V4 alignment probe (awk RLENGTH over the Commands block) is a cheap, reusable idiom for guarding fixed-column help text without a golden file.

---
Generated-by: Claude Fable 5 (claude-fable-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG6TJhQS9RTaNKgHKhXmc8
