### PR TITLE
fix(run-job): build fail-loud alert/email body from code-owned fields only (WP-151)

### DIFF
--- a/docs/specs/WP-151-self-alert-code-owned-body.md
+++ b/docs/specs/WP-151-self-alert-code-owned-body.md
@@ -1,7 +1,7 @@
 ---
 id: WP-151
 title: Build the fail-loud alert and self-email body from code-owned status fields, never a free-form failure string
-status: Ready
+status: In-Review
 model: sonnet
 size: S
 depends_on: []

--- a/src/cli/run-job.js
+++ b/src/cli/run-job.js
@@ -87,6 +87,37 @@ function runStamp(d = new Date()) {
   return d.toISOString().replace(/[:.]/g, '-');
 }
 
+/** Errno-token gate (WP-151, Table R): the ONLY non-template bytes that may reach
+ *  the durable alert `reason` or the self-email body — at most 16 uppercase
+ *  alphanumeric chars, first char a letter. Fully anchored, NO flags (`^`/`$`
+ *  without `m` cannot match at an interior newline, and a flagless RegExp makes
+ *  `.test()` stateless). */
+const TOKEN_OK = /^[A-Z][A-Z0-9]{1,15}$/;
+
+/** Table R rows 1-3 (WP-151, audit A13): the code-owned reason for a
+ *  non-WienerdogError failure. The raw `failure.message` NEVER reaches the
+ *  durable alert or the self-email: row 1 points at the per-run log (the
+ *  finally wrote the redacted detail there while the stream was open); rows
+ *  2-3 carry at most ONE validated errno token when no log could be written.
+ *  `failure.code` is read exactly once — a getter must not get a second read
+ *  after validation (that re-read is how prose would smuggle back in).
+ *  @param {string} name @param {any} failure @param {any} logStream
+ *  @returns {string} */
+function noLogReason(name, failure, logStream) {
+  if (logStream) return `job "${name}" failed to run — see the log for details`;
+  const C = failure && failure.code; // ONE read. Never `failure.code` again.
+  const t = typeof C === 'string' && TOKEN_OK.test(C) ? C : 'UNKNOWN';
+  return `job "${name}" failed to run (${t}) — no log could be written`;
+}
+
+/** Table R row 4 (WP-151, D6). `code` is the ALREADY-CAPTURED logStreamErrCode —
+ *  never re-read from an error object here.
+ *  @param {string} name @param {any} code @returns {string} */
+function logFailedReason(name, code) {
+  const t = typeof code === 'string' && TOKEN_OK.test(code) ? code : 'UNKNOWN';
+  return `job "${name}" ran but its log could not be written (${t})`;
+}
+
 /** Display an absolute path under home as ~/... .
  *  @param {string} home @param {string} p @returns {string} */
 function tilde(home, p) {
@@ -509,10 +540,29 @@ function rotateLogs(dir) {
   }
 }
 
-/** Close a write stream and wait for its flush.
+/** Close a write stream and wait for its flush. Resolves in EVERY state — this
+ *  runs on the failure path, where a hang is as bad as a throw and a logging
+ *  failure must never mask the original failure (WP-151). Never rejects, never
+ *  throws, never awaits an event that has already fired.
  *  @param {NodeJS.WritableStream} stream @returns {Promise<void>} */
 function endStream(stream) {
-  return new Promise((resolve) => stream.end(resolve));
+  return new Promise((resolve) => {
+    let done = false;
+    const finish = () => { if (!done) { done = true; resolve(); } };
+    // 1. ALREADY-SETTLED CHECK, FIRST. A stream destroyed on an earlier tick has
+    //    already emitted 'close', so a listener attached now never fires. The
+    //    check is destroyed/closed ONLY — the ended flag goes true at the end()
+    //    CALL, before the flush, so keying on it would truncate a healthy buffer.
+    if (stream.destroyed || stream.closed) return finish();
+    // 2. BOTH terminal events, attached before end() (end() can emit synchronously).
+    stream.on('error', finish);
+    stream.on('close', finish);
+    try {
+      stream.end(finish);
+    } catch {
+      finish();
+    }
+  });
 }
 
 /**
@@ -677,6 +727,8 @@ function safeResolvePath(input, guard, hopCap = 40) {
  *          timeoutMs?: number,
  *          reapTree?: typeof killProcessTree,
  *          reapGroup?: typeof reap.reapGroup,
+ *          mkdirPrivate?: typeof mkdirPrivate,
+ *          createLogStream?: typeof createLogStreamPrivate,
  *          probeCmd?: string,
  *          skipContainmentProbe?: boolean,
  *          profile?: Record<string,string>}} [opts] `opts.profile` is the
@@ -827,6 +879,10 @@ async function runJob(paths, job, opts = {}) {
   //    (R4-A, WP-a9): a private-open failure must reach the step-7
   //    error-watermark + failLoud branch, not escape uncaught.
   const logDir = path.join(paths.logs, name);
+  // Log seams (test-only, WP-155 idiom): production never sets them, so the
+  // scheduled path always uses the real private-fs helpers.
+  const mkdirFn = opts.mkdirPrivate || mkdirPrivate;
+  const openLogFn = opts.createLogStream || createLogStreamPrivate;
 
   // 4. Watchdog: detached child (own process group), race exit vs timeout, kill
   //    the whole tree on timeout, always clear the timer (reuse dream.js's shape).
@@ -836,14 +892,25 @@ async function runJob(paths, job, opts = {}) {
   let failure = null;
   let reapFailure = null;
   let logStream = null;
+  let logStreamFailed = false;
+  let logStreamErrCode = null;
   try {
     // Per-run log dir (0700) + stream (0600) — umask-independent and
     // fail-closed (WP-a9): mkdirPrivate defeats a permissive umask on the dir,
     // createLogStreamPrivate secures the fd to 0600 or throws (it never writes
     // into a file it could not secure). A throw here lands in the catch below
     // and takes the existing fail-loud branch.
-    mkdirPrivate(logDir, { core: paths.core });
-    logStream = createLogStreamPrivate(path.join(logDir, `${runStamp()}.log`), { core: paths.core });
+    mkdirFn(logDir, { core: paths.core });
+    logStream = openLogFn(path.join(logDir, `${runStamp()}.log`), { core: paths.core });
+    // D5 (WP-151): the tee handlers below write for the child's whole life, and
+    // finalization writes again. A stream with NO 'error' listener turns an
+    // EIO/ENOSPC into an unhandled 'error' that takes the process down before
+    // the fail-loud path runs. Absorb it: the log is best-effort, the refusal is
+    // not. Recording the flag keeps the failure visible without throwing.
+    logStream.on('error', (err) => {
+      logStreamFailed = true;
+      logStreamErrCode = err && err.code; // ONE read — Table R's single-read rule
+    });
 
     const child = spawn(command, args, {
       cwd: spawnCwd,
@@ -922,7 +989,20 @@ async function runJob(paths, job, opts = {}) {
     failure = err;
   } finally {
     // The open may have thrown before logStream was assigned (R4-A).
-    if (logStream) await endStream(logStream);
+    if (logStream) {
+      // A13/WP-151: a non-Wienerdog error's raw message never reaches the durable
+      // alert or the self-email. Preserve it for the user HERE — redacted, through
+      // the SAME already-private fd, before it closes. Best-effort: a logging
+      // failure must never mask the original failure.
+      if (failure && !(failure instanceof WienerdogError)) {
+        try {
+          logStream.write(redactOnly(`\nwienerdog: job failed to run: ${failure && failure.message}\n`));
+        } catch {
+          /* best-effort */
+        }
+      }
+      await endStream(logStream); // error-absorbing, settles in every state (D3)
+    }
   }
 
   // 5. Rotate logs after the run — ONLY if we privately opened the log dir/file
