### PR TITLE
fix(manifest): make the symlink reverser target-aware (WP-153)

### DIFF
--- a/docs/specs/WP-153-target-aware-symlink-reverser.md
+++ b/docs/specs/WP-153-target-aware-symlink-reverser.md
@@ -1,7 +1,7 @@
 ---
 id: WP-153
 title: Make the manifest symlink reverser target-aware so uninstall never deletes a user's replacement link
-status: Ready
+status: In-Review
 model: opus
 size: S
 depends_on: [WP-144, WP-147]

--- a/src/adapters/shared.js
+++ b/src/adapters/shared.js
@@ -431,7 +431,7 @@ function applySkillLinks(skillsDir, targetSkillsDir, dryRun, manifest, out, opts
       }
       if (currentTarget === target) {
         out.unchanged.push(linkPath);
-        recordOnce(manifest, { kind: 'symlink', path: linkPath });
+        recordOnce(manifest, { kind: 'symlink', path: linkPath, target });
       } else {
         // A wienerdog-* symlink whose target is NOT our core skill source — a user's
         // own link, or a stale one from another install root. Never silently clobber
@@ -482,13 +482,13 @@ function applySkillLinks(skillsDir, targetSkillsDir, dryRun, manifest, out, opts
       out.notices.push(`left user file untouched: ${linkPath}`);
     } else if (dryRun) {
       // A dry run does not probe symlink permission; report the common case.
-      recordOnce(manifest, { kind: 'symlink', path: linkPath });
+      recordOnce(manifest, { kind: 'symlink', path: linkPath, target });
       out.changed.push(linkPath);
     } else {
       // Absent: prefer a symlink; copy where symlink creation is unpermitted.
       try {
         symlink(target, linkPath);
-        recordOnce(manifest, { kind: 'symlink', path: linkPath });
+        recordOnce(manifest, { kind: 'symlink', path: linkPath, target });
       } catch (err) {
         if (err && (err.code === 'EPERM' || err.code === 'EACCES')) {
           fs.cpSync(target, linkPath, { recursive: true });

--- a/src/core/manifest.js
+++ b/src/core/manifest.js
@@ -14,7 +14,10 @@ const { WienerdogError } = require('./errors');
  * user modifications on uninstall.
  *
  * Adapters add three more kinds (WP-006), each with precise reverse semantics:
- *   {kind:'symlink', path}                          — a symlink we created
+ *   {kind:'symlink', path, target?}                 — a symlink we created;
+ *                                                     `target` is the source it
+ *                                                     must still resolve to
+ *                                                     (absent on legacy entries)
  *   {kind:'managed-block', path, createdFile:bool,
  *    sepBefore?:string, sepAfter?:string}           — a sentinel block we wrote
  *                                                     into a (maybe user-owned) file;
@@ -154,20 +157,63 @@ function isSymlink(p) {
 }
 
 /**
- * Reverse a 'symlink' entry: unlink only if it is still a symlink we created.
- * @param {ManifestEntry} entry
+ * Reverse a 'symlink' entry: unlink ONLY when the link still resolves to the
+ * source we recorded. A legacy (target-less) entry and a target mismatch are
+ * both PRESERVED and reported as skipped — never unlinked.
+ * @param {ManifestEntry} entry  {kind:'symlink', path, target?}
  * @param {boolean} dryRun
  * @param {string[]} removed @param {string[]} skipped @param {Set<string>} removedSet
+ * @param {string[]} skillsRoots the harness skills roots (row 4 OWNED gate)
  */
-function reverseSymlink(entry, dryRun, removed, skipped, removedSet) {
-  if (!isSymlink(entry.path)) {
-    // User replaced it with a real file/dir, or it is already gone.
-    skipped.push(entry.path);
+function reverseSymlink(entry, dryRun, removed, skipped, removedSet, skillsRoots) {
+  const L = entry.path;
+  const T = entry.target;
+  // Row 1: not a symlink (real file/dir, or already gone) — never ours to delete.
+  if (!isSymlink(L)) {
+    skipped.push(L);
     return;
   }
-  if (!dryRun) fs.unlinkSync(entry.path);
-  removedSet.add(entry.path);
-  removed.push(entry.path);
+  // Row 2: LEGACY (target-less) entry — ownership is unprovable, preserve
+  // unconditionally (owner ruling 2026-08-01). No backfill exists or ever will.
+  if (typeof T !== 'string' || T === '') {
+    process.stderr.write(
+      `wienerdog: keeping ${L} — not the Wienerdog skill link we recorded (replaced, or unverifiable)\n`
+    );
+    skipped.push(L);
+    return;
+  }
+  // Row 3: the link no longer resolves to the source we recorded. Realpath first
+  // (semantic, follows the link); lexical fallback for the one reachable case
+  // where the core was deleted by hand so realpath(T) throws. Both fail-closed.
+  let lexicalMatch = false;
+  try {
+    lexicalMatch = fs.readlinkSync(L) === T;
+  } catch {
+    lexicalMatch = false;
+  }
+  if (!sameResolvedDir(L, T) && !lexicalMatch) {
+    process.stderr.write(
+      `wienerdog: keeping ${L} — not the Wienerdog skill link we recorded (replaced, or unverifiable)\n`
+    );
+    skipped.push(L);
+    return;
+  }
+  // Row 4: a target match is NOT delete authority — the manifest is untrusted, so
+  // an attacker can forge a (path, target) pair. Require the STRUCTURAL ownership
+  // proof reverseCopiedSkill uses: wienerdog-* basename AND parent realpath-equal
+  // to a harness skills root.
+  const parentIsRoot = skillsRoots.some((root) => sameResolvedDir(path.dirname(L), root));
+  if (!path.basename(L).startsWith('wienerdog-') || !parentIsRoot) {
+    process.stderr.write(
+      `wienerdog: keeping ${L} — not the Wienerdog skill link we recorded (replaced, or unverifiable)\n`
+    );
+    skipped.push(L);
+    return;
+  }
+  // Row 5: OWNED, in-namespace, and provably resolves to our recorded source.
+  if (!dryRun) fs.unlinkSync(L);
+  removedSet.add(L);
+  removed.push(L);
 }
 
 /**
@@ -779,7 +825,7 @@ function reverse(paths, manifest, { dryRun = false } = {}) {
           skipped.push(entry.path);
           continue;
         }
-        reverseSymlink(entry, dryRun, removed, skipped, removedSet);
+        reverseSymlink(entry, dryRun, removed, skipped, removedSet, skillsRoots);
       } else if (entry.kind === 'managed-block' || entry.kind === 'settings-entry') {
         // F30: canonicalize the PARENT, then open the final component with
         // O_NOFOLLOW so a symlink at the recorded path (a swap-to-symlink)
@@ -859,7 +905,7 @@ function reverse(paths, manifest, { dryRun = false } = {}) {
 const ENTRY_FIELD_TYPES = {
   file: { hash: 'string' },
   dir: {},
-  symlink: {},
+  symlink: { target: 'string' },
   // sepBefore/sepAfter (WP-147) are deliberately NOT type-gated here: a non-string
   // forgery must reach reverseManagedBlock so its SEP_BEFORE_OK allowlist degrades
   // to the legacy conservative strip and still removes the block (Table M:
@@ -1013,4 +1059,4 @@ function disposeCoreMechanics(paths, { dryRun = false, vaultPath = null } = {}) 
   return { removed, skippedForVault };
 }
 
-module.exports = { load, record, save, reverse, disposeCoreMechanics, reverseSchedulerEntry, reverseVendoredTree, reverseCopiedSkill, hashDir, sha256File, validateEntry, withinAllowedRoot, withinSchedulerRoot };
+module.exports = { load, record, save, reverse, disposeCoreMechanics, reverseSchedulerEntry, reverseVendoredTree, reverseCopiedSkill, reverseSymlink, hashDir, sha256File, validateEntry, withinAllowedRoot, withinSchedulerRoot };

--- a/tests/unit/manifest.test.js
+++ b/tests/unit/manifest.test.js
@@ -297,11 +297,17 @@ test('global guard (ii): a {kind:scheduler-entry, path: manifest} entry never rm
 test('global guard (iii): a {kind:symlink} whose path resolves to a deferred member is never unlinked', () => {
   const paths = tempPaths();
   const manifest = makeInstall(paths);
-  // A symlink (inside the core) pointing at the manifest ledger. Without the
-  // realpath-aware guard, reverseSymlink would unlink it.
-  const link = path.join(paths.core, 'ledger-link');
+  // An OWNED, target-matched skill link (wienerdog-* directly under a harness
+  // skills root) pointing at the manifest ledger. It reaches Table A row 5 —
+  // OWNED (row 4) and readlink === target (row 3) — so the deferred-member guard
+  // is the ONLY thing between it and fs.unlinkSync. (A <core>/ledger-link fixture
+  // would be doubly vacuous under WP-153: preserved by row 2 as legacy AND by
+  // row 4 for not being OWNED, so the guard could never be shown to matter.)
+  const skillsRoot = path.join(paths.claudeDir, 'skills');
+  fs.mkdirSync(skillsRoot, { recursive: true });
+  const link = path.join(skillsRoot, 'wienerdog-ledger');
   fs.symlinkSync(paths.manifest, link);
-  manifestLib.record(manifest, { kind: 'symlink', path: link });
+  manifestLib.record(manifest, { kind: 'symlink', path: link, target: paths.manifest });
   manifestLib.save(paths, manifest);
   const reloaded = manifestLib.load(paths);
   const { removed, skipped } = manifestLib.reverse(paths, reloaded, {});
@@ -1471,5 +1477,150 @@ test('WP-147 T12 (AC14): non-string separator metadata still strips the block, n
     assert.equal(final, 'lineA\nlineB\n', `${label}: legacy conservative strip, no user text touched`);
     assert.ok(res.removed.includes(md), `${label}: block still removed (entry NOT rejected upstream)`);
     assert.match(err, /ignoring out-of-vocabulary separator metadata/, `${label}: the stderr notice fires`);
+  }
+});
+
+// ── WP-153: target-aware symlink reverser (audit A13 follow-up) ───────────────
+// reverseSymlink now unlinks ONLY a link it can prove Wienerdog owns (Table A):
+// row 2 legacy (target-less) → preserve; row 3 target mismatch → preserve;
+// row 4 not-OWNED (wienerdog-* directly under a harness skills root) → preserve;
+// row 5 OWNED + resolves to the recorded source → unlink. OWNED fixtures live at
+// `<claudeDir>/skills/wienerdog-<name>` (a harness skills root); their symlink
+// destinations sit inside `claudeDir` so reverse()'s withinAllowedRoot gate
+// (which realpaths — i.e. follows — the link) passes and the red baseline is
+// obtainable.
+
+test('reverseSymlink: a user replacement link (target mismatch) survives uninstall — Table A row 3 (T1)', (t) => {
+  if (!isPosix) return t.skip('symlink creation may be unavailable');
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  const skillsRoot = path.join(paths.claudeDir, 'skills');
+  fs.mkdirSync(skillsRoot, { recursive: true });
+  const recordedSource = path.join(paths.claudeDir, 'core-skills', 'wienerdog-foo');
+  fs.mkdirSync(recordedSource, { recursive: true });
+  // The user replaced our link with their own wienerdog-foo symlink to their dir.
+  const userDir = path.join(paths.claudeDir, 'my-notes');
+  fs.mkdirSync(userDir, { recursive: true });
+  const link = path.join(skillsRoot, 'wienerdog-foo');
+  fs.symlinkSync(userDir, link);
+  manifestLib.record(manifest, { kind: 'symlink', path: link, target: recordedSource });
+  manifestLib.save(paths, manifest);
+  const { removed, skipped } = manifestLib.reverse(paths, manifestLib.load(paths), {});
+  assert.equal(fs.lstatSync(link).isSymbolicLink(), true, "the user's replacement link is not unlinked");
+  assert.equal(fs.readlinkSync(link), userDir, "the user's link target is unchanged");
+  assert.ok(!removed.includes(link));
+  assert.ok(skipped.includes(link));
+});
+
+test('reverseSymlink: our own unmodified link is removed, in real and dry-run mode — Table A row 5 (T2)', (t) => {
+  if (!isPosix) return t.skip('symlink creation may be unavailable');
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  const skillsRoot = path.join(paths.claudeDir, 'skills'); // OWNED location — required
+  fs.mkdirSync(skillsRoot, { recursive: true });
+  const source = path.join(paths.claudeDir, 'core-skills', 'wienerdog-foo');
+  fs.mkdirSync(source, { recursive: true });
+  const link = path.join(skillsRoot, 'wienerdog-foo');
+  fs.symlinkSync(source, link);
+  manifestLib.record(manifest, { kind: 'symlink', path: link, target: source });
+  manifestLib.save(paths, manifest);
+  // dry-run first: reports it as removed but leaves it on disk.
+  const dry = manifestLib.reverse(paths, manifestLib.load(paths), { dryRun: true });
+  assert.equal(fs.lstatSync(link).isSymbolicLink(), true, 'dry-run does not unlink');
+  assert.ok(dry.removed.includes(link), 'dry-run still reports it in removed');
+  // real: unlinks it.
+  const real = manifestLib.reverse(paths, manifestLib.load(paths), {});
+  assert.equal(fs.existsSync(link), false, 'our own link is removed');
+  assert.ok(real.removed.includes(link));
+});
+
+test('reverseSymlink: a legacy (target-less) entry is preserved whatever it points at — Table A row 2 (T3)', (t) => {
+  if (!isPosix) return t.skip('symlink creation may be unavailable');
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  const skillsRoot = path.join(paths.claudeDir, 'skills');
+  fs.mkdirSync(skillsRoot, { recursive: true });
+  const source = path.join(paths.claudeDir, 'core-skills', 'wienerdog-a');
+  const other = path.join(paths.claudeDir, 'elsewhere');
+  fs.mkdirSync(source, { recursive: true });
+  fs.mkdirSync(other, { recursive: true });
+  // Sub-case A: legacy entry, link points at what would be its source.
+  const linkA = path.join(skillsRoot, 'wienerdog-a');
+  fs.symlinkSync(source, linkA);
+  manifestLib.record(manifest, { kind: 'symlink', path: linkA }); // NO target — legacy
+  // Sub-case B: legacy entry, link points elsewhere.
+  const linkB = path.join(skillsRoot, 'wienerdog-b');
+  fs.symlinkSync(other, linkB);
+  manifestLib.record(manifest, { kind: 'symlink', path: linkB }); // NO target — legacy
+  manifestLib.save(paths, manifest);
+  const { removed, skipped } = manifestLib.reverse(paths, manifestLib.load(paths), {});
+  for (const link of [linkA, linkB]) {
+    assert.equal(fs.lstatSync(link).isSymbolicLink(), true, 'a legacy link is never unlinked');
+    assert.ok(!removed.includes(link));
+    assert.ok(skipped.includes(link));
+  }
+});
+
+test('reverseSymlink: a dangling own link is still removed via the lexical fallback — Table A row 3→5 (T4)', (t) => {
+  if (!isPosix) return t.skip('symlink creation may be unavailable');
+  // T4 exercises reverseSymlink DIRECTLY, not via reverse(). The lexical fallback
+  // (readlinkSync(L) === T) only ever fires when T is unresolvable — i.e. the core
+  // was deleted by hand so the link dangles. But reverse()'s withinAllowedRoot gate
+  // realpaths the link (following it), which THROWS on a dangling link and preserves
+  // the entry BEFORE reverseSymlink runs. That gate is pre-existing (WP-144/F30) and
+  // out of scope here, so the fallback contract (Table A row 3 → row 5) is proven at
+  // the unit boundary. See the PR "Discovered issues" note.
+  const paths = tempPaths();
+  const skillsRoot = path.join(paths.claudeDir, 'skills'); // OWNED location — required
+  fs.mkdirSync(skillsRoot, { recursive: true });
+  const source = path.join(paths.claudeDir, 'core-skills', 'wienerdog-foo');
+  fs.mkdirSync(source, { recursive: true });
+  const link = path.join(skillsRoot, 'wienerdog-foo');
+  fs.symlinkSync(source, link);
+  fs.rmSync(source, { recursive: true, force: true }); // core deleted by hand → link dangles
+  const removed = [];
+  const skipped = [];
+  const removedSet = new Set();
+  manifestLib.reverseSymlink(
+    { kind: 'symlink', path: link, target: source },
+    false,
+    removed,
+    skipped,
+    removedSet,
+    [skillsRoot]
+  );
+  assert.equal(fs.existsSync(link), false, 'the dangling own link is unlinked via the lexical fallback');
+  assert.ok(removed.includes(link));
+  assert.ok(!skipped.includes(link));
+});
+
+test('reverseSymlink: a forged (path,target) pair for a non-OWNED link is preserved — Table A row 4 (T7)', (t) => {
+  if (!isPosix) return t.skip('symlink creation may be unavailable');
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  const skillsRoot = path.join(paths.claudeDir, 'skills');
+  fs.mkdirSync(skillsRoot, { recursive: true });
+  // Destination inside an allowed root, so withinAllowedRoot passes and the red
+  // baseline is obtainable (a /tmp destination would be preserved at :775 for the
+  // WRONG reason — no red baseline).
+  const userDest = path.join(paths.claudeDir, 'my-skills');
+  fs.mkdirSync(userDest, { recursive: true });
+  // Case 1: a user link WITHOUT the wienerdog- prefix, directly under the skills root.
+  const notes = path.join(skillsRoot, 'my-notes');
+  fs.symlinkSync(userDest, notes);
+  // Forgery: target read straight off the link, so rows 1-3 all pass.
+  manifestLib.record(manifest, { kind: 'symlink', path: notes, target: fs.readlinkSync(notes) });
+  // Case 2: a wienerdog-* link ONE DIRECTORY DEEPER than the skills root.
+  const nested = path.join(skillsRoot, 'nested');
+  fs.mkdirSync(nested, { recursive: true });
+  const deep = path.join(nested, 'wienerdog-deep');
+  fs.symlinkSync(userDest, deep);
+  manifestLib.record(manifest, { kind: 'symlink', path: deep, target: fs.readlinkSync(deep) });
+  manifestLib.save(paths, manifest);
+  const { removed, skipped } = manifestLib.reverse(paths, manifestLib.load(paths), {});
+  for (const link of [notes, deep]) {
+    assert.equal(fs.lstatSync(link).isSymbolicLink(), true, 'a non-OWNED forged link is preserved');
+    assert.ok(!removed.includes(link));
+    assert.ok(skipped.includes(link));
   }
 });

--- a/tests/unit/shared-skill-links.test.js
+++ b/tests/unit/shared-skill-links.test.js
@@ -51,7 +51,7 @@ test('skill symlinked into the target dir with the default seam (POSIX)', () => 
   assert.ok(out.changed.includes(linkPath));
   assert.deepEqual(
     manifest.entries.filter((e) => e.path === linkPath),
-    [{ kind: 'symlink', path: linkPath }]
+    [{ kind: 'symlink', path: linkPath, target: coreSkill }]
   );
 });
 
@@ -190,7 +190,7 @@ test('dry-run records a symlink entry and reports the change without writing', (
   assert.ok(out.changed.includes(linkPath));
   assert.deepEqual(
     manifest.entries.filter((e) => e.path === linkPath),
-    [{ kind: 'symlink', path: linkPath }]
+    [{ kind: 'symlink', path: linkPath, target: path.join(skillsDir, 'wienerdog-setup') }]
   );
 });
 
@@ -336,7 +336,7 @@ test('a pre-existing correct symlink is adopted into the manifest (recorded, rep
   assert.ok(!out.changed.includes(linkPath));
   assert.deepEqual(
     manifest.entries.filter((e) => e.path === linkPath),
-    [{ kind: 'symlink', path: linkPath }]
+    [{ kind: 'symlink', path: linkPath, target: coreSkill }]
   );
 });
 


### PR DESCRIPTION
Spec: docs/specs/WP-153-target-aware-symlink-reverser.md

Makes `reverseSymlink` target-aware so `wienerdog uninstall` unlinks only a skill
symlink it can PROVE Wienerdog owns. Closes the WP-146 F1 residual (direct
uninstall / re-sync-that-failed-before-save) and the gate-round-4 forged-pair
delete-authority hole.

## Dispatch-time re-verification (tested SHA `3eff9d8`, post-WP-147 merge PR #134)

WP-147 landed as `3eff9d8` and grew `manifest.js` by ~53 lines in/around the
reverse region; `shared.js` producer anchors also shifted. **Every code SHAPE the
spec asserts holds; only line numbers drifted. The design fits — no material
staleness.** Implemented against the CURRENT tree, not the spec's stale numbers.

| Spec claim (anchor @ e7c845e) | @ 3eff9d8 | Status |
|---|---|---|
| `reverseSymlink` body verbatim (def :150) | def :162, body :156-171 | CONFIRMED (byte-identical shape); DRIFTED +12 |
| `isSymlink` = lstat.isSymbolicLink in try (:136-142) | :147-154 | CONFIRMED; DRIFTED |
| `grep reverseSymlink` → 4 lines (def/comment/call/shared prose) | def :162, comment :772, call :782, shared :441 | CONFIRMED (still 4); DRIFTED |
| symlink arm at call site (:718-729) | :771-782 | CONFIRMED shape; DRIFTED +53 |
| call `reverseSymlink(entry,dryRun,removed,skipped,removedSet)` (:729) | :782 | CONFIRMED; DRIFTED |
| 3 producers `kind:'symlink'` target-less (:399,:450,:456) | :434,:485,:491 | CONFIRMED; DRIFTED |
| `target`/`linkPath` in scope (:381-382) | :416-417 | CONFIRMED; DRIFTED |
| adopt/dryRun/create branch mapping | adopt :434, dryRun :485, create :491 | CONFIRMED (Table T mapping holds by branch semantics) |
| WP-146 preserve arm + `dropOwnedEntry` (:400-412,:408) | :435-447, :443 | CONFIRMED; DRIFTED (untouched) |
| `recordOnce` no-ops on existing (:47-52) | :47-52 | CONFIRMED (identical) |
| `ENTRY_FIELD_TYPES` (:806-817); `symlink: {}` (:809) | :859-875; :862 | CONFIRMED; DRIFTED |
| `validateEntry` types only when present (`if(value===undefined)continue`) | :899 | CONFIRMED; DRIFTED |
| doc comment line 17 `{kind:'symlink', path}` | :17 (unchanged) | CONFIRMED (before :205, unaffected by WP-147) |
| `sameResolvedDir` fail-closed (:353-359) | :406-412 | CONFIRMED; DRIFTED |
| `reverseCopiedSkill` OWNED proof `startsWith('wienerdog-') && parentIsRoot` (:406-408) | :459-461 | CONFIRMED (shape mirrored exactly); DRIFTED |
| `skillsRoots` built once (:521); passed to reverseCopiedSkill (:716) | :574; :769 | CONFIRMED; value `[claudeDir/skills, codexDir/skills]` unchanged |
| deferred-member guard `resolvesTo(entry.path, paths.manifest)` (:578-586) | :677 | CONFIRMED; DRIFTED |
| T5 three deepEqual assertions (:52-55,:191-194,:337-340) + scopes (coreSkill @:42/:326; none @:181) | :54,:193,:339 (in-range); scopes as stated | CONFIRMED |
| WP-146 fenced tests (:345,:371,:387,:405) | same lines | CONFIRMED |
| T6 fixture `:297-312` | :297-312 | CONFIRMED |

**Key WP-147 sequencing finding:** WP-147 did NOT add `sepBefore`/`sepAfter` to
the `ENTRY_FIELD_TYPES` managed-block cell (it left it un-type-gated with an
explanatory comment, so a non-string forgery still reaches `reverseManagedBlock`).
So the `symlink` cell change is cleanly WP-153's alone — **no schema-object
collision**, exactly as the spec's "Sequencing with WP-147" section anticipated.

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
  (`src/adapters/shared.js`, `src/core/manifest.js`, `tests/unit/manifest.test.js`,
  `tests/unit/shared-skill-links.test.js`) + the spec file itself.
- [x] Spec status flipped to In-Review

## Verification output

**V1 — the two suites (`node tests/run.js …`):** 98 tests, 97 pass, 1 skipped, 0 fail.
Full suite `npm test`: 1852 tests, 1847 pass, 5 skipped, **0 fail**.

**V2 — producer sites carry the target (AC4):**
```
$ grep -c "kind: 'symlink', path: linkPath, target" src/adapters/shared.js
3
$ grep -c "kind: 'symlink', path: linkPath }" src/adapters/shared.js
0        (grep exits 1 on zero count — expected)
```

**V3 — schema cell literal:**
```
$ grep -n "symlink: { target: 'string' }," src/core/manifest.js
908:  symlink: { target: 'string' },
```

**V4 — reverseSymlink body** consults `sameResolvedDir` AND `readlinkSync`
(rows 3+5): present. **V4b — structural gate** (`startsWith('wienerdog-')` AND
`skillsRoots`): `V4b ok — structural ownership gate present`.

**Red-first proofs (AC1, AC2b, T6):**
- **T1** against a target-blind `reverseSymlink` → **RED** (T1, T3, T7 all fail:
  the user's link is unlinked). After the fix → GREEN.
- **T7** against a row-4-less reverser (rows 1-3 kept, row 4 removed) → **RED**
  (only T7 fails; T1/T3 stay green — rows 1-3 preserve them). After the fix → GREEN.
- **T6** with the deferred-member guard's manifest arm removed → guard (iii)
  goes **RED** (the relocated OWNED + target-matched fixture reaches row 5 and is
  unlinked), proving the guard is load-bearing again. Restored → GREEN.

**V5 — `npm test` and `npm run lint`: both green** (lint: 0 markdownlint errors,
frontmatter check passed).

**AC6 — `git diff tests/unit/shared-skill-links.test.js`** touches only the three
Table T assertion lines (`:54`, `:193`, `:339`, all inside the fenced `:52-55`,
`:191-194`, `:337-340` ranges); `:181` untouched; the four WP-146 sync-side tests
byte-unmodified.

## Decisions made

- **Branch name** matches the spec frontmatter (`wp/153-target-aware-symlink-reverser`).
  The dispatch worktree branch was `worktree-agent-…`; the WP branch was created off it.
- **`reverseSymlink` is exported** from `src/core/manifest.js` (added to
  `module.exports`, one symbol, mirroring the already-exported `reverseCopiedSkill`
  / `reverseVendoredTree` / `reverseSchedulerEntry`). Required to unit-test T4's
  lexical fallback directly — see Discovered issues. In-convention:
  `reverseSchedulerEntry` is already called directly in its test suite.
- **T4 is a direct unit test of `reverseSymlink`, not a `reverse()` test** (the
  spec's Test index prose says "reverse() still unlinks L"). Rationale in
  Discovered issues; the row 3→5 lexical-fallback contract is still proven, red-first.
- Rows 2, 3 and 4 share the single stderr string from Table A row 2
  (`keeping <L> — … (replaced, or unverifiable)`), exactly as Table A specifies
  ("same line as row 2").

## Discovered issues (out of scope, not fixed)

- **The spec's T4 is not reachable through `reverse()` as its prose claims**, and
  this is a genuine (pre-existing, non-WP-147) spec inaccuracy the architect should
  see. The lexical fallback (`readlinkSync(L) === T`) only ever fires when `T` is
  unresolvable — i.e. the core was deleted by hand so the link **dangles**. But
  `reverse()`'s `withinAllowedRoot` gate (`manifest.js` symlink arm, F30/WP-144)
  calls `contains()` → `fs.realpathSync` on the link, which **follows** it and
  **throws ENOENT** on a dangling link, so the entry is preserved (skipped) at that
  gate **before `reverseSymlink` ever runs**. Verified empirically. Consequences:
  (a) T4 cannot be a `reverse()` test — it is implemented as a direct unit test of
  `reverseSymlink`, which still proves Table A row 3→5 red-first (a fallback-less
  reverser preserves; the fix unlinks); (b) the lexical fallback is effectively
  **dead through `reverse()`**, but is retained because the spec mandates it (Table
  A row 3, "Exact contracts", and V4 greps for `readlinkSync` in the body) and it
  is harmless (safe/preserve direction). **This does not affect the security fix**
  — rows 2/3/4/5 delete-authority are all reachable and fully tested through
  `reverse()` (T1, T2, T3, T6, T7). Recommend the architect either drop the
  fallback (and V4's `readlinkSync` requirement) or, if uninstall should stop
  leaving its own dangling links, loosen the symlink arm's `withinAllowedRoot` for
  the OWNED-dangling case — a separate design decision, not this WP's scope.

## Lessons (dogfooding)

- WP-153: Dispatch-time re-verification paid off — WP-147 shifted every `manifest.js`
  anchor after ~:205 by ~53 lines; implementing by CONTENT (not the spec's stale
  numbers) was essential. All code shapes still matched, so the design held.
- WP-153: A gate at the enclosing loop can silently shadow a branch a spec assumes
  is reachable. `reverse()`'s `withinAllowedRoot` follows the link via realpath, so
  a dangling-link fixture is preserved before the reverser runs — the spec's T4
  "reverse() unlinks" claim was untestable as written. Verify reachability
  empirically before writing a fixture, not just the branch logic.
- WP-153: The Deliverables table said the arm's "only change" is the extra
  `skillsRoots` arg, but honestly testing the lexical fallback required one more
  in-file change (exporting `reverseSymlink`). When a required test can only be
  written against a non-exported internal, the export is part of the deliverable —
  flag it rather than skip the test.

---
Generated-by: claude-opus-4-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG6TJhQS9RTaNKgHKhXmc8
