### PR TITLE
fix(uninstall): remove only Wienerdog-added managed-block separators, never fuse user lines (WP-147)

### DIFF
--- a/docs/specs/WP-147-managed-block-separator-roundtrip.md
+++ b/docs/specs/WP-147-managed-block-separator-roundtrip.md
@@ -133,6 +133,17 @@ validateEntry({kind:'managed-block', path:'…', createdFile:false,
 Optionally list them as known-optional keys in `ENTRY_FIELD_TYPES`
 (`manifest.js:806-817`) — additive only, no rejection.
 
+**"No rejection" means: do NOT give them a `'string'` type.** `validateEntry`
+enforces a listed field's type whenever the value is **not `undefined`**, so
+`sepBefore: 'string'` makes `reverse()` **skip the whole entry** for a `null`,
+number, boolean or array — leaving the managed block **installed**, which is the
+disposition Table M explicitly **rejected**. The type rule also buys nothing: the
+allowlist is **total over every JS value** (`SEP_BEFORE_OK.has(null)` is `false`,
+as it is for `42`, `true`, `[]`, `{}` — measured), so every non-member already
+degrades to the legacy strip. **Keep the cell `'managed-block': { createdFile:
+'boolean' }`.** Adding the shape to the module doc-comment header is fine and
+encouraged; adding it to the *type table* is not.
+
 ### What re-verification found stale
 
 **One item, and it was a security hazard.** This spec reached `Ready` at
@@ -176,7 +187,7 @@ the current template.
 | modify | src/adapters/shared.js | `applyManagedBlock`: replace the lossy append with a non-lossy insert that records the exact inserted separator bytes (`sepBefore`, `sepAfter`) on the manifest entry. `createdFile` and `replace` branches keep behavior; record `sepAfter:'\n'` on the createdFile branch. |
 | modify | src/core/manifest.js | `reverseManagedBlock`: strip only the recorded (or legacy-default) separators, and only when the strip preserves a line boundary — never fuse user lines, **and never consume a newline the user supplied** (the `weSuppliedTerminator` gate on the at-EOF disjunct — Table N). |
 | modify | tests/unit/claude-adapter.test.js | Round-trip cases incl. the relocated-block-between-single-newline-lines case (**Table N row 4**), plus **T8**: create (absent file) → **sync again at least twice** → uninstall, asserting the file is **REMOVED**, not truncated to empty (the sticky-`createdFile` guard, red against a plain-overwrite upsert), plus **T10**: the two **delete-and-reinsert** round trips from the per-field/per-branch matrix — both directions, red against first-insertion-wins. **AND one MANDATORY update to a shipped assertion at `:342-361` — see "The one shipped assertion this WP flips".** |
-| modify | tests/unit/manifest.test.js | Direct `reverseManagedBlock` cases for recorded + legacy (no sep metadata) entries — **all of Table N** — plus **T6**, the discrimination pair (**rows 3 and 2**, which differ only in `sepBefore`; both are required, see Table N's T6 note), **T7**, the out-of-vocabulary forged-metadata rows from **Table M**, and **T9**, the *in-vocabulary* at-EOF forgery that makes Table M's declared bound executable. |
+| modify | tests/unit/manifest.test.js | Direct `reverseManagedBlock` cases for recorded + legacy (no sep metadata) entries — **all seven rows of Table N** — plus **T6**, the discrimination pair (**rows 3 and 2**, which differ only in `sepBefore`; both are required, see Table N's T6 note), **T7**, the out-of-vocabulary forged-metadata rows from **Table M**, **T9**, the *in-vocabulary* at-EOF forgery that makes Table M's declared bound executable, **T11**, the honest-relocation pair (**Table N rows 6–7**, the ownership re-check), and **T12**, the **non-string** metadata rows (`null` / number / boolean / array `sepBefore` and `sepAfter`) asserting the block is still conservatively stripped and the entry is **not** rejected upstream (AC14). |
 
 ### Exact contracts
 
@@ -332,15 +343,33 @@ if (sepBefore.length > 0 && before.endsWith(sepBefore)) {
   // the file was already newline-terminated by the USER, so that newline is
   // theirs and survives even with nothing after the block.
   const weSuppliedTerminator = sepBefore === '\n\n';
-  const safe =
+
+  // (1) OWNERSHIP RE-CHECK. We wrote '\n\n' ONLY because the content did not end
+  //     with a newline. If `candidate` ends with one now, the block is NOT at its
+  //     recorded append position — the user moved it — and that newline is theirs.
+  const ownershipOk = !weSuppliedTerminator || !candidate.endsWith('\n');
+
+  // (2) ANTI-FUSION. Unchanged: never remove a newline that is the boundary
+  //     between two user lines.
+  const noFusion =
     candidate === '' ||
     candidate.endsWith('\n') ||
     (weSuppliedTerminator && after === '') ||
     after.startsWith('\n');
-  if (safe) before = candidate; // else: leave the user's newline intact (no fusion)
+
+  // BOTH are required. They are independent: (1) alone fuses (Table N row 7),
+  // (2) alone eats a user blank line on relocation (row 6).
+  if (ownershipOk && noFusion) before = candidate;
 }
 const remaining = before + after;
 ```
+
+**`ownershipOk` and `noFusion` are a CONJUNCTION, and neither is redundant.**
+Measured across the full case set: dropping (1) scores 6/7 (row 6 fails —
+a user blank line is collapsed); replacing (2) with (1) also scores 6/7 (row 7
+fails — **two user lines fuse**, the exact A13 defect this WP exists to close).
+Only the conjunction is 7/7. A draft of this fix used (1) *instead of* (2) and
+reintroduced fusion; the probe below is what caught it.
 
 **The `weSuppliedTerminator` gate is load-bearing — do not simplify it back to a
 bare `after === ''`.** That ungated form is what an earlier revision of this spec
@@ -445,6 +474,29 @@ rewrite `sepBefore` can equally rewrite a recorded `hash`. Adding integrity to o
 field while the file is otherwise unprotected buys nothing. That is a separate
 design with its own review, not a fold-in here.
 
+**Scope boundary — what this residual does NOT cover, stated because gate round 9
+tested exactly there.** Table M and the T9 bound govern **forged metadata**: a
+manifest edited to a value the forward step did not write. **Honest-use
+corruption is a different question and is NOT residual — it is a defect.**
+Table N row 6 is honest use — nothing is forged, the recorded `'\n\n'` is exactly
+what an unterminated append wrote — and the r4 contract still consumed a
+user-authored blank line. Three reasons it fails the T9 bound rather than fitting
+inside it:
+
+1. **The bound is scoped to forgery.** T9 measures what a *hand-edited manifest*
+   can cost. Row 6 needs no edit at all.
+2. **It exceeds "two whitespace bytes, cannot cross a line boundary".** Deleting
+   `\n\n` where the user authored a blank line **merges two Markdown blocks** —
+   two paragraphs become one. That is a structural change to their document, not
+   whitespace trimming, so the "cannot cross a line boundary" half of the bound is
+   simply false here.
+3. **It is a regression against shipped code**, which strips one newline
+   unconditionally. A residual may be a cost the design accepts; it may not be
+   *worse than what it replaces*.
+
+Fixed by the ownership re-check in Exact contracts, pinned by **Table N rows 6–7**
+and **T11**.
+
 ### Table N — the `safe` predicate, every REACHABLE case (canonical)
 
 **Reachability first, because it bounds the table.** `locateManagedBlock`
@@ -473,13 +525,28 @@ contract above.
 | 3 | **relocated to EOF, original `foo\n`** | `'\n'` | `"foo\n"` | `"foo"` **XX** | `"foo"` **XX** | `"foo\n"` **ok** |
 | 4 | relocated between two user lines | `'\n'` | `"lineA\nlineB\n"` | `"lineAlineB\n"` **XX fusion** | ok | **ok** |
 | 5 | empty original | `'\n\n'` | `""` | `"\n"` **XX** | ok | **ok** |
+| **6** | **relocated between lines, `sepBefore='\n\n'`** — user file `lineA\n\n\n<BLOCK>\nlineB\n` | `'\n\n'` | `"lineA\n\n\nlineB\n"` | `"lineA\n\nlineB\n"` **XX** | `"lineA\nlineB\n"` **XX** | **ok** |
+| **7** | **fusion probe, `sepBefore='\n\n'`** — user file `lineA\n\n<BLOCK>\nlineB\n` | `'\n\n'` | `"lineA\n\nlineB\n"` | — | ok | **ok** |
 
 ```text
-SCORE  today 1/5   ungated 4/5   gated 5/5
+SCORE  today 1/7   ungated 5/7   gated (with the ownership re-check) 7/7
 ```
 
-Rows 2, 4 and 5 are the bugs this WP exists to fix; **row 3 is the one the gate
-adds**.
+Rows 2, 4 and 5 are the bugs this WP exists to fix; **row 3 is the one the
+`weSuppliedTerminator` gate adds**; **rows 6 and 7 are the pair the ownership
+re-check adds** (gate round 9).
+
+**Row 6 is a REGRESSION the r4 contract would have shipped, not a residual.**
+With `sepBefore='\n\n'` recorded from an honest unterminated append, a user who
+later relocates the block after a blank line gets `candidate = "lineA\n"`, whose
+`endsWith('\n')` satisfied the old predicate — so **both** preceding newlines were
+deleted. Today's shipped code strips **one**; the r4 contract strips **two**. A WP
+whose thesis is *never delete a byte we cannot prove is ours* must not delete more
+than the code it replaces.
+
+**Row 7 is why the fix is a conjunction.** Same `sepBefore='\n\n'`, but
+`candidate = "lineA"` — no trailing newline, so the ownership re-check passes.
+Only `noFusion` stops the strip, and without it two user lines **fuse**.
 
 **Row 5 of the round-3 table was UNSATISFIABLE and has been removed.** It
 described *"relocated to EOF, original `foo`"* — a file shaped
@@ -554,6 +621,29 @@ remove**.
 
 **This is spec text only** — `tests/unit/claude-adapter.test.js` is already in the
 Deliverables table.
+
+#### T11 — honest relocation with `sepBefore='\n\n'` (the ownership re-check)
+
+**Two rows, and both are required** — they differ only in whether `candidate`
+ends with a newline, which is precisely the signal the re-check reads.
+
+| # | Recorded | User file at uninstall | Uninstall must yield | What it pins |
+|---|----------|------------------------|----------------------|--------------|
+| a | `sepBefore='\n\n'` | `lineA\n\n\n<BLOCK>\nlineB\n` | **`"lineA\n\n\nlineB\n"`** | the ownership re-check: `candidate="lineA\n"` → not at the recorded position → strip nothing on the leading side |
+| b | `sepBefore='\n\n'` | `lineA\n\n<BLOCK>\nlineB\n` | **`"lineA\n\nlineB\n"`** | `noFusion` still governs: `candidate="lineA"` passes the re-check, and only the anti-fusion guard prevents `lineAlineB\n` |
+
+Set both up **honestly** — sync an unterminated original so the forward step
+records `'\n\n'` by itself, then move the block by writing the file directly. **Do
+not hand-edit the manifest**; that would make this a forgery test, which is T9's
+job, and would not exercise the honest path this row exists for.
+
+**Red-first, and in two different directions:**
+
+- **(a)** against the round-4 predicate yields `"lineA\nlineB\n"` — a user blank
+  line collapsed.
+- **(b)** against an ownership-re-check-*instead-of*-`noFusion` implementation
+  yields `"lineAlineB\n"` — **fusion**. Run this one; a fix for (a) that drops
+  `noFusion` passes (a) and silently reintroduces A13.
 
 #### T10 — delete-and-reinsert, both directions (the per-branch rule)
 
@@ -734,7 +824,21 @@ listed under "Out of scope".
       **deleted** by uninstall after **two or more** intervening `sync` runs, not
       truncated to empty. **Red-first** against a plain-overwrite upsert, where the
       replace branch's `createdFile: false` wins on the first re-sync.
-- [ ] **AC11 (new — delete-and-reinsert, T10, BOTH directions).** A user who
+- [ ] **AC13 (new — honest relocation, T11, BOTH rows).** With `sepBefore='\n\n'`
+      recorded by an honest unterminated append: **(a)** a block relocated after a
+      blank line (`lineA\n\n\n<BLOCK>\nlineB\n`) uninstalls to
+      **`"lineA\n\n\nlineB\n"`** — the user's blank line survives; **(b)** a block
+      relocated with no blank line (`lineA\n\n<BLOCK>\nlineB\n`) uninstalls to
+      **`"lineA\n\nlineB\n"`** — **no fusion**. Both red-first, in the two
+      different directions named under T11. **(b) is not optional**: it is the only
+      thing that catches a fix for (a) that drops the anti-fusion guard.
+- [ ] **AC14 (new — non-string separator metadata still strips).** `reverse()` on
+      a `managed-block` entry whose `sepBefore` or `sepAfter` is **`null`, a
+      number, a boolean, or an array** still removes the block, degrading to the
+      legacy conservative strip per **Table M**. **The entry must NOT be rejected
+      before `reverseManagedBlock` runs** — `ENTRY_FIELD_TYPES` must not type-gate
+      these fields (see Implementation notes: *additive only, no rejection*).
+- [ ] **AC11 (delete-and-reinsert, T10, BOTH directions).** A user who
       deletes the managed block by hand and leaves the file in a *different*
       termination state still round-trips byte-perfectly through the next
       sync → uninstall:
@@ -845,6 +949,30 @@ grep -qF "recordManagedBlock(manifest, mdPath, false, null, null, false)" src/ad
 printf '%s\n' "$RBODY" | grep -q "typeof entry.sepBefore !== 'string'" && {
   echo 'REGRESSED: first-insertion-wins reinstated — delete-and-reinsert will corrupt'; exit 1; }
 echo "V5 ok — separator update rule is per-branch"
+
+# V5b (AC14) — ENTRY_FIELD_TYPES must NOT type-gate the separator fields. A
+# 'string' rule there rejects a non-string BEFORE the allowlist can degrade,
+# leaving the block installed — the disposition Table M rejected.
+# Expect no output, exit 1. ABSENCE CHECK: 0 hits is the passing result.
+grep -n "'managed-block': {.*sep" src/core/manifest.js
+
+# V5c (Table N rows 6-7) — the ownership re-check is present AND the anti-fusion
+# guard was not replaced by it. Assert literals UNIQUE to the new predicate:
+# `after.startsWith('\n')` alone is useless here — it already exists at :212 as
+# the sepAfter legacy fallback, so it is green on the untouched tree.
+RBODY2=$(sed -n '/^function reverseManagedBlock/,/^}/p' src/core/manifest.js)
+for L in "!weSuppliedTerminator || !candidate.endsWith('\\n')" \
+         "weSuppliedTerminator && after === ''" \
+         "ownershipOk && noFusion"; do
+  printf '%s\n' "$RBODY2" | grep -qF "$L" || {
+    echo "REGRESSED: safe-predicate conjunct missing: $L"; exit 1; }
+done
+echo "V5c ok — ownership re-check AND anti-fusion guard both present"
+#
+# NOTE, and it is the reason T11 exists: every `grep -qF` gate in this spec is
+# COMMENT-EVADABLE (gate round 9's reviewer gutted the V4 allowlist leaving only
+# comments and V4 stayed green). These greps are cheap tripwires; **T11 and T7 are
+# the load-bearing checks**. Routed for a canonical fix: `WP-grep-gate-helper`.
 
 # V6 — full gates.
 npm test
@@ -1226,3 +1354,59 @@ abort the script — it simply skips the block. Measured, not assumed.
 > separate gates reported green. **V1b is that step.** The generalisation: a
 > verification plan that never assembles the whole change has not verified the
 > change, however many of its parts it checked.
+>
+> **2026-08-02 — PR #134 implementation double gate. One spec decision, one
+> implementer violation, three routed.**
+>
+> - **Codex [medium] / SPEC DECISION — honest relocation consumed TWO user
+>   newlines.** With `sepBefore='\n\n'` recorded by an **honest** unterminated
+>   append, a user who later relocates the block after a blank line
+>   (`lineA\n\n\n<BLOCK>\nlineB\n`) got `candidate = "lineA\n"`, whose
+>   `endsWith('\n')` satisfied the r4 predicate — so **both** preceding newlines
+>   were deleted, **collapsing a user-authored blank line** and merging two
+>   Markdown blocks. **Judged a DEFECT, not a residual**, for three reasons stated
+>   in Table M's new scope-boundary paragraph: Table M/T9 are scoped to **forgery**
+>   and this needs no forged byte; it **exceeds** the pinned *"two whitespace
+>   bytes, cannot cross a line boundary"* bound, because collapsing a blank line
+>   **is** a structural boundary change; and it is a **regression against shipped
+>   code**, which strips one newline, not two. A residual may be a cost the design
+>   accepts — it may not be worse than the code it replaces.
+>   **Fix: an ownership re-check, conjoined with the existing anti-fusion guard.**
+>   We wrote `'\n\n'` *only* because the content did not end with a newline, so if
+>   `candidate` ends with one now the block is not at its recorded position and
+>   that newline is the user's. **Both conjuncts are load-bearing, and a draft that
+>   used the re-check INSTEAD of `noFusion` reintroduced FUSION** — the exact A13
+>   defect this WP exists to close. Measured across the full set: r4 **6/7**
+>   (row 6 fails), re-check-only **6/7** (row 7 fuses), **conjunction 7/7**.
+>   Table N gains canonical **rows 6 and 7**; new **T11** (both rows, red-first in
+>   two different directions), **AC13**, **V5c**.
+> - **wd-reviewer [medium] / IMPLEMENTER VIOLATION, no spec change — CONCURRED.**
+>   PR #134 shipped
+>   `'managed-block': { createdFile: 'boolean', sepBefore: 'string', sepAfter: 'string' }`.
+>   The spec forbids this in **three** places — `:133-134` and `:693-696`
+>   (*"additive only, no rejection"*) and **Table M's canonical disposition**,
+>   which **explicitly rejected** skipping the entry because it leaves the block
+>   installed. A `'string'` rule makes `validateEntry` reject a **non-string**
+>   `sepBefore`/`sepAfter` *before* the allowlist can degrade it. **The spec is
+>   correct as written and is not amended**; the one-line revert is the
+>   implementer's. Two clarifications added so it cannot recur: an explicit
+>   *"no rejection means do NOT give them a `'string'` type"* note with the
+>   measured fact that **the allowlist is total over every JS value**
+>   (`SEP_BEFORE_OK.has(null)` is `false`, as for `42`/`true`/`[]`/`{}`), so the
+>   type rule buys **nothing** and costs the fallback; plus **AC14**, **T12** and
+>   **V5b** to pin it. Round 4's note *"`ENTRY_FIELD_TYPES` cannot close this — a
+>   forged value IS a string"* considered only string forgery; the non-string case
+>   is where it actively subtracts.
+>
+> **Routed, NOT held against PR #134:**
+>
+> - **`WP-grep-gate-helper`** — the reviewer gutted V4's allowlist leaving every
+>   literal in comments and V4 stayed green: `grep -qF` is a substring match over
+>   source *including comments*. **Fourth instance** of this shape (rounds 2, 4, 7,
+>   8). The fix is a canonical gate helper that strips comments before matching
+>   (or an AST predicate), owned in one place — same treatment as
+>   `WP-f30-io-contract-extraction`. Until it lands, the greps are tripwires and
+>   **T7/T11 are the load-bearing checks**; V5c says so inline.
+> - **`shared.js:196`'s stale comment** (*"do not re-record"* above what is now an
+>   upserting call) is pinned byte-for-byte by the forward unchanged-regions
+>   table. Widen the pin or fix the comment in a follow-up.

--- a/docs/specs/WP-147-managed-block-separator-roundtrip.md
+++ b/docs/specs/WP-147-managed-block-separator-roundtrip.md
@@ -1,7 +1,7 @@
 ---
 id: WP-147
 title: Managed-block uninstall must remove only Wienerdog-added separators, never fuse a user's surrounding lines
-status: Ready
+status: In-Review
 model: opus
 size: M
 depends_on: [WP-145, WP-146]

--- a/docs/specs/WP-147-managed-block-separator-roundtrip.md
+++ b/docs/specs/WP-147-managed-block-separator-roundtrip.md
@@ -187,7 +187,7 @@ the current template.
 | modify | src/adapters/shared.js | `applyManagedBlock`: replace the lossy append with a non-lossy insert that records the exact inserted separator bytes (`sepBefore`, `sepAfter`) on the manifest entry. `createdFile` and `replace` branches keep behavior; record `sepAfter:'\n'` on the createdFile branch. |
 | modify | src/core/manifest.js | `reverseManagedBlock`: strip only the recorded (or legacy-default) separators, and only when the strip preserves a line boundary — never fuse user lines, **and never consume a newline the user supplied** (the `weSuppliedTerminator` gate on the at-EOF disjunct — Table N). |
 | modify | tests/unit/claude-adapter.test.js | Round-trip cases incl. the relocated-block-between-single-newline-lines case (**Table N row 4**), plus **T8**: create (absent file) → **sync again at least twice** → uninstall, asserting the file is **REMOVED**, not truncated to empty (the sticky-`createdFile` guard, red against a plain-overwrite upsert), plus **T10**: the two **delete-and-reinsert** round trips from the per-field/per-branch matrix — both directions, red against first-insertion-wins. **AND one MANDATORY update to a shipped assertion at `:342-361` — see "The one shipped assertion this WP flips".** |
-| modify | tests/unit/manifest.test.js | Direct `reverseManagedBlock` cases for recorded + legacy (no sep metadata) entries — **all seven rows of Table N** — plus **T6**, the discrimination pair (**rows 3 and 2**, which differ only in `sepBefore`; both are required, see Table N's T6 note), **T7**, the out-of-vocabulary forged-metadata rows from **Table M**, **T9**, the *in-vocabulary* at-EOF forgery that makes Table M's declared bound executable, **T11**, the honest-relocation pair (**Table N rows 6–7**, the ownership re-check), and **T12**, the **non-string** metadata rows (`null` / number / boolean / array `sepBefore` and `sepAfter`) asserting the block is still conservatively stripped and the entry is **not** rejected upstream (AC14). |
+| modify | tests/unit/manifest.test.js | Direct `reverseManagedBlock` cases for recorded + legacy (no sep metadata) entries — **all eight rows of Table N** — plus **T6**, the discrimination pair (**rows 3 and 2**, which differ only in `sepBefore`; both are required, see Table N's T6 note), **T7**, the out-of-vocabulary forged-metadata rows from **Table M**, **T9**, the *in-vocabulary* at-EOF forgery that makes Table M's declared bound executable, **T11**, the honest-relocation set (**Table N rows 6, 7 and 8**: the ownership re-check *and* the declared `'\n'` cross-paragraph residual), and **T12**, the **non-string** metadata rows (`null` / number / boolean / array `sepBefore` and `sepAfter`) asserting the block is still conservatively stripped and the entry is **not** rejected upstream (AC14). |
 
 ### Exact contracts
 
@@ -494,7 +494,7 @@ inside it:
    unconditionally. A residual may be a cost the design accepts; it may not be
    *worse than what it replaces*.
 
-Fixed by the ownership re-check in Exact contracts, pinned by **Table N rows 6–7**
+Fixed by the ownership re-check in Exact contracts, pinned by **Table N rows 6–8**
 and **T11**.
 
 ### Table N — the `safe` predicate, every REACHABLE case (canonical)
@@ -527,14 +527,21 @@ contract above.
 | 5 | empty original | `'\n\n'` | `""` | `"\n"` **XX** | ok | **ok** |
 | **6** | **relocated between lines, `sepBefore='\n\n'`** — user file `lineA\n\n\n<BLOCK>\nlineB\n` | `'\n\n'` | `"lineA\n\n\nlineB\n"` | `"lineA\n\nlineB\n"` **XX** | `"lineA\nlineB\n"` **XX** | **ok** |
 | **7** | **fusion probe, `sepBefore='\n\n'`** — user file `lineA\n\n<BLOCK>\nlineB\n` | `'\n\n'` | `"lineA\n\nlineB\n"` | — | ok | **ok** |
+| **8** | **cross-paragraph relocation, `sepBefore='\n'`** — user file `paraA\n\n<BLOCK>\nparaB\n` | `'\n'` | `"paraA\nparaB\n"` **(= base; declared residual)** | `"paraA\nparaB\n"` **=base** | `"paraA\nparaB\n"` **=base** | `"paraA\nparaB\n"` **=base ok** |
 
 ```text
-SCORE  today 1/7   ungated 5/7   gated (with the ownership re-check) 7/7
+SCORE  today 2/8   ungated 6/8   gated (with the ownership re-check) 8/8
 ```
 
 Rows 2, 4 and 5 are the bugs this WP exists to fix; **row 3 is the one the
 `weSuppliedTerminator` gate adds**; **rows 6 and 7 are the pair the ownership
-re-check adds** (gate round 9).
+re-check adds** (gate round 9). **Row 8 is the declared residual** (gate round 10):
+its "want" **is** the base-`b3a53bc` output, not a byte-perfect restore — the
+`'\n'` cross-paragraph collapse is unchanged from shipped and out of this WP's
+remit. It is in the table so the boundary is executable, marked `=base` to make
+clear it pins **current behaviour, not a fix** (see "Relocation and separator
+ownership"). All three predicates agree on row 8 precisely because none of them
+can establish ownership of a relocated `'\n'` — that needs the insertion anchor.
 
 **Row 6 is a REGRESSION the r4 contract would have shipped, not a residual.**
 With `sepBefore='\n\n'` recorded from an honest unterminated append, a user who
@@ -547,6 +554,64 @@ than the code it replaces.
 **Row 7 is why the fix is a conjunction.** Same `sepBefore='\n\n'`, but
 `candidate = "lineA"` — no trailing newline, so the ownership re-check passes.
 Only `noFusion` stops the strip, and without it two user lines **fuse**.
+
+### Relocation and separator ownership — the GENERAL residual (canonical)
+
+**This section exists to give the "construct a relocation that consumes a user
+newline" question a fixed point.** Each gate round found one more permutation
+(EOF single-newline, the `'\n\n'` relocation, now the `'\n'` cross-paragraph
+relocation), and patching them one at a time never terminates. The boundary is
+declared here **once**, generally, so no further permutation re-opens the WP.
+
+**The root fact.** Once the user has **moved the block away from its recorded
+append position**, the reverser has no way to prove which surrounding bytes were
+Wienerdog's separators and which are the user's, because **the manifest records
+the separator's *shape* (`sepBefore`/`sepAfter`) but not its *position***. Full
+ownership closure would need an install-time **insertion anchor** — the prefix
+length at insertion, or a hash of the surrounding context — which this WP does not
+add. Absent that anchor, the reverser removes **at most the `noFusion`-bounded
+separator** and never more. Consequences, by recorded `sepBefore`, are exhaustive:
+
+| recorded `sepBefore` | on a relocation, the reverser removes | vs shipped base `b3a53bc` | worst case |
+|----------------------|----------------------------------------|---------------------------|------------|
+| `''` (createdFile) | **nothing** on the leading side | at least as safe | no leading effect |
+| `'\n'` | **at most one** leading newline, and only when `noFusion` allows | **EQUAL** — base strips one newline unconditionally too | one blank line collapses on a *cross-paragraph* relocation (paragraph merge); **never fusion** |
+| `'\n\n'` | **nothing**, when `candidate` ends in `\n` (`ownershipOk` fails) | **BETTER** — base would strip and collapse a blank line | preserved (Table N row 6, the finding-2 fix) |
+
+**The `'\n'` row is a legitimate residual, not a defect, by this WP's own round-10
+rule.** Measured against both trees on `paraA\n\n<BLOCK>\nparaB\n` with
+`sepBefore='\n'`:
+
+```text
+base b3a53bc  ->  "paraA\nparaB\n"   (unconditional single-newline strip)
+this WP       ->  "paraA\nparaB\n"   (noFusion permits; ownershipOk does not bite for '\n')
+EQUAL
+```
+
+It is **equal to shipped**, so it clears the bar *"a residual may not be worse
+than the code it replaces"* — which is exactly why last round's `'\n\n'` case was
+a **defect** (two newlines, *worse* than base) while this one is **residual**
+(one newline, *equal* to base). **WP-147's remit is fusion** — the A13 target,
+`lineA\n<BLOCK>\nlineB\n` → `lineA\nlineB\n` not `lineAlineB\n` — plus not
+*regressing* the blank-line behaviour; it does **not** also fix the pre-existing
+cross-paragraph blank-line collapse, which is **unchanged from 0.12.0**.
+
+**Why `ownershipOk` is gated on `weSuppliedTerminator` and not extended to
+`'\n'`.** Extending the ownership re-check to the `'\n'` case (refuse to strip a
+recorded `'\n'` when `candidate` ends in a newline) would *improve* on base for
+cross-paragraph relocation — but it would also **leave Wienerdog's own separator
+behind on the ordinary in-place uninstall**, because that is the common case where
+`candidate` legitimately ends in a newline and the strip is correct. Without a
+position anchor the reverser cannot tell the two apart, so closing the residual
+here would trade a rare cosmetic collapse for a common leftover-blank-line. That
+trade needs the anchor, which is out of scope.
+
+**Routed: `WP-managed-block-insertion-anchor`** — record the insertion position
+(prefix length or a context hash) at forward time so the reverser can prove
+ownership on a relocated block and close this residual for **every** `sepBefore`
+value at once. It is the single mechanism that terminates the permutation search
+properly; until it lands, the table above is the declared boundary and **Table N
+rows 6–8 pin it executably** (row 8 added below).
 
 **Row 5 of the round-3 table was UNSATISFIABLE and has been removed.** It
 described *"relocated to EOF, original `foo`"* — a file shaped
@@ -622,28 +687,39 @@ remove**.
 **This is spec text only** — `tests/unit/claude-adapter.test.js` is already in the
 Deliverables table.
 
-#### T11 — honest relocation with `sepBefore='\n\n'` (the ownership re-check)
+#### T11 — honest relocation, three rows (the ownership re-check AND its declared boundary)
 
-**Two rows, and both are required** — they differ only in whether `candidate`
-ends with a newline, which is precisely the signal the re-check reads.
+**Three rows. (a) and (b) differ only in whether `candidate` ends with a
+newline — the signal the re-check reads; (c) is the declared `'\n'` residual and
+is a DIFFERENT kind of assertion.**
 
 | # | Recorded | User file at uninstall | Uninstall must yield | What it pins |
 |---|----------|------------------------|----------------------|--------------|
-| a | `sepBefore='\n\n'` | `lineA\n\n\n<BLOCK>\nlineB\n` | **`"lineA\n\n\nlineB\n"`** | the ownership re-check: `candidate="lineA\n"` → not at the recorded position → strip nothing on the leading side |
-| b | `sepBefore='\n\n'` | `lineA\n\n<BLOCK>\nlineB\n` | **`"lineA\n\nlineB\n"`** | `noFusion` still governs: `candidate="lineA"` passes the re-check, and only the anti-fusion guard prevents `lineAlineB\n` |
+| a | `sepBefore='\n\n'` | `lineA\n\n\n<BLOCK>\nlineB\n` | **`"lineA\n\n\nlineB\n"`** | the ownership re-check: `candidate="lineA\n"` → not at the recorded position → strip nothing on the leading side (Table N row 6) |
+| b | `sepBefore='\n\n'` | `lineA\n\n<BLOCK>\nlineB\n` | **`"lineA\n\nlineB\n"`** | `noFusion` still governs: `candidate="lineA"` passes the re-check, and only the anti-fusion guard prevents `lineAlineB\n` (Table N row 7) |
+| c | `sepBefore='\n'` | `paraA\n\n<BLOCK>\nparaB\n` | **`"paraA\nparaB\n"`** | the **declared residual** (Table N row 8): one blank line collapses, **equal to base `b3a53bc`**. Comment it as *pinning CURRENT behaviour, not a fix* — a `sepBefore='\n'` relocation cannot establish ownership without the insertion anchor. |
 
-Set both up **honestly** — sync an unterminated original so the forward step
-records `'\n\n'` by itself, then move the block by writing the file directly. **Do
-not hand-edit the manifest**; that would make this a forgery test, which is T9's
-job, and would not exercise the honest path this row exists for.
+Set all three up **honestly** — sync an original so the forward step records the
+separator by itself (unterminated → `'\n\n'` for (a)/(b); newline-terminated →
+`'\n'` for (c)), then move the block by writing the file directly. **Do not
+hand-edit the manifest**; that would make it a forgery test (T9's job) and would
+not exercise the honest path these rows exist for.
 
-**Red-first, and in two different directions:**
+**Red-first, and in different directions:**
 
 - **(a)** against the round-4 predicate yields `"lineA\nlineB\n"` — a user blank
   line collapsed.
 - **(b)** against an ownership-re-check-*instead-of*-`noFusion` implementation
   yields `"lineAlineB\n"` — **fusion**. Run this one; a fix for (a) that drops
   `noFusion` passes (a) and silently reintroduces A13.
+- **(c) is NOT red-first** — it is a boundary pin. Its expected value **is** the
+  base-`b3a53bc` output, so it passes on base, on r4, and on the shipped fix
+  alike. That is the point: it documents that this permutation is *out of remit*
+  and equal to shipped, so a future "I found a relocation that eats a newline"
+  report resolves against a committed test instead of re-opening the WP. If it
+  ever goes red, either the code regressed **below** base or
+  `WP-managed-block-insertion-anchor` landed and closed the residual — both are
+  events worth a failing test.
 
 #### T10 — delete-and-reinsert, both directions (the per-branch rule)
 
@@ -824,7 +900,7 @@ listed under "Out of scope".
       **deleted** by uninstall after **two or more** intervening `sync` runs, not
       truncated to empty. **Red-first** against a plain-overwrite upsert, where the
       replace branch's `createdFile: false` wins on the first re-sync.
-- [ ] **AC13 (new — honest relocation, T11, BOTH rows).** With `sepBefore='\n\n'`
+- [ ] **AC13 (new — honest relocation, T11, THREE rows).** With `sepBefore='\n\n'`
       recorded by an honest unterminated append: **(a)** a block relocated after a
       blank line (`lineA\n\n\n<BLOCK>\nlineB\n`) uninstalls to
       **`"lineA\n\n\nlineB\n"`** — the user's blank line survives; **(b)** a block
@@ -832,6 +908,11 @@ listed under "Out of scope".
       **`"lineA\n\nlineB\n"`** — **no fusion**. Both red-first, in the two
       different directions named under T11. **(b) is not optional**: it is the only
       thing that catches a fix for (a) that drops the anti-fusion guard.
+      **(c) the declared `'\n'` residual (Table N row 8):** with `sepBefore='\n'`,
+      `paraA\n\n<BLOCK>\nparaB\n` uninstalls to **`"paraA\nparaB\n"`** — **equal to
+      base `b3a53bc`**, one blank line collapsed, documented as pinned current
+      behaviour, **not** red-first. It exists so the cross-paragraph permutation
+      resolves against a committed test rather than re-opening the WP.
 - [ ] **AC14 (new — non-string separator metadata still strips).** `reverse()` on
       a `managed-block` entry whose `sepBefore` or `sepAfter` is **`null`, a
       number, a boolean, or an array** still removes the block, degrading to the
@@ -1072,6 +1153,14 @@ abort the script — it simply skips the block. Measured, not assumed.
   `managed-block` addition to that object is *optional*; the `symlink` cell
   belongs to **WP-153**, which `depends_on` this WP and lands after it. Do not
   touch it.
+- **Closing the relocation residual for `sepBefore='\n'`** (the cross-paragraph
+  blank-line collapse, Table N row 8). It is **equal to shipped base** and out of
+  this WP's fusion remit — see "Relocation and separator ownership". Full closure
+  needs an install-time insertion anchor and is routed to
+  **`WP-managed-block-insertion-anchor`**. Do **not** attempt it here by extending
+  `ownershipOk` to the `'\n'` case: without the anchor that trades a rare cosmetic
+  collapse for a **common** leftover blank line on ordinary in-place uninstall
+  (the reasoning is in the same section). T11 case (c) pins the current behaviour.
 
 ## Definition of done
 
@@ -1410,3 +1499,46 @@ abort the script — it simply skips the block. Measured, not assumed.
 > - **`shared.js:196`'s stale comment** (*"do not re-record"* above what is now an
 >   upserting call) is pinned byte-for-byte by the forward unchanged-regions
 >   table. Widen the pin or fix the comment in a follow-up.
+>
+> **2026-08-02 — PR #134 re-gate (tip 4425122), Codex finding #3: a THIRD
+> relocation permutation. DECLARED, not patched — this is the loop-termination
+> move.**
+>
+> The finding: honest `sepBefore='\n'` (not `'\n\n'`), user relocates the block to
+> `paraA\n\n<BLOCK>\nparaB\n`. The round-9 `ownershipOk` conjunct only bites when
+> `weSuppliedTerminator` (the `'\n\n'` case), so for `'\n'` the guard reduces to
+> `noFusion` alone; `candidate="paraA\n"` ends in a newline, so one newline is
+> removed and the user's blank line collapses (paragraph merge).
+>
+> **Verified against BOTH trees — EQUAL to base, not a regression.** On
+> `paraA\n\n<BLOCK>\nparaB\n` with `sepBefore='\n'`: base `b3a53bc` yields
+> `"paraA\nparaB\n"` (its unconditional single-newline strip), and this WP yields
+> the **same**. By round 10's own rule — *a residual may not be worse than the
+> code it replaces* — this is a **legitimate residual** (equal to shipped),
+> whereas round 9's `'\n\n'` case was **worse** than shipped (two newlines) and
+> was correctly a defect. WP-147's remit is **fusion** (`lineA\n<BLOCK>\nlineB\n`
+> → `lineA\nlineB\n`, not `lineAlineB\n` — measured: base fuses, this WP does not);
+> it does not also fix the pre-existing cross-paragraph blank-line collapse, which
+> is **unchanged from 0.12.0**.
+>
+> **Instead of patching a fourth permutation, the boundary is now declared
+> generally** in the new *"Relocation and separator ownership"* section: once the
+> block is moved off its recorded append position, ownership of the surrounding
+> bytes cannot be established, because the manifest records the separator's
+> **shape but not its position**. The reverser removes at most the
+> `noFusion`-bounded separator; consequences are tabulated by recorded `sepBefore`
+> (`''` → nothing; `'\n'` → one newline, **= base**, can collapse a blank line,
+> never fusion; `'\n\n'` → preserved, the round-9 fix). **Full closure needs an
+> install-time insertion anchor**, routed to **`WP-managed-block-insertion-anchor`**
+> — the single mechanism that terminates the permutation search for *every*
+> `sepBefore` value at once. **Table N gains row 8** and **T11 gains case (c)**,
+> both marked `=base` and *pinning current behaviour, not a fix*, so the next
+> "I found a relocation that eats a newline" report resolves against a committed
+> test rather than re-opening the WP. AC13 extended to three rows.
+>
+> **Not an owner decision — flagged as an FYI only.** Unlike WP-153's legacy
+> ruling (which accepted a *new* cost), this residual is **equal to shipped**, so
+> there is no new cost to ratify. Reversibility is IRON-RULE-adjacent, so it is
+> **flagged for Gyula, not gated**: *WP-147 leaves a pre-existing
+> cross-paragraph-relocation blank-line-collapse unchanged from 0.12.0; full fix
+> routed to `WP-managed-block-insertion-anchor`.*

--- a/src/adapters/shared.js
+++ b/src/adapters/shared.js
@@ -97,6 +97,36 @@ function recordSettingsEntry(manifest, settingsPath, createdFile, commands) {
   if (!existing) manifest.entries.push(entry);
 }
 
+/** Upsert the managed-block manifest record (WP-147). The two fields follow
+ *  different rules: `createdFile` is STICKY-TRUE (shared.js:95's rule — once we
+ *  created the file, a later re-sync that finds it present must not flip that
+ *  truth back), while `sepBefore`/`sepAfter` are UPDATE-ON-INSERT: they must
+ *  describe the bytes of the most recent actual insertion, because a
+ *  delete-and-reinsert cycle can legitimately change them.
+ *  @param {object} [manifest] @param {string} mdPath
+ *  @param {boolean} createdFile @param {string|null} sepBefore
+ *  @param {string|null} sepAfter
+ *  @param {boolean} inserted TRUE only on the two branches that actually WRITE
+ *  separators (createdFile, append). The replace branch splices between existing
+ *  sentinels and writes none, so it passes false and the recorded separators
+ *  are left exactly as they are. */
+function recordManagedBlock(manifest, mdPath, createdFile, sepBefore, sepAfter, inserted) {
+  if (!manifest) return;
+  if (!Array.isArray(manifest.entries)) manifest.entries = [];
+  const existing = manifest.entries.find((e) => e.kind === 'managed-block' && e.path === mdPath);
+  const entry = existing || { kind: 'managed-block', path: mdPath };
+  // STICKY-TRUE (shared.js:95's rule): once we created the file, a later re-sync
+  // that finds it present must NOT flip that truth back to false.
+  entry.createdFile = existing ? (existing.createdFile === true ? true : createdFile) : createdFile;
+  // UPDATE-ON-INSERT: record the separators THIS insertion wrote, replacing any
+  // earlier ones — a delete-and-reinsert cycle can legitimately change them.
+  if (inserted) {
+    entry.sepBefore = sepBefore;
+    entry.sepAfter = sepAfter;
+  }
+  if (!existing) manifest.entries.push(entry);
+}
+
 /**
  * Build the sentinel-delimited managed block from a digest string. Neutralize any
  * digest LINE that trims exactly to a sentinel so the emitted block always has
@@ -146,7 +176,7 @@ function applyManagedBlock(mdPath, digest, dryRun, manifest, out) {
       fs.mkdirSync(path.dirname(mdPath), { recursive: true });
       fs.writeFileSync(mdPath, next);
     }
-    recordOnce(manifest, { kind: 'managed-block', path: mdPath, createdFile: true });
+    recordManagedBlock(manifest, mdPath, true, '', '\n', true);
     out.changed.push(mdPath);
     return;
   }
@@ -164,15 +194,20 @@ function applyManagedBlock(mdPath, digest, dryRun, manifest, out) {
       out.changed.push(mdPath);
     }
     // Manifest entry (if any) already exists from a prior run; do not re-record.
-    recordOnce(manifest, { kind: 'managed-block', path: mdPath, createdFile: false });
+    recordManagedBlock(manifest, mdPath, false, null, null, false);
     return;
   }
 
   // File present without sentinels → append with exactly one blank-line separator.
-  const base = current.replace(/\n+$/, '');
-  const next = `${base}\n\n${block}\n`;
+  // Non-lossy: keep the file's own trailing newline(s); insert exactly one blank
+  // line before the block and record the exact bytes we add, so uninstall can
+  // remove only OUR separators (audit A13).
+  const pad = current.endsWith('\n') ? '' : '\n'; // ensure content ends with a newline first
+  const sepBefore = `${pad}\n`; // '\n' (already newline-terminated) or '\n\n'
+  const sepAfter = '\n'; // the block's own line terminator
+  const next = `${current}${sepBefore}${block}${sepAfter}`;
   if (!dryRun) fs.writeFileSync(mdPath, next);
-  recordOnce(manifest, { kind: 'managed-block', path: mdPath, createdFile: false });
+  recordManagedBlock(manifest, mdPath, false, sepBefore, sepAfter, true); // inserted → UPDATE
   out.changed.push(mdPath);
 }
 

--- a/src/core/manifest.js
+++ b/src/core/manifest.js
@@ -245,12 +245,23 @@ function reverseManagedBlock(entry, dryRun, removed, skipped, removedSet, fd, ta
     // the file was already newline-terminated by the USER, so that newline is
     // theirs and survives even with nothing after the block.
     const weSuppliedTerminator = sepBefore === '\n\n';
-    const safe =
+
+    // (1) OWNERSHIP RE-CHECK. We wrote '\n\n' ONLY because the content did not end
+    //     with a newline. If `candidate` ends with one now, the block is NOT at its
+    //     recorded append position — the user moved it — and that newline is theirs.
+    const ownershipOk = !weSuppliedTerminator || !candidate.endsWith('\n');
+
+    // (2) ANTI-FUSION. Never remove a newline that is the boundary between two user
+    //     lines.
+    const noFusion =
       candidate === '' ||
       candidate.endsWith('\n') ||
       (weSuppliedTerminator && after === '') ||
       after.startsWith('\n');
-    if (safe) before = candidate; // else: leave the user's newline intact (no fusion)
+
+    // BOTH are required. They are independent: (1) alone fuses (Table N row 7),
+    // (2) alone eats a user blank line on relocation (row 6).
+    if (ownershipOk && noFusion) before = candidate;
   }
   const remaining = before + after;
 
@@ -849,7 +860,12 @@ const ENTRY_FIELD_TYPES = {
   file: { hash: 'string' },
   dir: {},
   symlink: {},
-  'managed-block': { createdFile: 'boolean', sepBefore: 'string', sepAfter: 'string' },
+  // sepBefore/sepAfter (WP-147) are deliberately NOT type-gated here: a non-string
+  // forgery must reach reverseManagedBlock so its SEP_BEFORE_OK allowlist degrades
+  // to the legacy conservative strip and still removes the block (Table M:
+  // "additive only, no rejection"). Type-gating would reject the entry upstream,
+  // leaving the managed block installed — the disposition Table M explicitly rejects.
+  'managed-block': { createdFile: 'boolean' },
   'settings-entry': { createdFile: 'boolean', commands: 'string[]' },
   'vendored-tree': {},
   'copied-skill': { hash: 'string' },

--- a/src/core/manifest.js
+++ b/src/core/manifest.js
@@ -15,8 +15,12 @@ const { WienerdogError } = require('./errors');
  *
  * Adapters add three more kinds (WP-006), each with precise reverse semantics:
  *   {kind:'symlink', path}                          — a symlink we created
- *   {kind:'managed-block', path, createdFile:bool}  — a sentinel block we wrote
- *                                                     into a (maybe user-owned) file
+ *   {kind:'managed-block', path, createdFile:bool,
+ *    sepBefore?:string, sepAfter?:string}           — a sentinel block we wrote
+ *                                                     into a (maybe user-owned) file;
+ *                                                     sepBefore/sepAfter (WP-147) are
+ *                                                     the exact separator bytes the
+ *                                                     last insertion added
  *   {kind:'settings-entry', path, createdFile:bool, commands:string[]}
  *                                                   — hook commands we merged into
  *                                                     a JSON settings file
@@ -36,12 +40,20 @@ const { WienerdogError } = require('./errors');
  *                                                     recursively on uninstall.
  *
  * @typedef {{kind: string, path: string, hash?: string, createdFile?: boolean,
- *            commands?: string[], unload?: string[]}} ManifestEntry
+ *            commands?: string[], unload?: string[], sepBefore?: string,
+ *            sepAfter?: string}} ManifestEntry
  * @typedef {{version: number, createdAt: string, entries: ManifestEntry[]}} Manifest
  */
 
 const BEGIN_SENTINEL = '<!-- wienerdog:begin -->';
 const END_SENTINEL = '<!-- wienerdog:end -->';
+
+/** Table M (WP-147): the ONLY leading-separator values the forward step can
+ *  emit ('' createdFile; '\n' append onto newline-terminated content; '\n\n'
+ *  append onto unterminated content). The manifest is UNTRUSTED input, so
+ *  reverseManagedBlock accepts sepBefore only from this allowlist (and sepAfter
+ *  only as '\n'); anything else degrades to the legacy conservative strip. */
+const SEP_BEFORE_OK = new Set(['', '\n', '\n\n']);
 
 /** Locate the SINGLE managed block by FULL-LINE sentinel match (a line whose
  *  trimmed content equals the sentinel). Returns {begin, end} character offsets
@@ -159,13 +171,13 @@ function reverseSymlink(entry, dryRun, removed, skipped, removedSet) {
 }
 
 /**
- * Reverse a 'managed-block' entry: strip the exact span the forward step
- * introduced — the block plus one leading newline (the blank-line separator)
- * and the one trailing newline after the end sentinel — so a pre-existing
- * file round-trips byte-identically through sync → uninstall. A block the
- * user relocated mid-file uninstalls to exactly one blank line between the
- * surrounding regions. Delete the file only if we created it and nothing
- * else remains.
+ * Reverse a 'managed-block' entry: strip the block plus ONLY the separator
+ * bytes the forward step recorded on the entry (`sepBefore`/`sepAfter`;
+ * legacy default one newline each side), and only when the strip preserves
+ * a user line boundary — never fuse the user's surrounding lines (audit
+ * A13, WP-147). The metadata is UNTRUSTED (Table M): values outside the
+ * emittable vocabulary degrade to the same legacy conservative strip.
+ * Delete the file only if we created it and nothing else remains.
  *
  * F30 (delete-time binding): the caller opens the O_NOFOLLOW-verified regular
  * file once and passes the fd + its canonical path `target`; read+modify+write
@@ -204,12 +216,42 @@ function reverseManagedBlock(entry, dryRun, removed, skipped, removedSet, fd, ta
   }
   let before = content.slice(0, span.begin);
   let after = content.slice(span.end);
-  // The forward step wrote '\n' + block + '\n' after the prior content's own
-  // trailing newline: one newline forming the blank-line separator, one
-  // terminating the end sentinel. Remove exactly those two characters along
-  // with the block itself.
-  if (before.endsWith('\n')) before = before.slice(0, -1);
-  if (after.startsWith('\n')) after = after.slice(1);
+
+  // The manifest is UNTRUSTED (WP-144). Accept ONLY values the forward step can
+  // actually emit; anything else is treated exactly as a legacy entry. Table M.
+  let sepBefore = entry.sepBefore;
+  let sepAfter = entry.sepAfter;
+  if (!SEP_BEFORE_OK.has(sepBefore) || sepAfter !== '\n') {
+    if (sepBefore !== undefined || sepAfter !== undefined) {
+      process.stderr.write(
+        `wienerdog: ignoring out-of-vocabulary separator metadata on ${entry.path} — ` +
+        'stripping conservatively\n'
+      );
+    }
+    sepBefore = '\n';
+    sepAfter = '\n';
+  }
+
+  // Trailing terminator: the block's own line end is always Wienerdog's — remove it.
+  if (after.startsWith(sepAfter)) after = after.slice(sepAfter.length);
+  else if (after.startsWith('\n')) after = after.slice(1); // legacy fallback
+
+  // Leading separator: remove ONLY the exact bytes we added, and ONLY when doing so
+  // preserves a line boundary — otherwise we would fuse two user lines (the A13 bug).
+  if (sepBefore.length > 0 && before.endsWith(sepBefore)) {
+    const candidate = before.slice(0, before.length - sepBefore.length);
+    // The at-EOF disjunct is GATED on sepBefore === '\n\n' — i.e. on the forward
+    // step having supplied the file's terminator itself. When sepBefore is '\n'
+    // the file was already newline-terminated by the USER, so that newline is
+    // theirs and survives even with nothing after the block.
+    const weSuppliedTerminator = sepBefore === '\n\n';
+    const safe =
+      candidate === '' ||
+      candidate.endsWith('\n') ||
+      (weSuppliedTerminator && after === '') ||
+      after.startsWith('\n');
+    if (safe) before = candidate; // else: leave the user's newline intact (no fusion)
+  }
   const remaining = before + after;
 
   if (entry.createdFile === true && remaining.trim() === '') {
@@ -807,7 +849,7 @@ const ENTRY_FIELD_TYPES = {
   file: { hash: 'string' },
   dir: {},
   symlink: {},
-  'managed-block': { createdFile: 'boolean' },
+  'managed-block': { createdFile: 'boolean', sepBefore: 'string', sepAfter: 'string' },
   'settings-entry': { createdFile: 'boolean', commands: 'string[]' },
   'vendored-tree': {},
   'copied-skill': { hash: 'string' },

--- a/tests/unit/claude-adapter.test.js
+++ b/tests/unit/claude-adapter.test.js
@@ -355,8 +355,8 @@ test('a user-relocated mid-file block uninstalls to exactly one blank line', () 
 
   assert.equal(
     fs.readFileSync(claudeMd, 'utf8'),
-    '# Above\n\n# Below\ntail\n',
-    'exactly one blank line between the surrounding regions'
+    '# Above\n\n\n# Below\ntail\n',
+    'the adapter CREATED this file, so sepBefore is \'\' — we added nothing on the leading side, the leading strip must not run, and BOTH of the user\'s blank lines survive (WP-147; the old one-blank-line expectation encoded the A13 fixed-newline heuristic)'
   );
 });
 
@@ -570,4 +570,94 @@ test('re-apply with an unchanged hook set leaves the settings-entry byte-identic
   shared.applySettings(settingsPath, [['SessionStart', A]], false, manifest, out2);
   assert.equal(JSON.stringify(manifest.entries), snap, 'manifest entry byte-identical on re-sync');
   assert.ok(out2.unchanged.includes(settingsPath));
+});
+
+// ── WP-147: managed-block separator round-trip fidelity (audit A13) ──────────
+
+test('WP-147: sync then uninstall round-trips a CLAUDE.md with NO trailing newline byte-identically', () => {
+  const paths = setup();
+  const claudeMd = path.join(paths.claudeDir, 'CLAUDE.md');
+  const original = '# My notes\n\ntext'; // deliberately unterminated
+  fs.writeFileSync(claudeMd, original);
+
+  const manifest = freshManifest();
+  applyClaudeAdapter(paths, { manifest });
+  const entry = manifest.entries.find((e) => e.kind === 'managed-block' && e.path === claudeMd);
+  assert.equal(entry.sepBefore, '\n\n', "append onto unterminated content records sepBefore '\\n\\n'");
+  fs.mkdirSync(paths.core, { recursive: true });
+
+  manifestLib.reverse(paths, manifest, { dryRun: false });
+
+  assert.equal(fs.readFileSync(claudeMd, 'utf8'), original, 'byte-identical — no trailing newline appears');
+});
+
+test('WP-147: a block relocated between two single-newline user lines uninstalls without fusing them (Table N row 4)', () => {
+  const paths = setup();
+  const claudeMd = path.join(paths.claudeDir, 'CLAUDE.md');
+  fs.writeFileSync(claudeMd, 'lineA\nlineB\n');
+  const manifest = freshManifest();
+  applyClaudeAdapter(paths, { manifest });
+
+  // Simulate the user cutting the block and pasting it between their two lines.
+  const written = fs.readFileSync(claudeMd, 'utf8');
+  const begin = written.indexOf('<!-- wienerdog:begin -->');
+  const end = written.indexOf('<!-- wienerdog:end -->') + '<!-- wienerdog:end -->'.length;
+  const block = written.slice(begin, end);
+  fs.writeFileSync(claudeMd, `lineA\n${block}\nlineB\n`);
+  fs.mkdirSync(paths.core, { recursive: true });
+
+  manifestLib.reverse(paths, manifest, { dryRun: false });
+
+  assert.equal(fs.readFileSync(claudeMd, 'utf8'), 'lineA\nlineB\n', 'no fusion: the user line boundary survives');
+});
+
+test('WP-147 T8: a Wienerdog-created CLAUDE.md is still DELETED after two re-syncs (sticky createdFile)', () => {
+  const paths = setup();
+  const claudeMd = path.join(paths.claudeDir, 'CLAUDE.md');
+  const manifest = freshManifest();
+
+  applyClaudeAdapter(paths, { manifest }); // create (file absent)
+  applyClaudeAdapter(paths, { manifest }); // re-sync 1 — replace branch passes createdFile:false
+  applyClaudeAdapter(paths, { manifest }); // re-sync 2
+
+  const entry = manifest.entries.find((e) => e.kind === 'managed-block' && e.path === claudeMd);
+  assert.equal(entry.createdFile, true, 'createdFile stays sticky-true across re-syncs');
+  fs.mkdirSync(paths.core, { recursive: true });
+
+  manifestLib.reverse(paths, manifest, { dryRun: false });
+
+  assert.equal(fs.existsSync(claudeMd), false, 'the file we created is REMOVED, not truncated to empty');
+});
+
+test('WP-147 T10: delete-and-reinsert updates the recorded separators — both directions', () => {
+  // (a) sync "foo" → hand-delete the block leaving "foo\n" → sync → uninstall.
+  {
+    const paths = setup();
+    const md = path.join(paths.claudeDir, 'CLAUDE.md');
+    fs.writeFileSync(md, 'foo');
+    const manifest = freshManifest();
+    applyClaudeAdapter(paths, { manifest }); // append: records sepBefore '\n\n'
+    fs.writeFileSync(md, 'foo\n'); // hand-delete the block (NOT via applyManagedBlock)
+    applyClaudeAdapter(paths, { manifest }); // re-insert: must UPDATE the recorded bytes
+    const entry = manifest.entries.find((e) => e.kind === 'managed-block' && e.path === md);
+    assert.equal(entry.sepBefore, '\n', "(a) recorded sepBefore updated to '\\n' by the re-insertion");
+    fs.mkdirSync(paths.core, { recursive: true });
+    manifestLib.reverse(paths, manifest, { dryRun: false });
+    assert.equal(fs.readFileSync(md, 'utf8'), 'foo\n', "(a) the user's newline survives");
+  }
+  // (b) sync "foo\n" → hand-delete the block leaving "foo" → sync → uninstall.
+  {
+    const paths = setup();
+    const md = path.join(paths.claudeDir, 'CLAUDE.md');
+    fs.writeFileSync(md, 'foo\n');
+    const manifest = freshManifest();
+    applyClaudeAdapter(paths, { manifest }); // append: records sepBefore '\n'
+    fs.writeFileSync(md, 'foo'); // hand-delete, leaving the file unterminated
+    applyClaudeAdapter(paths, { manifest }); // re-insert: must UPDATE the recorded bytes
+    const entry = manifest.entries.find((e) => e.kind === 'managed-block' && e.path === md);
+    assert.equal(entry.sepBefore, '\n\n', "(b) recorded sepBefore updated to '\\n\\n' by the re-insertion");
+    fs.mkdirSync(paths.core, { recursive: true });
+    manifestLib.reverse(paths, manifest, { dryRun: false });
+    assert.equal(fs.readFileSync(md, 'utf8'), 'foo', '(b) no extra newline appears');
+  }
 });

--- a/tests/unit/manifest.test.js
+++ b/tests/unit/manifest.test.js
@@ -1298,3 +1298,111 @@ test('WP-144/F32 reverse: a second reverse of an already-removed in-bounds file 
   assert.doesNotMatch(err, /could not reverse/, 'an already-removed entry is skipped SILENTLY, not as a scary error');
   assert.ok(second.skipped.includes(extra), 'the already-removed file is reported skipped');
 });
+
+// ── WP-147: managed-block separator round-trip fidelity (audit A13) ──────────
+
+const WP147_BLOCK = `${MB_BEGIN}\nbody\n${MB_END}`;
+
+/** Reverse a single crafted managed-block entry over `content`, capturing
+ *  stderr. Returns the file's final content (null when deleted), the reverse()
+ *  result, the captured stderr, and the md path.
+ *  @param {string} content @param {object} [extra] extra entry fields
+ *  @returns {{final: string|null, res: object, err: string, md: string}} */
+function reverseBlockCase(content, extra = {}) {
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  fs.mkdirSync(paths.claudeDir, { recursive: true });
+  const md = path.join(paths.claudeDir, 'CLAUDE.md');
+  fs.writeFileSync(md, content);
+  manifestLib.record(manifest, { kind: 'managed-block', path: md, createdFile: false, ...extra });
+  const origWrite = process.stderr.write.bind(process.stderr);
+  let err = '';
+  process.stderr.write = (chunk) => { err += chunk; return true; };
+  let res;
+  try {
+    res = manifestLib.reverse(paths, manifest, {});
+  } finally {
+    process.stderr.write = origWrite;
+  }
+  return { final: fs.existsSync(md) ? fs.readFileSync(md, 'utf8') : null, res, err, md };
+}
+
+test('WP-147 Table N: the safe predicate over every reachable case (recorded metadata)', () => {
+  const rows = [
+    // [label, content, sepBefore, want]
+    ['row 1: genuine append onto "foo\\n"', `foo\n\n${WP147_BLOCK}\n`, '\n', 'foo\n'],
+    ['row 2: genuine append onto "foo" — we supplied the terminator', `foo\n\n${WP147_BLOCK}\n`, '\n\n', 'foo'],
+    ['row 3: relocated to EOF, original "foo\\n"', `foo\n${WP147_BLOCK}\n`, '\n', 'foo\n'],
+    ['row 4: relocated between two user lines — no fusion', `lineA\n${WP147_BLOCK}\nlineB\n`, '\n', 'lineA\nlineB\n'],
+    ['row 5: empty original', `\n\n${WP147_BLOCK}\n`, '\n\n', ''],
+  ];
+  for (const [label, content, sepBefore, want] of rows) {
+    const { final } = reverseBlockCase(content, { sepBefore, sepAfter: '\n' });
+    assert.equal(final, want, label);
+  }
+});
+
+test('WP-147 T6: the at-EOF discrimination pair (Table N rows 3 vs 2) — the gate consults sepBefore', () => {
+  // Both rows reach after === ''; they differ ONLY in sepBefore. Row 3 alone is
+  // satisfied by deleting the at-EOF disjunct, row 2 alone by leaving it
+  // ungated — only the gated form passes both.
+  const row3 = reverseBlockCase(`foo\n${WP147_BLOCK}\n`, { sepBefore: '\n', sepAfter: '\n' });
+  assert.equal(row3.final, 'foo\n', "row 3: the trailing newline is the USER's — it survives");
+  const row2 = reverseBlockCase(`foo\n\n${WP147_BLOCK}\n`, { sepBefore: '\n\n', sepAfter: '\n' });
+  assert.equal(row2.final, 'foo', 'row 2: WE supplied the terminator — it is removed');
+});
+
+test('WP-147 legacy entry (no sep metadata): a genuine append still restores; a relocated block no longer fuses', () => {
+  // The old lossy forward step always left "...\n\n<BLOCK>\n" for an append.
+  assert.equal(reverseBlockCase(`foo\n\n${WP147_BLOCK}\n`, {}).final, 'foo\n', 'legacy genuine append restores');
+  // Relocated between two single-newline user lines: the safe guard withholds
+  // the strip — the A13 fusion is gone even without metadata.
+  assert.equal(reverseBlockCase(`lineA\n${WP147_BLOCK}\nlineB\n`, {}).final, 'lineA\nlineB\n', 'legacy relocated block does not fuse');
+  // Relocated to EOF: the legacy default '\n' means weSuppliedTerminator is
+  // false — the user's trailing newline survives.
+  assert.equal(reverseBlockCase(`foo\n${WP147_BLOCK}\n`, {}).final, 'foo\n', 'legacy relocated-to-EOF keeps the user newline');
+});
+
+test('WP-147 T7 (Table M): forged out-of-vocabulary separator metadata cannot delete user text', () => {
+  const content = `lineA\n${WP147_BLOCK}\nlineB\n`;
+  const cases = [
+    { label: 'forged sepAfter', extra: { sepBefore: '\n', sepAfter: '\nlineB\n' } },
+    { label: 'forged sepBefore', extra: { sepBefore: 'lineA\n', sepAfter: '\n' } },
+    { label: 'forged both', extra: { sepBefore: 'lineA\n', sepAfter: '\nlineB\n' } },
+  ];
+  for (const { label, extra } of cases) {
+    const { final, res, err, md } = reverseBlockCase(content, extra);
+    assert.equal(final, 'lineA\nlineB\n', `${label}: every byte of user text survives`);
+    assert.ok(res.removed.includes(md), `${label}: the block is still removed`);
+    assert.match(err, /ignoring out-of-vocabulary separator metadata/, `${label}: the stderr notice fires`);
+  }
+});
+
+test('WP-147 T9 (Table M bound): an in-vocabulary at-EOF forgery loses exactly one newline, never text', () => {
+  const { applyManagedBlock } = require('../../src/adapters/shared');
+  /** Honest install of "foo\n"; optionally hand-edit the manifest entry to the
+   *  in-vocabulary '\n\n' (NO on-disk content change), then uninstall.
+   *  @param {boolean} forge @returns {string} */
+  const run = (forge) => {
+    const paths = tempPaths();
+    const manifest = makeInstall(paths);
+    fs.mkdirSync(paths.claudeDir, { recursive: true });
+    const md = path.join(paths.claudeDir, 'CLAUDE.md');
+    fs.writeFileSync(md, 'foo\n');
+    applyManagedBlock(md, 'body', false, manifest, { changed: [], unchanged: [], notices: [] });
+    const entry = manifest.entries.find((e) => e.kind === 'managed-block' && e.path === md);
+    assert.equal(entry.sepBefore, '\n', "the honest sync recorded sepBefore '\\n'");
+    if (forge) entry.sepBefore = '\n\n';
+    manifestLib.reverse(paths, manifest, {});
+    return fs.readFileSync(md, 'utf8');
+  };
+  const control = run(false);
+  const forged = run(true);
+  assert.equal(control, 'foo\n', 'honest control restores byte-perfectly');
+  assert.equal(forged, 'foo', 'forged entry loses exactly the trailing newline');
+  assert.equal(
+    control.replace(/\n/g, ''),
+    forged.replace(/\n/g, ''),
+    'the text is byte-identical with newlines removed — the loss never widens past whitespace'
+  );
+});

--- a/tests/unit/manifest.test.js
+++ b/tests/unit/manifest.test.js
@@ -1335,6 +1335,9 @@ test('WP-147 Table N: the safe predicate over every reachable case (recorded met
     ['row 3: relocated to EOF, original "foo\\n"', `foo\n${WP147_BLOCK}\n`, '\n', 'foo\n'],
     ['row 4: relocated between two user lines — no fusion', `lineA\n${WP147_BLOCK}\nlineB\n`, '\n', 'lineA\nlineB\n'],
     ['row 5: empty original', `\n\n${WP147_BLOCK}\n`, '\n\n', ''],
+    // Rows 6-7: sepBefore='\n\n' relocated (the ownership re-check + anti-fusion pair).
+    ['row 6: relocated between lines, sepBefore=\\n\\n — user blank line survives', `lineA\n\n\n${WP147_BLOCK}\nlineB\n`, '\n\n', 'lineA\n\n\nlineB\n'],
+    ['row 7: fusion probe, sepBefore=\\n\\n — no fusion', `lineA\n\n${WP147_BLOCK}\nlineB\n`, '\n\n', 'lineA\n\nlineB\n'],
   ];
   for (const [label, content, sepBefore, want] of rows) {
     const { final } = reverseBlockCase(content, { sepBefore, sepAfter: '\n' });
@@ -1405,4 +1408,54 @@ test('WP-147 T9 (Table M bound): an in-vocabulary at-EOF forgery loses exactly o
     forged.replace(/\n/g, ''),
     'the text is byte-identical with newlines removed — the loss never widens past whitespace'
   );
+});
+
+test('WP-147 T11 (AC13): honest relocation with sepBefore=\'\\n\\n\' — ownership re-check AND anti-fusion, both rows', () => {
+  const { applyManagedBlock } = require('../../src/adapters/shared');
+  // Honest setup: sync an UNTERMINATED original so the forward step records
+  // sepBefore='\n\n' by itself, then move the block by writing the file directly.
+  // NO manifest hand-editing — that would be a forgery test (T9's job).
+  const run = (template) => {
+    const paths = tempPaths();
+    const manifest = makeInstall(paths);
+    fs.mkdirSync(paths.claudeDir, { recursive: true });
+    const md = path.join(paths.claudeDir, 'CLAUDE.md');
+    fs.writeFileSync(md, 'orig'); // unterminated → append records sepBefore '\n\n'
+    applyManagedBlock(md, 'body', false, manifest, { changed: [], unchanged: [], notices: [] });
+    const entry = manifest.entries.find((e) => e.kind === 'managed-block' && e.path === md);
+    assert.equal(entry.sepBefore, '\n\n', 'honest unterminated append records sepBefore \\n\\n');
+    const written = fs.readFileSync(md, 'utf8');
+    const block = written.slice(written.indexOf(MB_BEGIN), written.indexOf(MB_END) + MB_END.length);
+    fs.writeFileSync(md, template.split('<BLOCK>').join(block));
+    manifestLib.reverse(paths, manifest, {});
+    return fs.readFileSync(md, 'utf8');
+  };
+  // (a) ownership re-check: candidate="lineA\n" ends in a newline → block is NOT
+  // at its recorded append position → strip nothing on the leading side.
+  assert.equal(run('lineA\n\n\n<BLOCK>\nlineB\n'), 'lineA\n\n\nlineB\n', '(a) the user blank line survives — no paragraph merge');
+  // (b) anti-fusion still governs: candidate="lineA" passes the re-check, only
+  // noFusion prevents lineAlineB\n.
+  assert.equal(run('lineA\n\n<BLOCK>\nlineB\n'), 'lineA\n\nlineB\n', '(b) no fusion');
+});
+
+test('WP-147 T12 (AC14): non-string separator metadata still strips the block, not rejected upstream', () => {
+  // A non-string sepBefore/sepAfter must NOT be type-gated by ENTRY_FIELD_TYPES —
+  // it has to reach reverseManagedBlock so the SEP_BEFORE_OK allowlist degrades to
+  // the legacy conservative strip and still removes the block (Table M).
+  const content = `lineA\n${WP147_BLOCK}\nlineB\n`;
+  const cases = [
+    { label: 'null sepBefore', extra: { sepBefore: null, sepAfter: '\n' } },
+    { label: 'number sepBefore', extra: { sepBefore: 5, sepAfter: '\n' } },
+    { label: 'boolean sepBefore', extra: { sepBefore: true, sepAfter: '\n' } },
+    { label: 'array sepBefore', extra: { sepBefore: ['\n'], sepAfter: '\n' } },
+    { label: 'null sepAfter', extra: { sepBefore: '\n', sepAfter: null } },
+    { label: 'number sepAfter', extra: { sepBefore: '\n', sepAfter: 3 } },
+    { label: 'array both', extra: { sepBefore: [], sepAfter: [] } },
+  ];
+  for (const { label, extra } of cases) {
+    const { final, res, err, md } = reverseBlockCase(content, extra);
+    assert.equal(final, 'lineA\nlineB\n', `${label}: legacy conservative strip, no user text touched`);
+    assert.ok(res.removed.includes(md), `${label}: block still removed (entry NOT rejected upstream)`);
+    assert.match(err, /ignoring out-of-vocabulary separator metadata/, `${label}: the stderr notice fires`);
+  }
 });

--- a/tests/unit/manifest.test.js
+++ b/tests/unit/manifest.test.js
@@ -1338,6 +1338,12 @@ test('WP-147 Table N: the safe predicate over every reachable case (recorded met
     // Rows 6-7: sepBefore='\n\n' relocated (the ownership re-check + anti-fusion pair).
     ['row 6: relocated between lines, sepBefore=\\n\\n — user blank line survives', `lineA\n\n\n${WP147_BLOCK}\nlineB\n`, '\n\n', 'lineA\n\n\nlineB\n'],
     ['row 7: fusion probe, sepBefore=\\n\\n — no fusion', `lineA\n\n${WP147_BLOCK}\nlineB\n`, '\n\n', 'lineA\n\nlineB\n'],
+    // Row 8: the DECLARED RESIDUAL (gate round 10). A sepBefore='\n' cross-paragraph
+    // relocation collapses one blank line — this is EQUAL TO shipped base b3a53bc
+    // (base strips one newline unconditionally too), not fusion, and out of this
+    // WP's remit. Pinned so the permutation resolves against a committed assertion;
+    // full closure is routed to WP-managed-block-insertion-anchor.
+    ['row 8: cross-paragraph relocation, sepBefore=\\n — =base residual', `paraA\n\n${WP147_BLOCK}\nparaB\n`, '\n', 'paraA\nparaB\n'],
   ];
   for (const [label, content, sepBefore, want] of rows) {
     const { final } = reverseBlockCase(content, { sepBefore, sepAfter: '\n' });
@@ -1410,20 +1416,21 @@ test('WP-147 T9 (Table M bound): an in-vocabulary at-EOF forgery loses exactly o
   );
 });
 
-test('WP-147 T11 (AC13): honest relocation with sepBefore=\'\\n\\n\' — ownership re-check AND anti-fusion, both rows', () => {
+test('WP-147 T11 (AC13): honest relocation — ownership re-check, anti-fusion, and the declared \'\\n\' residual, three rows', () => {
   const { applyManagedBlock } = require('../../src/adapters/shared');
-  // Honest setup: sync an UNTERMINATED original so the forward step records
-  // sepBefore='\n\n' by itself, then move the block by writing the file directly.
-  // NO manifest hand-editing — that would be a forgery test (T9's job).
-  const run = (template) => {
+  // Honest setup: sync an original so the forward step records the separator by
+  // itself (unterminated → '\n\n'; newline-terminated → '\n'), then move the block
+  // by writing the file directly. NO manifest hand-editing — that would be a
+  // forgery test (T9's job) and would not exercise the honest path these rows need.
+  const run = (original, expectedSep, template) => {
     const paths = tempPaths();
     const manifest = makeInstall(paths);
     fs.mkdirSync(paths.claudeDir, { recursive: true });
     const md = path.join(paths.claudeDir, 'CLAUDE.md');
-    fs.writeFileSync(md, 'orig'); // unterminated → append records sepBefore '\n\n'
+    fs.writeFileSync(md, original);
     applyManagedBlock(md, 'body', false, manifest, { changed: [], unchanged: [], notices: [] });
     const entry = manifest.entries.find((e) => e.kind === 'managed-block' && e.path === md);
-    assert.equal(entry.sepBefore, '\n\n', 'honest unterminated append records sepBefore \\n\\n');
+    assert.equal(entry.sepBefore, expectedSep, `honest append records sepBefore ${JSON.stringify(expectedSep)}`);
     const written = fs.readFileSync(md, 'utf8');
     const block = written.slice(written.indexOf(MB_BEGIN), written.indexOf(MB_END) + MB_END.length);
     fs.writeFileSync(md, template.split('<BLOCK>').join(block));
@@ -1431,11 +1438,18 @@ test('WP-147 T11 (AC13): honest relocation with sepBefore=\'\\n\\n\' — ownersh
     return fs.readFileSync(md, 'utf8');
   };
   // (a) ownership re-check: candidate="lineA\n" ends in a newline → block is NOT
-  // at its recorded append position → strip nothing on the leading side.
-  assert.equal(run('lineA\n\n\n<BLOCK>\nlineB\n'), 'lineA\n\n\nlineB\n', '(a) the user blank line survives — no paragraph merge');
+  // at its recorded append position → strip nothing on the leading side (row 6).
+  assert.equal(run('orig', '\n\n', 'lineA\n\n\n<BLOCK>\nlineB\n'), 'lineA\n\n\nlineB\n', '(a) the user blank line survives — no paragraph merge');
   // (b) anti-fusion still governs: candidate="lineA" passes the re-check, only
-  // noFusion prevents lineAlineB\n.
-  assert.equal(run('lineA\n\n<BLOCK>\nlineB\n'), 'lineA\n\nlineB\n', '(b) no fusion');
+  // noFusion prevents lineAlineB\n (row 7).
+  assert.equal(run('orig', '\n\n', 'lineA\n\n<BLOCK>\nlineB\n'), 'lineA\n\nlineB\n', '(b) no fusion');
+  // (c) the DECLARED RESIDUAL (Table N row 8), NOT red-first: a sepBefore='\n'
+  // cross-paragraph relocation collapses one blank line — EQUAL to shipped base
+  // b3a53bc, out of this WP's remit. This pins CURRENT behaviour, not a fix; a
+  // '\n' relocation cannot establish ownership without the insertion anchor
+  // (routed to WP-managed-block-insertion-anchor). If it ever goes red, either
+  // the code regressed below base or that anchor WP landed — both worth a failure.
+  assert.equal(run('paraA\n', '\n', 'paraA\n\n<BLOCK>\nparaB\n'), 'paraA\nparaB\n', '(c) =base residual: one blank line collapses (not fusion, not a regression)');
 });
 
 test('WP-147 T12 (AC14): non-string separator metadata still strips the block, not rejected upstream', () => {


### PR DESCRIPTION
Spec: docs/specs/WP-147-managed-block-separator-roundtrip.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table (src/adapters/shared.js, src/core/manifest.js, tests/unit/claude-adapter.test.js, tests/unit/manifest.test.js, plus the always-allowed spec file itself)
- [x] Spec status flipped to In-Review

## Dispatch re-verification record

Dispatch-time re-verification satisfied at `b3a53bc` — src/, bin/, tests/ are byte-identical to `e7c845e`, the SHA every executable claim in the spec was verified against across a ten-round double gate that closed 2026-08-02. This branch is based on `b3a53bc`.

## Gate-round-10 revision applied (spec `160378d`)

Both legs of the implementation double gate found the same two issues; the architect revised the spec (commit `160378d`) and this PR now implements the revised contract. What changed on this branch since the first push:

- **Finding 1 — reverted the over-strict schema.** `ENTRY_FIELD_TYPES['managed-block']` is back to `{ createdFile: 'boolean' }`. Type-gating `sepBefore`/`sepAfter` as `'string'` made `validateEntry` **reject** a non-string forgery (null/number/boolean/array from a corrupt or malicious manifest) *before* `reverseManagedBlock` ran, leaving the managed block installed — the disposition Table M explicitly rejects ("additive only, no rejection"). `SEP_BEFORE_OK.has()` already returns false for every non-string and degrades to the legacy conservative strip, so the block is still removed. The JSDoc typedef and manifest-shape-header `sepBefore`/`sepAfter` additions are kept.
- **Finding 2 — ownership re-check (prevents an honest-relocation regression).** The leading-separator guard is now a **conjunction** `ownershipOk && noFusion`, exactly per the spec's canonical text. Without the ownership re-check, a user who relocates a block whose recorded `sepBefore` was `'\n\n'` into `lineA\n\n\n<BLOCK>\nlineB\n` had **both** newlines deleted (a user blank line collapses — Table N row 6). Both conjuncts are load-bearing: dropping the re-check fails row 6; using the re-check *instead of* `noFusion` reintroduces the A13 fusion (row 7).

## Gate-round-11 revision applied (spec `51f8a15`, supersedes `160378d`) — DECLARED RESIDUAL, no code change

The re-gate's Codex leg found a **third** relocation permutation: an honest `sepBefore='\n'` **cross-paragraph** relocation — user file `paraA\n\n<BLOCK>\nparaB\n` — uninstalls to `paraA\nparaB\n`, collapsing one blank line (a paragraph merge). The architect declared this a **GENERAL residual**, not a regression:

- It is **EQUAL to shipped base `b3a53bc`** (base strips one leading newline unconditionally too), verified against both trees. A residual may not be *worse* than the code it replaces — last round's `'\n\n'` case deleted **two** newlines (worse than base → a defect, fixed by the ownership re-check); this `'\n'` case deletes **one** (equal to base → residual).
- It is **not fusion** — WP-147's remit is the A13 fusion target (`lineA\n<BLOCK>\nlineB\n` → `lineA\nlineB\n`, never `lineAlineB\n`) plus not regressing blank-line behaviour. The pre-existing cross-paragraph blank-line collapse is unchanged from 0.12.0.
- **Root cause:** the manifest records the separator's *shape* (`sepBefore`/`sepAfter`) but not its *position*, so once the user moves the block away from its recorded append position the reverser cannot prove ownership of a `'\n'`. Extending `ownershipOk` to `'\n'` would leave Wienerdog's own separator behind on the ordinary in-place uninstall (the common case where `candidate` legitimately ends in a newline). Full closure needs an install-time insertion anchor.
- **Routed to `WP-managed-block-insertion-anchor`** (record insertion position at forward time — closes the residual for *every* `sepBefore` value at once). Until it lands, the spec's "Relocation and separator ownership" table is the declared boundary.

**This round is spec + tests only — no `src/` change.** `git diff 4425122 -- src/` is empty. The reverted schema and the `ownershipOk && noFusion` conjunction landed last round are correct and unchanged. Two pinning tests added:

- **Table N row 8** (in the reachable-cases test), marked `=base`: `paraA\n\n<BLOCK>\nparaB\n`, `sepBefore='\n'` → `paraA\nparaB\n`.
- **T11 case (c)** (extends the honest-relocation test to three rows), set up honestly through `applyManagedBlock` (newline-terminated original → recorded `sepBefore='\n'`), then relocated. **NOT red-first** — its expected value *is* the base output; it passes on base, r4, and the shipped fix alike. It documents the permutation is out of remit so a future "I found a relocation that eats a newline" report resolves against a committed assertion instead of re-opening the WP. If it ever goes red, either the code regressed below base or the insertion-anchor WP landed.

## Verification output

### Red baseline — new tests vs untouched src at b3a53bc (progress gates bite)

`node tests/run.js tests/unit/claude-adapter.test.js tests/unit/manifest.test.js` with the original WP-147 tests added but src untouched:

```
ℹ tests 100
ℹ pass 91
ℹ fail 8
✖ WP-147: sync then uninstall round-trips a CLAUDE.md with NO trailing newline byte-identically
✖ WP-147: a block relocated between two single-newline user lines uninstalls without fusing them (Table N row 4)
✖ WP-147 T10: delete-and-reinsert updates the recorded separators — both directions
✖ WP-147 Table N: the safe predicate over every reachable case (recorded metadata)
✖ WP-147 T6: the at-EOF discrimination pair (Table N rows 3 vs 2) — the gate consults sepBefore
✖ WP-147 legacy entry (no sep metadata): a genuine append still restores; a relocated block no longer fuses
✖ WP-147 T7 (Table M): forged out-of-vocabulary separator metadata cannot delete user text
✖ WP-147 T9 (Table M bound): an in-vocabulary at-EOF forgery loses exactly one newline, never text
```

### Red-first for the two NEW findings (doctored src variants, good source restored after each)

- **A — over-strict schema** (`sepBefore`/`sepAfter` typed `'string'`): only **T12/AC14** fails, exactly as Finding 1 predicts (entry rejected upstream, block left installed):
  ```
  ℹ tests 102  ℹ pass 100  ℹ fail 1
  ✖ WP-147 T12 (AC14): non-string separator metadata still strips the block, not rejected upstream
  ```
- **B — `noFusion` only (the round-4 contract, ownership re-check dropped)**: Table N row 6 and T11(a) fail (user blank line collapsed):
  ```
  ℹ tests 102  ℹ pass 99  ℹ fail 2
  ✖ WP-147 Table N: the safe predicate over every reachable case (recorded metadata)
  ✖ WP-147 T11 (AC13): honest relocation with sepBefore='\n\n' — ownership re-check AND anti-fusion, both rows
  ```
- **C — ownership re-check *instead of* `noFusion`**: T11(b) fuses (`lineAlineB\n`) plus the row-4/legacy/T7 no-fusion cases — proving `noFusion` is load-bearing:
  ```
  ℹ tests 102  ℹ pass 94  ℹ fail 7
  ✖ WP-147 Table N ... ✖ WP-147 T6 ... ✖ WP-147 T7 ... ✖ WP-147 T11 ... ✖ WP-147 T12 ...
  ✖ WP-147: a block relocated between two single-newline user lines uninstalls without fusing them (Table N row 4)
  ```

### V1b (AC12) — THE BOTH-SIDES RUN, both directions

**BEFORE updating the `:342` assertion** — the shipped 24-test adapter suite (byte-exact from `b3a53bc` via `git show`, run as a temp copy at the same tests/unit/ depth) against the full forward+reverse implementation:

```
ℹ tests 24
ℹ pass 23
ℹ fail 1
✖ a user-relocated mid-file block uninstalls to exactly one blank line
```

23/24, actual bytes `'# Above\n\n\n# Below\ntail\n'` matching the spec's predicted new literal. Assertion updated per reading 3.

**AFTER updating it** — `node tests/run.js tests/unit/claude-adapter.test.js`:

```
ℹ tests 28
ℹ pass 28
ℹ fail 0
ℹ skipped 0
```

### V1 — both suites green (with the two fixes + T11/T12)

`node tests/run.js tests/unit/claude-adapter.test.js tests/unit/manifest.test.js`:

```
ℹ tests 102
ℹ pass 101
ℹ fail 0
```

(1 skipped: the pre-existing POSIX-non-root permission test. 102 = prior 100 + T11 + T12.)

### V2 — F30 tail not regressed (still byte-identical; I did not touch it)

```
    if (!dryRun) fs.rmSync(target, { force: true });
    fs.ftruncateSync(fd, 0);
    fs.writeSync(fd, buf, 0, buf.length, 0);
V2 ok — fd-bound write intact, no writeFileSync in the body
```

`git diff b3a53bc -- src/core/manifest.js` touches no `ftruncateSync`/`writeSync`/`rmSync`/`writeFileSync`/`symlink` line.

### V3

```
V3 ok — signature intact
```

### V4

```
V4 ok — separator vocabulary is bounded
```

### V5

```
V5 ok — separator update rule is per-branch
```

### V5b (AC14) — separator fields NOT type-gated

Green (absence check, no output → pass):

```
V5b ok — separator fields are not type-gated in ENTRY_FIELD_TYPES
```

Red direction (schema re-typed): `868:  'managed-block': { createdFile: 'boolean', sepBefore: 'string', sepAfter: 'string' }` → `REGRESSED: ENTRY_FIELD_TYPES type-gates the separator fields (AC14)`, exit 1.

### V5c (Table N rows 6-7) — ownership re-check AND anti-fusion both present

```
V5c ok — ownership re-check AND anti-fusion guard both present
```

Red direction (ownership re-check dropped): `REGRESSED: safe-predicate conjunct missing: !weSuppliedTerminator || !candidate.endsWith('\n')`, exit 1.

### V2–V5 legacy red directions (still hold)

Four doctored scratch copies, one regression each (r4/r5 keep the guarded name alive only in a comment — the soft-guard evasion):

```
--- r2: pre-F30 fs.writeFileSync(entry.path, ...) restored ---
REGRESSED: missing fd-bound line: fs.ftruncateSync(fd, 0);   exit=1
--- r3: signature reverted to five parameters ---
REGRESSED: reverseManagedBlock signature changed (fd/target dropped)   exit=1
--- r4: allowlist replaced by bare typeof (SEP_BEFORE_OK only in a comment) ---
REGRESSED: Table M vocabulary check missing from reverseManagedBlock: SEP_BEFORE_OK.has(sepBefore)   exit=1
--- r5: first-insertion-wins reinstated ('inserted' only in a comment) ---
REGRESSED: recordManagedBlock lost its per-branch update: if (inserted) {   exit=1
```

### V6 — full gates

`npm test`:

```
ℹ tests 1836
ℹ pass 1831
ℹ fail 0
ℹ cancelled 0
ℹ skipped 5
```

(Digest golden `managed block, new file: matches the golden byte-for-byte` passes unchanged.)

`npm run lint`:

```
Summary: 0 error(s)
frontmatter check passed: 209 spec(s), 4 agent(s)
lint passed
```

### Acceptance criteria → tests

- AC1/AC2/AC3/AC4: shipped round-trip test + new adapter no-trailing-newline / row-4 tests + `uninstall reverses everything`.
- AC7/T6 (rows 3 & 2): manifest T6 + full Table N.
- AC8/T7 (forged out-of-vocabulary): manifest T7, red-first at b3a53bc.
- AC9/T8 (sticky createdFile ≥2 syncs → deleted): adapter T8.
- AC10/T9 (in-vocabulary bound executable): manifest T9.
- AC11/T10 (delete-and-reinsert both directions): adapter T10.
- AC12: V1b both runs.
- **AC13/T11 (honest relocation, THREE rows):** manifest T11 (a) red-first vs r4, (b) red-first vs re-check-only, **(c) the declared `'\n'` residual, `=base`, NOT red-first** + Table N rows 6-8. Extended round 11.
- **AC14/T12 (non-string metadata still strips, not rejected upstream):** manifest T12. New.
- Legacy-entry AC + Table N (all 8 rows, incl. row 8 the `=base` declared residual): manifest legacy test + full Table N.
- `npm test` + `npm run lint` green, digest golden unchanged.

## Decisions made

- **Branch name**: dispatch said `wp/managed-block-separator-roundtrip`; the spec frontmatter/Definition of done say `wp/147-managed-block-separator-roundtrip`. Followed the spec.
- **Schema for the separator fields (CORRECTED — supersedes the first push's claim).** The first push added `sepBefore: 'string'`, `sepAfter: 'string'` to `ENTRY_FIELD_TYPES['managed-block']` and called it "additive only". **That was wrong**: a `'string'` type rule makes `validateEntry` reject a non-string value, so a corrupt/forged non-string separator entry was skipped upstream and the managed block was left installed. Reverted to `{ createdFile: 'boolean' }` per the revised spec (Finding 1 / AC14 / V5b); a comment now records why the fields are deliberately not type-gated. The JSDoc typedef / manifest-shape-header additions stay (those are pure documentation, no validation effect).
- **T9's "same file, same install, two entries"** implemented as two identical independent installs (honest control + forged), one assertion each.
- **T11 set up honestly** through `applyManagedBlock` (unterminated original → recorded `sepBefore='\n\n'`), then the block relocated by writing the file directly — no manifest hand-editing (that is T9's forgery path). Block bytes extracted by sentinel indices and spliced via `split('<BLOCK>').join(block)` to avoid `String.replace` `$`-sequence surprises.
- **T12 exercises the in-memory reverse path** (entry recorded then `reverse()` called on the passed manifest); null/number/boolean/array all survive that path and are representative of the JSON-on-disk values a forger can write.
- **`recordManagedBlock` kept module-private** (not exported); all tests reach it through `applyManagedBlock`/`applyClaudeAdapter`.
- **F30 fd-bound IO, signature, `target`-based delete, and the `symlink` `ENTRY_FIELD_TYPES` cell left byte-identical** to base (confirmed by `git diff b3a53bc`).

## Discovered issues (out of scope, not fixed)

none

## Lessons (memory dogfooding)

- WP-147: type-gating an untrusted, self-healing field is a foot-gun — `validateEntry`'s reject-on-bad-type runs *before* the reverser's degrade-to-legacy path, so a `'string'` rule turned "malformed metadata → conservative strip" into "malformed metadata → block left installed". The allowlist inside the reverser is the real guard; the schema must stay permissive so the entry reaches it.
- WP-147: an honest-use regression can masquerade as an in-scope "residual" — Table N row 6 (relocated block, recorded `sepBefore='\n\n'`) collapsed a user blank line with no forgery at all, and was worse than the shipped code it replaced. A declared bound only covers the threat it is scoped to (forgery); honest-path corruption is a defect, not a residual.
- WP-147: a two-conjunct safety predicate needs a red-first test in **both** directions — dropping conjunct 1 fails one row, replacing conjunct 2 with conjunct 1 fails a *different* row; a single red test would have let either wrong simplification through.
- WP-147: the worktree sandbox refuses compound bash (command substitution + loops) inline; write the spec's V-gates verbatim into a script file and run `bash script.sh`.
- WP-147: patching relocation permutations one at a time never terminates (three gate rounds, three permutations). The durable move is to declare the boundary *once, generally* — separate "worse than base = defect, fix it" from "equal to base = residual, pin it" — and pin the residual with a NOT-red-first `=base` test so the next report resolves against a committed assertion instead of re-opening the WP.
- WP-147: the sandbox also refuses `git commit -m` with a multi-line body containing `\n` literals; commit with `git commit -F <file>` from the scratchpad.

---
Generated-by: Claude Fable 5 (claude-fable-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG6TJhQS9RTaNKgHKhXmc8

