### PR TITLE
docs(adr): land ADR-0028 owner signature — entry-node-path amendment ACCEPTED (WP-adr-0028-entry-node-path-amendment)

### DIFF
--- a/docs/adr/0028-scheduler-app-executable-integrity.md
+++ b/docs/adr/0028-scheduler-app-executable-integrity.md
@@ -1212,7 +1212,7 @@ rejected**.
 
 ## Amendment (2026-08-01) — the scheduler ENTRY's node path is an upgrade-durable alias; `process.execPath` stays the runtime and the authorization value
 
-Status: **PROPOSED — awaiting owner signature.**
+Status: **ACCEPTED - OWNER-SIGNED 2026-08-02**
 
 **Architect note (2026-08-01, architect-authored — this is NOT an owner
 signature, confers no approval, and no gate may key on it).** This amendment was

--- a/docs/specs/done/WP-adr-0028-entry-node-path-amendment.md
+++ b/docs/specs/done/WP-adr-0028-entry-node-path-amendment.md
@@ -1,7 +1,7 @@
 ---
 id: WP-adr-0028-entry-node-path-amendment
 title: Amend ADR-0028 Decision 1 so the scheduler entry's node path may be an upgrade-durable alias while process.execPath stays the runtime and authorization value
-status: Draft
+status: Done
 model: opus
 size: S
 depends_on: []
@@ -290,6 +290,7 @@ else changes. Updating it is part of the owner's signature pass (B2).
 752:Status: **Accepted. OWNER-SIGNED 2026-07-26.**                [1] MARKER
 760:`OWNER-SIGNED 2026-07-25` line at the head of the file, and … [3] BACK-REF
 978:Status: **ACCEPTED — OWNER-SIGNED 2026-08-01**                [1] MARKER
+1215:Status: **ACCEPTED - OWNER-SIGNED 2026-08-02**               [1] MARKER
 1224:Fehér types an `OWNER-SIGNED <date>` line into it by hand …  [4] PLACEHOLDER
 1225:heading — not the `OWNER-SIGNED 2026-07-25` line at the …    [3] BACK-REF
 1342:`OWNER-SIGNED <date>`, the gate is **not** satisfied …       [4] PLACEHOLDER


### PR DESCRIPTION
Spec: docs/specs/done/WP-adr-0028-entry-node-path-amendment.md

Lands the owner's hand-typed signature on the ADR-0028 entry-node-path
amendment. The `Status:` line bytes at ADR-0028:1215
(`ACCEPTED - OWNER-SIGNED 2026-08-02`) were typed by Gyula in the working
tree on 2026-08-02; this PR records them mechanically — no agent wrote the
marker. The signature pass also performs the two spec-mandated companion
edits (DoD items 4 and 6): the A2 worked example gains the new marker as a
fifth `[1] MARKER` row (B2), and the spec flips to `Done` and moves to
`docs/specs/done/`.

Note: the signature satisfies the **ADR gate only** (B6).
`WP-scheduler-node-path-durability` still cannot dispatch — its
`depends_on` `WP-scheduler-register-replaces-loaded-record` is
`status: Draft`, unimplemented.

## Deliverables checklist

- [x] Every changed file is part of the spec's signature pass (ADR-0028 +
      the companion spec itself; owner-action WP, not implementer-dispatched)
- [x] Spec status flipped to Done + moved to done/ (per DoD item 6 — this
      WP closes in State B, it does not pass through In-Review)

## Verification output

State B gates VB1–VB5 run against this branch:

```
=== VB1 (expect NO output, exit 1) ===
VB1 exit=1

=== VB2 (exactly five dated markers, the new one at the amendment) ===
6:OWNER-SIGNED 2026-07-25
8:> **OWNER-APPROVED (2026-07-19).** The owner ratified the A7 architectural
14:> resolved as dated `OWNER-APPROVED` markers across the WP-154..WP-159
752:Status: **Accepted. OWNER-SIGNED 2026-07-26.**
760:`OWNER-SIGNED 2026-07-25` line at the head of the file, and every Decision and
978:Status: **ACCEPTED — OWNER-SIGNED 2026-08-01**
1215:Status: **ACCEPTED - OWNER-SIGNED 2026-08-02**
1224:Fehér types an `OWNER-SIGNED <date>` line into it by hand. Nothing above this
1225:heading — not the `OWNER-SIGNED 2026-07-25` line at the head of the file, not
1342:`OWNER-SIGNED <date>`, the gate is **not** satisfied and the code must not merge.
  -> dated markers: :6, :8, :752, :978 (pre-existing, class [1]) + :1215 (NEW).
     :14 convention, :760/:1225 back-refs, :1224/:1342 placeholders — per the
     A2 roster classes, matched by content.

=== VB3 (four pre-existing markers byte-unchanged) ===
OWNER-SIGNED 2026-07-25
> **OWNER-APPROVED (2026-07-19).** The owner ratified the A7 architectural
Status: **Accepted. OWNER-SIGNED 2026-07-26.**
Status: **ACCEPTED — OWNER-SIGNED 2026-08-01**

=== VB4 (pure append vs e7c845e) ===
VB4 ok — pure append preserved through the signature

=== VB5 ===
npm run lint -> lint passed
(markdownlint 0 errors; frontmatter check passed: 209 spec(s), 4 agent(s) —
the moved spec still resolves)
```

## Decisions made

- The owner's marker uses a plain hyphen (`ACCEPTED - OWNER-SIGNED`) where
  the `:978` marker uses an em-dash. VB2's grep matches on the word
  `OWNER-SIGNED`, so the gate is unaffected; the owner's bytes were left
  exactly as typed.
- The A2 roster's surrounding prose ("Nine lines, four classes"; "[1] Marker
  — the four dated ratifications") was intentionally NOT renumbered: the spec
  says the roster "gains one row … and nothing else changes", so only the row
  was added. Flagged here rather than silently rewritten.

## Discovered issues (out of scope, not fixed)

none

---
Generated-by: Claude Fable 5 (claude-fable-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THDN8Y8Syk7Lft4GDpBBhP