@@ -976,7 +1056,7 @@ async function runJob(paths, job, opts = {}) {
   //    capability ever exercised. The catch-up map is minted ONLY by attended,
   //    user-invoked registration (sync/schedule add/init/adopt). Here we do at most
   //    a READ-ONLY "catch-up entry missing" notice — never write, never load.
-  if (!failure && code === 0 && !reapFailure) {
+  if (!failure && code === 0 && !reapFailure && !logStreamFailed) {
     jobsLib.writeScheduleState(paths, name, { last_success: nowIso(), last_status: 'ok' });
     clearAlerts(paths, name);
     if (platform === 'darwin' || platform === 'win32') {
@@ -1001,10 +1081,12 @@ async function runJob(paths, job, opts = {}) {
   let reason = failure
     ? failure instanceof WienerdogError
       ? failure.message
-      : `job "${name}" failed: ${failure.message}`
+      : noLogReason(name, failure, logStream)
     : code !== 0
       ? `job "${name}" exited ${code}`
-      : `job "${name}" ${reapFailure.reason}`;
+      : reapFailure
+        ? `job "${name}" ${reapFailure.reason}`
+        : logFailedReason(name, logStreamErrCode);
   if (reapFailure && (failure || code !== 0)) {
     reason += ` — and it ${reapFailure.reason}`;
   }

--- a/tests/unit/scheduler-runjob.test.js
+++ b/tests/unit/scheduler-runjob.test.js
@@ -6,6 +6,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const crypto = require('node:crypto');
+const { EventEmitter } = require('node:events');
 
 const { getPaths } = require('../../src/core/paths');
 const manifestLib = require('../../src/core/manifest');
@@ -1959,4 +1960,410 @@ test('scheduler-runjob: the CATCH-UP path (catchUp → runJob) is gated by the p
   const state = jobsLib.readScheduleState(paths);
   assert.equal(state.digest.last_status, 'error', 'catch-up routed through the same probe gate and halted');
   assert.ok(!fs.existsSync(marker), 'the routine brain never spawned under catch-up');
+});
+
+// -------------------------------------------------------------------------
+// WP-151 (audit A13): the fail-loud alert/email body is built from code-owned
+// status fields — a non-Wienerdog error's raw message never leaves the machine.
+// Table R rows 1-4, the D2 log write, D3/D5 stream-error absorption, D6 gate.
+// -------------------------------------------------------------------------
+
+/** T7c skip guard (REAP_SKIP_WIN32 idiom): POSIX mode bits cannot deny the
+ *  owner on win32, and root bypasses them — either way the real-EACCES probe
+ *  would silently pass for the wrong reason. */
+const SKIP_NO_EACCES =
+  (process.platform === 'win32' && 'POSIX mode bits cannot deny the owner on win32') ||
+  (typeof process.getuid === 'function' && process.getuid() === 0 && 'root bypasses POSIX mode bits');
+
+/** WP-151 stub, family 1 (Table S rows C/F — error-then-callback): emits
+ *  'error' at the armed moment, and end(cb) STILL invokes cb afterwards, like a
+ *  real errored fs.WriteStream; destroyed/closed stay false. A lenient stub
+ *  that never emits passes against the untouched endStream too and proves
+ *  nothing — the red direction depends on the emit.
+ *  @param {{errorOnWrite?: Error|null, errorOnEnd?: Error|null}} [arm] */
+function errorThenCallbackStub({ errorOnWrite = null, errorOnEnd = null } = {}) {
+  const s = new EventEmitter();
+  /** @type {string[]} */ s.written = [];
+  s.destroyed = false;
+  s.closed = false;
+  s.writableEnded = false;
+  s.errored = false;
+  s.write = (chunk) => {
+    s.written.push(String(chunk));
+    if (errorOnWrite && !s.errored) {
+      s.errored = true;
+      s.emit('error', errorOnWrite);
+    }
+    return true;
+  };
+  s.end = (cb) => {
+    s.writableEnded = true;
+    if (errorOnEnd && !s.errored) {
+      s.errored = true;
+      s.emit('error', errorOnEnd);
+    }
+    if (cb) process.nextTick(cb);
+  };
+  return s;
+}
+
+/** WP-151 stub, family 2 (Table S rows A/B — destroyed-no-callback): reports
+ *  destroyed (row B: destroyed AND closed), NEVER invokes the end callback and
+ *  NEVER emits again. Against a listener-only endStream this HANGS; only the
+ *  synchronous already-settled check passes row B.
+ *  @param {{closed?: boolean}} [state] */
+function destroyedNoCallbackStub({ closed = false } = {}) {
+  const s = new EventEmitter();
+  /** @type {string[]} */ s.written = [];
+  s.destroyed = true;
+  s.closed = closed;
+  s.writableEnded = false;
+  s.write = (chunk) => (s.written.push(String(chunk)), true);
+  s.end = () => {
+    /* never calls back, never emits (Table S rows A/B) */
+  };
+  return s;
+}
+
+/** The T1/T2 fixture: a spawn of the nonexistent literal path `weird ENOENT /x`
+ *  makes the child emit a raw Node error (`spawn weird ENOENT /x ENOENT`) — a
+ *  non-WienerdogError whose message carries the marker. */
+const RAW_MARKER = 'weird ENOENT /x';
+const ROW1_REASON = 'job "dream" failed to run — see the log for details';
+
+test('scheduler-runjob: WP-151 T1 — a non-Wienerdog failure renders the code-owned row-1 reason; the raw message reaches NEITHER the durable alert NOR the email', async () => {
+  const { env, paths } = setup();
+  jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+  /** @type {string[]} */ const bodies = [];
+  const sendAlert = (_p, _n, _subject, body) => (bodies.push(body), { status: 0 });
+
+  await assert.rejects(
+    withRun(env, {}, ['dream'], {
+      resolveCommand: () => ({ command: RAW_MARKER, args: [], shell: false }),
+      sendAlert,
+      loader: noopLoader,
+    }),
+    (e) => e.message === ROW1_REASON || assert.fail(`rejected with "${e.message}" instead of the code-owned reason`)
+  );
+
+  assert.equal(jobsLib.readScheduleState(paths).dream.last_status, 'error');
+  const durable = readAlerts(paths);
+  assert.equal(durable.length, 1, 'one durable alert record');
+  assert.equal(durable[0].reason, ROW1_REASON, 'alert reason is exactly the row-1 template');
+  assert.ok(!JSON.stringify(durable[0]).includes(RAW_MARKER), 'raw message appears NOWHERE in the alert record');
+  assert.equal(bodies.length, 1, 'fail-loud email attempted');
+  assert.ok(!bodies[0].includes(RAW_MARKER), 'raw message appears NOWHERE in the email body');
+  assert.match(bodies[0], /failed to run — see the log for details/, 'email carries the code-owned reason');
+});
+
+test('scheduler-runjob: WP-151 T2 — the same run preserves the redacted raw cause in the per-run log', async () => {
+  const { env, paths } = setup();
+  jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+
+  await assert.rejects(
+    withRun(env, {}, ['dream'], {
+      resolveCommand: () => ({ command: RAW_MARKER, args: [], shell: false }),
+      sendAlert: () => ({ status: 0 }),
+      loader: noopLoader,
+    }),
+    (e) => e.message === ROW1_REASON
+  );
+
+  const logDir = path.join(paths.logs, 'dream');
+  const logs = fs.readdirSync(logDir).filter((f) => f.endsWith('.log'));
+  assert.equal(logs.length, 1, 'one per-run log file');
+  const log = fs.readFileSync(path.join(logDir, logs[0]), 'utf8');
+  assert.match(log, /wienerdog: job failed to run: /, 'the D2 diagnostic line is present');
+  assert.ok(log.includes(RAW_MARKER), 'the raw cause IS preserved locally, in the log');
+});
+
+test(
+  'scheduler-runjob: WP-151 T5 — a FAILED run with an un-reapable group keeps the R8-1 "— and it …" suffix',
+  { skip: REAP_SKIP_WIN32 },
+  async () => {
+    const { root, env, paths } = setup();
+    jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+    const fake = writeScript(root, 'fail.sh', ['#!/bin/sh', 'exit 3']);
+    // { reaped: false } across the bounded final escalation → reapFailure set.
+    const seams = reapSeams([{ reaped: false }, { reaped: false }]);
+    await assert.rejects(
+      withRun(env, {}, ['dream'], {
+        resolveCommand: fakeResolve(fake),
+        sendAlert: () => ({ status: 0 }),
+        loader: noopLoader,
+        reapTree: seams.reapTree,
+        reapGroup: seams.reapGroup,
+      }),
+      /exited 3 — and it left a live process group behind/
+    );
+    const durable = readAlerts(paths);
+    assert.equal(durable.length, 1);
+    assert.match(
+      durable[0].reason,
+      /^job "dream" exited 3 — and it left a live process group behind: /,
+      'the code-owned exit reason keeps the R8-1 suffix'
+    );
+    assert.match(durable[0].reason, /could not be reaped to quiescence/);
+  }
+);
+
+test('scheduler-runjob: WP-151 T7a — no log could be written: a seam-thrown raw EACCES renders the row-2 errno-token reason', async () => {
+  const { root, env, paths } = setup();
+  jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+  const fake = writeScript(root, 'ok.sh', ['#!/bin/sh', 'exit 0']);
+  /** @type {string[]} */ const bodies = [];
+  // A plain Error (NOT a WienerdogError) with a real errno token — the
+  // mkdirPrivate bare-mkdirSync shape (private-fs.js:250).
+  const boom = Object.assign(new Error('mkdir denied: /private/leaky path'), { code: 'EACCES' });
+  const expected = 'job "dream" failed to run (EACCES) — no log could be written';
+
+  await assert.rejects(
+    withRun(env, {}, ['dream'], {
+      resolveCommand: fakeResolve(fake),
+      mkdirPrivate: () => {
+        throw boom;
+      },
+      sendAlert: (_p, _n, _subject, body) => (bodies.push(body), { status: 0 }),
+      loader: noopLoader,
+    }),
+    (e) => e.message === expected || assert.fail(`rejected with "${e.message}"`)
+  );
+
+  assert.equal(jobsLib.readScheduleState(paths).dream.last_status, 'error');
+  const durable = readAlerts(paths);
+  assert.equal(durable.length, 1);
+  assert.equal(durable[0].reason, expected, 'alert reason is exactly the row-2 template with the validated token');
+  assert.ok(!JSON.stringify(durable[0]).includes('mkdir denied'), 'raw message not in the alert record');
+  assert.ok(!bodies[0].includes('mkdir denied'), 'raw message not in the email body');
+  assert.ok(!fs.existsSync(path.join(paths.logs, 'dream')), 'no log dir was created — "no log could be written" is true');
+});
+
+test('scheduler-runjob: WP-151 T7b — a hostile .code collapses to UNKNOWN, and a getter .code is read EXACTLY once', async () => {
+  const MARKER = 'HOSTILE-PROSE-MARKER-9000';
+  const UNKNOWN = 'job "dream" failed to run (UNKNOWN) — no log could be written';
+  /** Drive one run with mkdirPrivate throwing `err`; return {rejection, durable, bodies}. */
+  async function drive(err) {
+    const { root, env, paths } = setup();
+    jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+    const fake = writeScript(root, 'ok.sh', ['#!/bin/sh', 'exit 0']);
+    /** @type {string[]} */ const bodies = [];
+    /** @type {Error|undefined} */ let rejection;
+    await assert.rejects(
+      withRun(env, {}, ['dream'], {
+        resolveCommand: fakeResolve(fake),
+        mkdirPrivate: () => {
+          throw err;
+        },
+        sendAlert: (_p, _n, _subject, body) => (bodies.push(body), { status: 0 }),
+        loader: noopLoader,
+      }),
+      (e) => ((rejection = e), true)
+    );
+    return { rejection, durable: readAlerts(paths), bodies };
+  }
+
+  // Three TOKEN_OK-failing shapes: prose string, number, absent.
+  const throwables = [
+    Object.assign(new Error(`boom ${MARKER}`), { code: `long prose ${MARKER} that fails TOKEN_OK` }),
+    Object.assign(new Error(`boom ${MARKER}`), { code: 13 }),
+    new Error(`boom ${MARKER}`),
+  ];
+  for (const err of throwables) {
+    const { rejection, durable, bodies } = await drive(err);
+    assert.equal(rejection && rejection.message, UNKNOWN, 'rejects with the fixed UNKNOWN literal');
+    assert.equal(durable.length, 1);
+    assert.equal(durable[0].reason, UNKNOWN, 'alert reason is exactly the UNKNOWN literal');
+    assert.ok(!JSON.stringify(durable[0]).includes(MARKER), 'hostile value appears NOWHERE in the alert record');
+    assert.ok(!bodies[0].includes(MARKER), 'hostile value appears NOWHERE in the email body');
+  }
+
+  // N2 — the getter exploit: first read returns a valid token, every later read
+  // returns prose. Only a single-read implementation renders the EACCES form
+  // with no prose anywhere; validate-then-re-read leaks the marker.
+  let reads = 0;
+  const getterErr = new Error(`boom ${MARKER}`);
+  Object.defineProperty(getterErr, 'code', {
+    get() {
+      reads += 1;
+      return reads === 1 ? 'EACCES' : `EVIL ${MARKER}`;
+    },
+  });
+  const { rejection, durable, bodies } = await drive(getterErr);
+  assert.equal(
+    rejection && rejection.message,
+    'job "dream" failed to run (EACCES) — no log could be written',
+    'the FIRST (validated) read is what renders'
+  );
+  assert.equal(durable[0].reason, 'job "dream" failed to run (EACCES) — no log could be written');
+  assert.ok(!JSON.stringify(durable[0]).includes(MARKER), 'the getter never got a second read into the alert');
+  assert.ok(!bodies[0].includes(MARKER), 'the getter never got a second read into the email');
+});
+
+test(
+  'scheduler-runjob: WP-151 T7c — a REAL EACCES (chmod 0500 logs parent) renders the same row-2 reason — the seam is not the only evidence',
+  { skip: SKIP_NO_EACCES },
+  async () => {
+    const { root, env, paths } = setup();
+    jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+    const fake = writeScript(root, 'ok.sh', ['#!/bin/sh', 'exit 0']);
+    const expected = 'job "dream" failed to run (EACCES) — no log could be written';
+    fs.chmodSync(paths.logs, 0o500); // read+exec only → the REAL mkdirPrivate raises a genuine EACCES
+    try {
+      await assert.rejects(
+        withRun(env, {}, ['dream'], {
+          resolveCommand: fakeResolve(fake),
+          sendAlert: () => ({ status: 0 }),
+          loader: noopLoader,
+        }),
+        (e) => e.message === expected || assert.fail(`rejected with "${e.message}"`)
+      );
+      const durable = readAlerts(paths);
+      assert.equal(durable.length, 1);
+      assert.equal(durable[0].reason, expected, 'a genuine errno takes the identical row-2 rendering');
+    } finally {
+      fs.chmodSync(paths.logs, 0o700);
+    }
+  }
+);
+
+test('scheduler-runjob: WP-151 T8a — a stream error during FINALIZATION does not mask the failure (watermark + alert + email + code-owned throw)', async () => {
+  const { root, env, paths } = setup();
+  jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+  const fake = writeScript(root, 'fail.sh', ['#!/bin/sh', 'exit 3']);
+  const stub = errorThenCallbackStub({ errorOnEnd: Object.assign(new Error('I/O error on close'), { code: 'EIO' }) });
+  /** @type {string[]} */ const alerts = [];
+
+  await assert.rejects(
+    withRun(env, {}, ['dream'], {
+      resolveCommand: fakeResolve(fake),
+      createLogStream: () => stub,
+      sendAlert: (_p, _n, subject) => (alerts.push(subject), { status: 0 }),
+      loader: noopLoader,
+    }),
+    (e) => e.message === 'job "dream" exited 3' || assert.fail(`rejected with "${e.message}" — the stream error masked the failure`)
+  );
+
+  assert.ok(stub.errored, 'the stub really emitted its error (a lenient stub proves nothing)');
+  assert.equal(jobsLib.readScheduleState(paths).dream.last_status, 'error', 'error watermark still written');
+  const durable = readAlerts(paths);
+  assert.equal(durable.length, 1, 'one durable alerts.jsonl record');
+  assert.equal(durable[0].reason, 'job "dream" exited 3');
+  assert.deepEqual(alerts, ['job dream failed'], 'the fail-loud email still fired');
+});
+
+test('scheduler-runjob: WP-151 T8b — a stream error during the TEE (child still running, D5) does not take the process down or mask the failure', async () => {
+  const { root, env, paths } = setup();
+  jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+  const fake = writeScript(root, 'chatty-fail.sh', ['#!/bin/sh', 'echo mid-run output', 'exit 3']);
+  const stub = errorThenCallbackStub({ errorOnWrite: Object.assign(new Error('no space left on device'), { code: 'ENOSPC' }) });
+  /** @type {string[]} */ const alerts = [];
+
+  await assert.rejects(
+    withRun(env, {}, ['dream'], {
+      resolveCommand: fakeResolve(fake),
+      createLogStream: () => stub,
+      sendAlert: (_p, _n, subject) => (alerts.push(subject), { status: 0 }),
+      loader: noopLoader,
+    }),
+    (e) => e.message === 'job "dream" exited 3' || assert.fail(`rejected with "${e.message}" — the tee-window error masked the failure`)
+  );
+
+  assert.ok(stub.errored, 'the tee write really triggered the stream error');
+  assert.equal(jobsLib.readScheduleState(paths).dream.last_status, 'error', 'error watermark still written');
+  const durable = readAlerts(paths);
+  assert.equal(durable.length, 1, 'one durable alerts.jsonl record');
+  assert.equal(durable[0].reason, 'job "dream" exited 3', 'the failure-path reason is unchanged by the log degradation (Table R rows 1-3 key on the stream, not the flag)');
+  assert.deepEqual(alerts, ['job dream failed'], 'the fail-loud email still fired');
+});
+
+test(
+  'scheduler-runjob: WP-151 T9 row A — endStream settles on a destroyed stream (destroyed only, no callback, no events)',
+  { timeout: 5000 },
+  async () => {
+    const { root, env, paths } = setup();
+    jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+    const fake = writeScript(root, 'fail.sh', ['#!/bin/sh', 'exit 3']);
+    const stub = destroyedNoCallbackStub({ closed: false }); // Table S row A
+
+    await assert.rejects(
+      withRun(env, {}, ['dream'], {
+        resolveCommand: fakeResolve(fake),
+        createLogStream: () => stub,
+        sendAlert: () => ({ status: 0 }),
+        loader: noopLoader,
+      }),
+      (e) => e.message === 'job "dream" exited 3'
+    );
+    assert.equal(jobsLib.readScheduleState(paths).dream.last_status, 'error', 'the failure path completed — no hang');
+  }
+);
+
+test(
+  'scheduler-runjob: WP-151 T9 row B — endStream settles on destroyed AND closed (the state ONLY the synchronous already-settled check catches)',
+  { timeout: 5000 },
+  async () => {
+    // Row B is the discriminating case: 'close' has already fired before
+    // endStream attaches listeners, so a listener-only endStream hangs here.
+    const { root, env, paths } = setup();
+    jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+    const fake = writeScript(root, 'fail.sh', ['#!/bin/sh', 'exit 3']);
+    const stub = destroyedNoCallbackStub({ closed: true }); // Table S row B
+
+    await assert.rejects(
+      withRun(env, {}, ['dream'], {
+        resolveCommand: fakeResolve(fake),
+        createLogStream: () => stub,
+        sendAlert: () => ({ status: 0 }),
+        loader: noopLoader,
+      }),
+      (e) => e.message === 'job "dream" exited 3'
+    );
+    assert.equal(jobsLib.readScheduleState(paths).dream.last_status, 'error', 'the failure path completed — no hang');
+  }
+);
+
+test('scheduler-runjob: WP-151 T10 — a clean exit whose log stream errored is NOT certified clean (Table R row 4), and does not THROW getting there', async () => {
+  /** Drive one clean-exit run whose stub stream errors on the first tee write.
+   *  reapFailure === null is the whole point of the fixture: pre-D6 this state
+   *  could never reach the fail-loud reason, so without D1's :1007 null guard it
+   *  throws TypeError instead of rendering row 4. */
+  async function drive(codeVal) {
+    const { root, env, paths } = setup();
+    jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+    const fake = writeScript(root, 'chatty-ok.sh', ['#!/bin/sh', 'echo mid-run output', 'exit 0']);
+    const err = new Error('tee write failed mid-run');
+    if (codeVal !== undefined) err.code = codeVal;
+    const stub = errorThenCallbackStub({ errorOnWrite: err });
+    const seams = reapSeams(); // every reap { reaped: true } → reapFailure === null
+    /** @type {string[]} */ const bodies = [];
+    /** @type {Error|undefined} */ let rejection;
+    await assert.rejects(
+      withRun(env, {}, ['dream'], {
+        resolveCommand: fakeResolve(fake),
+        createLogStream: () => stub,
+        reapTree: seams.reapTree,
+        reapGroup: seams.reapGroup,
+        sendAlert: (_p, _n, _subject, body) => (bodies.push(body), { status: 0 }),
+        loader: noopLoader,
+      }),
+      (e) => ((rejection = e), true),
+      'the run must reject — a silent ok is the D6 red direction'
+    );
+    assert.ok(stub.errored, 'the tee write really triggered the stream error');
+    return { paths, rejection, durable: readAlerts(paths), bodies };
+  }
+
+  for (const [codeVal, token] of [['EIO', 'EIO'], ['ENOSPC', 'ENOSPC'], ['not an errno!!', 'UNKNOWN'], [undefined, 'UNKNOWN']]) {
+    const { paths, rejection, durable, bodies } = await drive(codeVal);
+    const expected = `job "dream" ran but its log could not be written (${token})`;
+    assert.ok(!(rejection instanceof TypeError), `no TypeError — got "${rejection}"`);
+    assert.equal(rejection && rejection.message, expected, 'rejects with the row-4 reason, not a TypeError');
+    const state = jobsLib.readScheduleState(paths).dream;
+    assert.equal(state.last_status, 'error', 'last_status is error, NOT ok');
+    assert.ok(!state.last_success, 'the success block (last_success + clearAlerts) did not run');
+    assert.equal(durable.length, 1, 'one durable alert — clearAlerts did not run');
+    assert.equal(durable[0].reason, expected, 'durable reason is exactly the row-4 template');
+    assert.equal(bodies.length, 1, 'the sendAlert stub was called');
+    assert.match(bodies[0], /ran but its log could not be written/, 'email carries the row-4 reason');
+  }
 });


### PR DESCRIPTION
Spec: docs/specs/WP-151-self-alert-code-owned-body.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
      (`src/cli/run-job.js`, `tests/unit/scheduler-runjob.test.js`, plus the
      always-allowed spec file itself for the status flip)
- [x] Spec status flipped to In-Review

## Re-verification record

Dispatch-time re-verification satisfied at `b3a53bc` — src/, bin/, tests/
byte-identical to `e7c845e`, the SHA all spec claims were verified against
across the ten-round gate closed 2026-08-02. Confirmed locally before work:
`git diff e7c845e b3a53bc --stat -- src/ bin/ tests/` → empty.

## What changed

- **D1** — the non-WienerdogError arm of the failure `reason` now renders
  `noLogReason(name, failure, logStream)` (Table R rows 1-3) instead of
  interpolating the raw `failure.message`; the clean-exit arm is wrapped in a
  `reapFailure ?` guard whose else-arm is `logFailedReason(name,
  logStreamErrCode)` (Table R row 4). The `reason +=` R8-1 mutation and its
  text are untouched. `TOKEN_OK = /^[A-Z][A-Z0-9]{1,15}$/` (fully anchored, no
  flags); `failure.code` is bound exactly once (`const C = failure &&
  failure.code;`) and only the validated binding is interpolated, only after
  `typeof C === 'string'`.
- **D2** — the redacted raw cause is written through the still-open private
  `logStream` inside the existing `finally`, before `endStream`, guarded
  `failure && !(failure instanceof WienerdogError)`, write in a `try`.
- **D3** — `endStream` rewritten to settle in every Table S state:
  synchronous `destroyed || closed` check FIRST (explicitly not the
  writable-ended flag), `error` + `close` listeners attached before `end(cb)`,
  idempotent `finish`, never rejects.
- **D4** — two opts-only test seams in the WP-155 idiom, declared beside
  `const logDir` (before the `try` that uses them): `opts.mkdirPrivate ||
  mkdirPrivate`, `opts.createLogStream || createLogStreamPrivate`. Never env,
  no exports, "production never sets them" comment included.
- **D5** — a no-throw `'error'` listener attached at stream creation records
  `logStreamFailed` + `logStreamErrCode` (single read off the event argument)
  — covers the tee window as well as finalization.
- **D6** — the success condition gains `&& !logStreamFailed`, so a clean exit
  whose log degraded falls through to fail-loud and renders row 4.

Tests added (all in `tests/unit/scheduler-runjob.test.js`): T1, T2, T5's
suffix half (`{ skip: REAP_SKIP_WIN32 }`), T7a, T7b (incl. the N2 getter
single-read detector), T7c (`{ skip: SKIP_NO_EACCES }` — win32 AND root),
T8a/T8b (family-1 error-then-callback stub, both windows), T9 rows A and B
(family-2 destroyed-no-callback stub, each `{ timeout: 5000 }`), T10 (row 4,
`reapFailure === null` fixture, EIO/ENOSPC/UNKNOWN token cases). T3/T4 and
T5's clean-exit half are existing guards, left unmodified and still green.

## Verification output

### V1 — the suite this WP touches (baseline at e7c845e: 63/63)

```
$ node tests/run.js tests/unit/scheduler-runjob.test.js
ℹ tests 74
ℹ pass 74
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
```

### AC1 — T1 red against the untouched `:1004`, green after

Red (src at b3a53bc, tests present):

```
✖ scheduler-runjob: WP-151 T1 — a non-Wienerdog failure renders the code-owned row-1 reason; ...
  AssertionError [ERR_ASSERTION]: rejected with "job "dream" failed: spawn weird ENOENT /x ENOENT"
  instead of the code-owned reason
ℹ tests 1  ℹ pass 0  ℹ fail 1
```

Green (finished tree): included in V1's 74/74 above.

### AC7 — T8 red against the untouched endStream/tee (state: b3a53bc + D4 seams only), green after

T8a red — the finalization-window stream error masks the failure (escapes the
`finally` before the watermark and `failLoud`):

```
✖ scheduler-runjob: WP-151 T8a — a stream error during FINALIZATION does not mask the failure ...
  AssertionError [ERR_ASSERTION]: rejected with "I/O error on close" — the stream error masked the failure
ℹ tests 1  ℹ pass 0  ℹ fail 1
```

T8b red — the tee-window error surfaces as the raw uncaught stream error in
place of the failure outcome (pre-D5 this is an unhandled 'error' that takes
the process down mid-run):

```
✖ scheduler-runjob: WP-151 T8b — a stream error during the TEE (child still running, D5) ...
  Error: no space left on device
ℹ tests 1  ℹ pass 0  ℹ fail 1
```

Green (finished tree): both included in V1's 74/74 above.

### AC7b — T9 red (same seams-only state): rows A and B HANG; `{ timeout: 5000 }` fails instead of wedging

```
✖ scheduler-runjob: WP-151 T9 row A — endStream settles on a destroyed stream ... (5006.35ms)
  'test timed out after 5000ms'
✖ scheduler-runjob: WP-151 T9 row B — endStream settles on destroyed AND closed ... (5001.83ms)
  'test timed out after 5000ms'
ℹ tests 2  ℹ pass 0  ℹ fail 0  ℹ cancelled 2
```

### AC7c — T10, BOTH red directions

Red direction 1 — full implementation minus only the `:979` gate → silent ok:

```
✖ scheduler-runjob: WP-151 T10 — a clean exit whose log stream errored is NOT certified clean ...
  AssertionError [ERR_ASSERTION]: Missing expected rejection: the run must reject — a silent ok is the D6 red direction
```

Red direction 2 — gate present but the `:1007` null guard removed → TypeError
before the watermark:

```
✖ scheduler-runjob: WP-151 T10 — a clean exit whose log stream errored is NOT certified clean ...
  AssertionError [ERR_ASSERTION]: no TypeError — got "TypeError: Cannot read properties of null (reading 'reason')"
```

Green (finished tree): included in V1's 74/74 above.

### AC6 red (seams-only state) — T7a/T7b before noLogReason existed

```
✖ WP-151 T7a ... AssertionError: rejected with "job "dream" failed: mkdir denied: /private/leaky path"
✖ WP-151 T7b ... + actual - expected
  + 'job "dream" failed: boom HOSTILE-PROSE-MARKER-9000'
  - 'job "dream" failed to run (UNKNOWN) — no log could be written'
```

### V2 — the free-form hole is gone (expect no output, exit 1)

```
$ grep -n 'failed: \${failure.message}' src/cli/run-job.js
exit=1
```

(Baseline at b3a53bc printed `1004:      : `job "${name}" failed: ${failure.message}``, exit 0.)

### V3 — R8-1 arms, boolean return, .trim() survived (all five lines)

```
624:    const body = `${reason}\n\nDetails: ${logHint}`.trim();
633:  return persisted;
1088:        ? `job "${name}" ${reapFailure.reason}`
1091:    reason += ` — and it ${reapFailure.reason}`;
1097:  const alertPersisted = await failLoud(paths, name, reason, opts);
```

### V4 — detail through the stream, no appendFileSync

```
$ grep -n "logStream.write" src/cli/run-job.js
934:        logStream.write(redactOnly(chunk.toString('utf8')));
939:        logStream.write(redactOnly(chunk.toString('utf8')));
999:          logStream.write(redactOnly(`\nwienerdog: job failed to run: ${failure && failure.message}\n`));
$ grep -n "appendFileSync" src/cli/run-job.js
exit=1
```

### V5 — endStream absorbs stream errors, no reject anywhere

```
function endStream(stream) {
  return new Promise((resolve) => {
    let done = false;
    const finish = () => { if (!done) { done = true; resolve(); } };
    // 1. ALREADY-SETTLED CHECK, FIRST. A stream destroyed on an earlier tick has
    //    already emitted 'close', so a listener attached now never fires. The
    //    check is destroyed/closed ONLY — the ended flag goes true at the end()
    //    CALL, before the flush, so keying on it would truncate a healthy buffer.
    if (stream.destroyed || stream.closed) return finish();
    // 2. BOTH terminal events, attached before end() (end() can emit synchronously).
    stream.on('error', finish);
    stream.on('close', finish);
    try {
      stream.end(finish);
    } catch {
      finish();
    }
  });
}
```

### V6 — TOKEN_OK present, fully anchored, no `m` flag (exactly one line)

```
95:const TOKEN_OK = /^[A-Z][A-Z0-9]{1,15}$/;
```

### V7 — the seams are opts-only and default to the real helpers

```
$ grep -n "opts.mkdirPrivate\|opts.createLogStream" src/cli/run-job.js
884:  const mkdirFn = opts.mkdirPrivate || mkdirPrivate;
885:  const openLogFn = opts.createLogStream || createLogStreamPrivate;
$ grep -n -A 3 "opts.mkdirPrivate\|opts.createLogStream" src/cli/run-job.js | grep "process\.env"
exit=1   (absence check — passing)
```

### V8 — the tee window is covered at creation

```
910:    logStream.on('error', (err) => {
```

### V9 — settled check + close listener present; writableEnded ABSENT

```
$ sed -n "/^function endStream/,/^}/p" src/cli/run-job.js | grep -E "destroyed|closed|'close'"
    // 1. ALREADY-SETTLED CHECK, FIRST. A stream destroyed on an earlier tick has
    //    already emitted 'close', so a listener attached now never fires. The
    //    check is destroyed/closed ONLY — the ended flag goes true at the end()
    if (stream.destroyed || stream.closed) return finish();
    stream.on('close', finish);
$ sed -n "/^function endStream/,/^}/p" src/cli/run-job.js | grep -c "writableEnded"
0   (absence check — passing)
```

### V10 — the success path is gated AND the clean-exit arm is null-guarded

```
$ grep -n "code === 0 && !reapFailure" src/cli/run-job.js
1059:  if (!failure && code === 0 && !reapFailure && !logStreamFailed) {
$ grep -c "logFailedReason" src/cli/run-job.js
2   (definition + the row-4 call site — present, PASS)
```

### V11 — full gates

```
$ npm test
ℹ tests 1836
ℹ pass 1831
ℹ fail 0
ℹ cancelled 0
ℹ skipped 5    (pre-existing platform skips)

$ npm run lint
--- markdownlint ---  Summary: 0 error(s)
--- shellcheck ---
--- PSScriptAnalyzer ---
--- frontmatter check ---  frontmatter check passed: 209 spec(s), 4 agent(s)
lint passed
```

## Decisions made

- **Branch name**: the dispatch message said `wp/self-alert-code-owned-body`;
  the spec frontmatter and Definition of done both say
  `wp/151-self-alert-code-owned-body`. Followed the spec.
- **T1/T2 fixture mechanics**: a child's spawn 'error' message is
  Node-authored, and D4 deliberately adds no spawn seam — so the test resolves
  the command to the literal nonexistent path `weird ENOENT /x`, making the
  raw message `spawn weird ENOENT /x ENOENT` (a plain Node Error carrying the
  spec's marker). T1 asserts the marker appears nowhere in the alert record or
  the email body; T2 asserts the log contains the D2 line prefix
  (`wienerdog: job failed to run: `) and the embedded marker.
- **T9 shape**: written as two tests (row A, row B), each with
  `{ timeout: 5000 }`, rather than one looped test — per-row diagnosability;
  row B is labeled as the discriminating case.
- **D3 comment wording**: the in-body comment explains why the ended flag is
  excluded without using the literal token, so V9's absence check stays a
  meaningful tripwire rather than matching documentation.
- **JSDoc**: the two seams were added to `runJob`'s opts typedef alongside the
  existing `reapTree`/`reapGroup` seam entries (type-consistency with the
  WP-155 idiom being mirrored; not API documentation — no export, no docs).
- **T10 red direction 1 state**: demonstrated against the full implementation
  minus only the `:979` gate (D5 present), because without D5 the tee error
  crashes before the gate is ever reachable; the seams-only state's T10
  failure (raw uncaught `Error` in place of the outcome) was also observed.

## Discovered issues (out of scope, not fixed)

- **`WP-mkdir-private-errno-wrap`** — `mkdirPrivate`'s bare
  `fs.mkdirSync(dir, { recursive: true, mode: 0o700 })` at
  `src/core/private-fs.js:250` raises a raw Node `Error` (EACCES/ENOSPC/EROFS)
  rather than a `WienerdogError`; it is the sole source of the lossy no-log
  path Table R rows 2-3 now bound. Wrapping it at the source is routed, not
  fixed here (file not in this WP's Deliverables; every other caller would
  inherit the change).

## Lessons (memory dogfooding)

- WP-151: `node:test`'s `{ timeout }` marks a hung test **cancelled**, not
  failed — `fail 0, cancelled 2` is what a red hang looks like; grep for
  cancelled too when hunting red evidence.
- WP-151: an absence-check verification (V9's `writableEnded` grep) can be
  tripped by your own explanatory comment — word comments so the forbidden
  token stays greppably absent.
- WP-151: a child's spawn-ENOENT message is Node-authored; to plant a marker
  in a non-Wienerdog failure without adding a spawn seam, put the marker in
  the nonexistent command path itself.

---
Generated-by: Claude Fable 5 (claude-fable-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG6TJhQS9RTaNKgHKhXmc8
