### PR TITLE
fix(scheduler): verify what the OS holds before reporting a register success (WP-scheduler-register-replaces-loaded-record)

### DIFF
--- a/docs/specs/WP-scheduler-register-replaces-loaded-record.md
+++ b/docs/specs/WP-scheduler-register-replaces-loaded-record.md
@@ -1,7 +1,7 @@
 ---
 id: WP-scheduler-register-replaces-loaded-record
 title: A register that cannot verify what the OS now holds must not report success
-status: Draft
+status: In-Review
 model: sonnet
 size: M
 depends_on: []

--- a/docs/specs/WP-scheduler-register-replaces-loaded-record.md
+++ b/docs/specs/WP-scheduler-register-replaces-loaded-record.md
@@ -840,12 +840,29 @@ rows 1, 4 and 5 stays byte-identical. Exhaustive site list, main line numbers:
 | `:1228` | `repointSchedules refreshes the descriptor … (WP-156)` (`:1224`) |
 
 **Every other `{ status: 0 }` loader in the file stays unchanged, and that is the
-boundary** — main `:106`, `:302`, `:321`, `:461`, `:495`, `:519`, `:643`, `:665`,
-`:752`, `:792`, `:840`, `:899`, `:1050`, `:1066`, `:1106`, `:1139`. A swap at any
-site not in the table above is out of boundary. Note in particular `:461`
-(`remove nope` — no register runs) and `:1139` (`list --json`'s own invocation):
-adjacent to swapped sites in the same tests, and deliberately left alone, because
-the swap is owed only where a register actually executes.
+boundary.** The list below is **complete, and its completeness is arithmetic
+rather than assertion** (corrected 2026-08-02, round-2 review note 1 — an earlier
+form said "every other" over a 16-entry list that was actually partial, which is
+the prose form of the range-abbreviation failure this table warns about):
+
+```bash
+git show origin/main:tests/unit/scheduler-schedule.test.js | grep -c "{ status: 0 }"
+```
+
+**49** on `main`. **14** of them are the swapped sites in the table above
+(`:338`; `:392`, `:395`; `:401`; `:420`; `:1021`, `:1025`; `:1035`; `:1084`;
+`:1131`, `:1132`; `:1185`, `:1199`; `:1228`). The remaining **35 stay unchanged**,
+and here they all are — `:106`, `:302`, `:321`, `:443`, `:461`, `:493`, `:495`,
+`:517`, `:519`, `:540`, `:579`, `:620`, `:643`, `:665`, `:729`, `:752`, `:773`,
+`:792`, `:827`, `:840`, `:855`, `:888`, `:899`, `:935`, `:953`, `:980`, `:993`,
+`:1050`, `:1066`, `:1104`, `:1106`, `:1118`, `:1139`, `:1216`, `:1238`.
+14 + 35 = 49, so the two lists together account for every site and neither can
+quietly lose a member.
+
+A swap at any site not in the table above is out of boundary. Note in particular
+`:461` (`remove nope` — no register runs) and `:1139` (`list --json`'s own
+invocation): adjacent to swapped sites in the same tests, and deliberately left
+alone, because the swap is owed only where a register actually executes.
 
 ### Table N — where §8's notice is asserted, and where it is inherited (canonical; +2026-08-02)
 
@@ -859,8 +876,10 @@ exactly the contract-density shape ADR-0031 names. This table is now that owner.
 (main; `:802` on the branch), inside an unconditional `if (!res.loaded)` — no
 platform branch, no second emitter of that string. Audited: the other two
 `did not accept it` strings in `schedule.js` (`:870`, `:895` on the branch) are
-`ensureCatchup`'s **different** catch-up sentences, not §8's. This WP does not
-change any of the three. **Consequence, and the reason this table exists:** a
+**different** catch-up sentences, not §8's, and both sit inside **`repairCatchup`**
+(branch `:832`) — the heal-gated primitive, not `ensureCatchup` (attribution
+corrected 2026-08-02, round-2 review note 2; the substantive claim is unchanged).
+This WP does not change any of the three. **Consequence, and the reason this table exists:** a
 fixture proves the notice **only if it drives `repointSchedules`**. A fixture that
 calls `registerPlatform` directly can prove `loaded === false` and nothing more —
 which is what all five clauses were resting on.

--- a/docs/specs/WP-scheduler-register-replaces-loaded-record.md
+++ b/docs/specs/WP-scheduler-register-replaces-loaded-record.md
@@ -356,7 +356,8 @@ not change the chain.
      and package-lock.json. Everything else must be listed. -->
 
 **Sizing.** Two new non-exported helpers plus four edited call sites in one file,
-one new Proposed ADR, one test file extended. **M** — one session.
+one new Proposed ADR, one test file extended, plus **one existing assertion in a
+second test file** (D6, the 2026-08-02 boundary amendment below). **M** — one session.
 
 | Action | Path | Notes |
 |--------|------|-------|
@@ -365,8 +366,11 @@ one new Proposed ADR, one test file extended. **M** — one session.
 | modify | src/scheduler/generators.js | **D0** — add **four** names to `module.exports`, and add **two** new pure parsers (`launchdLoadedCalendar`, `launchdLoadedEnv` — D1b). Existing names exported unchanged:: `launchdLoadedArgs` (`:679-689`, used internally at `:787`) and `jobLaunchArgs` (`:208`, used internally at `:355`); the two new parsers are exported with them. Structural, not an API promise — the WP-114 precedent for `repairCatchup`. Audited, not assumed (see "Export audit" in Implementation notes): `catchupLaunchArgs` (`:1030`) and `loadedEntryTargets` (`:1007`) are **already** exported and need no change. |
 | modify | src/cli/schedule.js | **D1, D2, D3, D4 and D5** — the complete set, reconciled against the Implementation notes and the ACs: **D1** `darwinLoadedVerdict` + `ensureDarwinEntryRegistered` (new, non-exported, incl. the `plutil` preflight, the tri-state verdict, `verifyLoaded` and the rollback); **D2** the darwin per-job arm (`:429-431`, Table A row 1); **D3** `ensureCatchup` (`:314-317`, row 2); **D4** the linux arm (`:456-466`, row 3); **D5** `add()`'s guard at `:882` — drop the `changed &&` conjunct so it throws on ANY unloaded outcome (**required by AC11**; a cell that stopped at D4 would leave the user-facing false-success shipped). Nothing beyond those five — no probe, no heal, no notice string, no Windows path, and **`darwinReplaceEntry` itself is not edited** (it stays the heal path's primitive). |
 | modify | tests/unit/scheduler-schedule.test.js | **T1, T2, T2b, T2c, T2d, T2e, T2f, T2g, T3, T4, T5, T6, T7** — the complete Test index, enumerated rather than range-abbreviated because `T3-T7` silently excluded T2c/T2d/T2e (the `plutil` preflight, its existence gate, and the post-bootstrap verify). Plus the **four** existing assertions enumerated in AC6 — no others. |
+| modify | tests/unit/init.test.js | **D6 / T8 — architect boundary amendment, 2026-08-02.** ONE existing assertion in the single test `init --fresh-vault schedules the nightly dream and surfaces it (ADR-0014)`: its `/catches up automatically/i` match becomes platform-aware, because under `WIENERDOG_LOADER_NOOP=1` the darwin leg now correctly reports `loaded: false`. Added post-hoc — the collision was discovered at `npm test` time, not at spec time; the full record, the decision and the rejected alternative are in Implementation notes → **D6**. Nothing else in this file: no other test, no helper, no `tempEnv`/`run` change. |
 
 Not deliverables, deliberately: `src/scheduler/status.js`,
+`src/scheduler/spawn.js` (**D6's rejected alternative** — the NOOP seam is never
+taught to fabricate a readback; see Implementation notes → D6),
 `src/scheduler/launcher.js`, `src/cli/sync.js` (§10), `src/cli/doctor.js`,
 `docs/adr/0018-windows-scheduled-dreaming.md` (owner-signed; ADR-0037 amends it
 from a new file — never edit it),
@@ -778,6 +782,7 @@ rounds 2-3, where an unregistered Deliverables cell shipped a wrong test set):
 - [ ] **(+r3/r5)** Deliverables cell for `src/scheduler/generators.js` — D0 exports **four** names (`launchdLoadedArgs`, `jobLaunchArgs`, and the two new parsers `launchdLoadedCalendar`/`launchdLoadedEnv`) and adds the two parser bodies (D1b). Mirrors **Table A2**.
 - [ ] Deliverables cell for `src/cli/schedule.js` (the four D-sites — Table A rows 1-3)
 - [ ] Deliverables cell for `tests/unit/scheduler-schedule.test.js` (T1, T2, T2b, T2c, T2d, T2e, T3, T4, T5, T6, T7 + AC6's four assertions)
+- [ ] **(+2026-08-02)** Deliverables cell for `tests/unit/init.test.js` (D6 / T8 — the one platform-aware assertion). Mirrors **Table A** rows 1 and 3: darwin verifies and so can report `loaded:false` under a blind seam, linux does not verify and so still reports `loaded:true`. Its other registered mirrors are Implementation notes → **D6**, **AC12**, Test index **T8**, and **V8**.
 - [ ] Deliverables cell for `docs/adr/0037-…` (the rule — Table A's spine)
 - [ ] "Exact contracts" — both JSDoc blocks and the `ensureDarwinEntryRegistered` body
 - [ ] Current state §2 (rows 1-2), §3 (the teardown guard), §4 (row 3), §6 (row 4), §7 (the readback machinery + the measured exit codes), §9 (why not a cache)
@@ -1121,6 +1126,101 @@ which is also the evidence that `add()` is the outlier:
 - `add()` (`schedule.js:882`) is the **only** `registerPlatform` caller gated on
   `changed`. Audited: those are all four call sites (`:380` definition, `:575`,
   `:813`, `:879`).
+
+### D6 — the `WIENERDOG_LOADER_NOOP` collision (architect boundary amendment, 2026-08-02)
+
+**This section was added after the implementer finished.** It is a spec bug being
+paid for, not a scope change the implementer chose: the collision below was
+invisible at spec time and surfaced only at full-`npm test` time, in a file this
+table did not list. Recorded here in full so the next reader does not have to
+reconstruct it from a PR body.
+
+**The collision, verified firsthand.** `tests/unit/init.test.js:115` runs a REAL
+subprocess of `bin/wienerdog.js init --fresh-vault --yes` with
+`WIENERDOG_LOADER_NOOP=1`. That seam (`src/scheduler/spawn.js:25`) answers EVERY
+scheduler spawn with a blind `{status:0}` and **no `stdout`**:
+
+```js
+  if (process.env.WIENERDOG_LOADER_NOOP) return { status: 0 };
+```
+
+Under Table A row 1 the darwin per-job register now reads the entry back with
+`launchctl print` and requires a `'match'` verdict. A `{status:0}` with no
+`stdout` parses to `'indeterminate'` — never `'match'` — so
+`ensureDarwinEntryRegistered` returns `false`, `ensureDreamSchedule` returns
+`{scheduled:false, reason:'load-failed'}` (`schedule.js:823`), and `init`'s
+summary takes the `load-failed` branch (`src/cli/init.js:199`) instead of the
+`scheduled` branch (`:192-195`). The test's `/catches up automatically/i`
+assertion is in that `scheduled` branch. Executed on this branch, the ONLY
+delta in `init --fresh-vault`'s entire stdout against `origin/main` is that
+three-line success block collapsing to the one-line degraded notice — nothing
+else in the run moved.
+
+**This is the postcondition working exactly as designed.** Nothing was verified,
+so nothing may claim success. The notice the user now sees under a blind seam is
+the correct output, and the WP-066 catch-up reassurance would be a false promise
+there: `init` cannot promise launchd will catch up on an entry it has no
+evidence launchd holds. Read the other way round, the pre-amendment assertion was
+never testing real scheduling — it was resting on the seam's blindness being
+indistinguishable from success, which is precisely the
+failing-outside-our-own-observability signature named in Context.
+
+**The fix is PLATFORM-AWARE, and that is not incidental.** Only the legs that
+verify can report `loaded:false` under a blind seam:
+
+| leg | under `WIENERDOG_LOADER_NOOP=1` | why | `init` summary |
+|---|---|---|---|
+| darwin (Table A rows 1-2) | `loaded:false` | the readback runs and yields `'indeterminate'` | the `load-failed` notice |
+| linux (Table A row 3) | `loaded:true` | Table A row 3 specifies **no** readback — `reloadOk && enableOk` are both `{status:0}` | the `scheduled` block |
+| win32 (Table A row 4) | `loaded:true` on a fresh install | `changed` is true, so `ensureWindowsTaskRegistered` skips its readback and returns from `/create` | the `scheduled` block |
+
+CI runs `ubuntu-latest` **and** `macos-latest` (`.github/workflows/ci.yml:33`), so
+a single unconditional assertion cannot be correct on both. The assertion branches
+on `process.platform === 'darwin'`.
+
+**The darwin leg asserts the NEGATIVE too** (`doesNotMatch(/catches up
+automatically/i)`) deliberately: that turns this test into a tripwire against the
+rejected alternative below. If anyone later teaches the seam to fabricate a
+matching readback, this assertion goes red and forces the conversation.
+
+**REJECTED ALTERNATIVE — extending `WIENERDOG_LOADER_NOOP` in
+`src/scheduler/spawn.js` so a NOOP `launchctl print` returns canonical-matching
+stdout.** Rejected, and rejected in this WP's own terms:
+
+1. **It fabricates the exact evidence the postcondition exists to require.**
+   ADR-0037's rule is *a register that cannot verify what the OS now holds must
+   not report success*. A seam that manufactures a `'match'` readback makes the
+   register report success from evidence it invented about an OS call that never
+   happened. That is the anti-pattern this WP kills, reintroduced one layer down
+   and harder to see, because it would then be baked into the chokepoint rather
+   than into any one call site.
+2. **It would make the postcondition untestable-by-construction on every NOOP
+   path.** All ~15 NOOP-using test files would permanently observe "verified",
+   so no subprocess-driven test could ever again detect a genuine regression in
+   the readback. One honest assertion change is strictly cheaper than blinding
+   the whole seam.
+3. **It contradicts the seam's documented contract and an existing in-tree
+   precedent.** `spawn.js`'s own JSDoc calls NOOP "the existing neutralizer; a
+   test that has deliberately opted out of real scheduling" — a *neutralizer*,
+   not a simulator. And `tests/unit/scheduler-entry-identity.test.js:396-407`
+   already pins the read side of exactly this question: under
+   `WIENERDOG_LOADER_NOOP=1` it asserts `defaultProbe(…) === 'unknown'`. NOOP
+   already means *you learn nothing*. Option (b) would put the two read paths in
+   direct contradiction.
+4. **It is not small.** To fabricate a matching `launchctl print`, the seam would
+   have to know the label→plist mapping, the live config and the rendered
+   canonical bytes — i.e. reimplement the generator inside the ONE scheduler
+   chokepoint that ADR-0028 hardened, in service of one assertion.
+
+**Blast radius, confirmed by grep, not by assumption.** The ~15 other
+NOOP-using files were checked for register-success assertions
+(`catches up automatically|is scheduled for|did not accept|loaded: *true|\.loaded`).
+Two files hit and neither is affected: `tests/integration/adopt-e2e.test.js:422`
+is a comment, and `tests/unit/scheduler-entry-identity.test.js`'s hits are
+unit-level `loadedEntryTargets` calls over explicit stdout fixtures (no seam
+involved) plus one assertion on a *failure* notice (`:815`). `init.test.js` is
+the only file whose meaning depends on the seam implying success — which is why
+it is the only one in this table.
 
 ### Rollback — OWNER-DIRECTED, and it is the contract, not a residual
 
@@ -1673,6 +1773,16 @@ mock `process.platform` — and no test may touch a real OS scheduler
       unmodified: `ensureDreamSchedule` (`:823`) and `repointSchedules` (`:583`)
       both branch on `!res.loaded` unconditionally.
 - [ ] **AC10 (mutation matrix).** Every Table B row demonstrated red; output pasted.
+- [ ] **AC12 (D6 — the NOOP boundary collision, added 2026-08-02).** In
+      `tests/unit/init.test.js`, the single test
+      `init --fresh-vault schedules the nightly dream and surfaces it (ADR-0014)`
+      branches on `process.platform === 'darwin'`: darwin asserts the
+      `load-failed` notice is present **and** that `/catches up automatically/i`
+      is **absent**; every other platform asserts the reassurance as before. The
+      unconditional `/dreaming/i` and the three config assertions are unchanged,
+      and no other test in the file is touched. `src/scheduler/spawn.js` is
+      **not** in the diff — the seam is never taught to fabricate a readback
+      (D6's rejected alternative). Full `npm test` is green (V8).
 
 ### Test index
 
@@ -1691,11 +1801,15 @@ mock `process.platform` — and no test may touch a real OS scheduler
 | T5 | tests/unit/scheduler-schedule.test.js | linux degraded reload ⇒ `loaded:false` + notice; null/missing results (AC5 i) |
 | T6 | tests/unit/scheduler-schedule.test.js | linux unchanged bytes still reload + enable, exactly two calls (AC5 ii) |
 | T7 | tests/unit/scheduler-schedule.test.js | **CLI path** — `add()` throws on an unloaded outcome for an UNCHANGED entry, on both legs: unchanged-darwin readback-mismatch-then-failure, and unchanged-linux degraded reload (AC11) |
+| T8 | tests/unit/init.test.js | **(+2026-08-02)** the D6 boundary collision — a REAL `init --fresh-vault` subprocess under `WIENERDOG_LOADER_NOOP=1` must not claim catch-up on the darwin leg, where nothing was verified (AC12). **Not a new test and not a `verified-register:` subtest** — one existing assertion in an existing test, so the naming rule below does not apply to it. |
 
 Name every subtest with the prefix `verified-register:` followed by one space.
+(T8 is exempt — see its row.)
 
-**Every T-test drives `registerPlatform` / `ensureCatchup` behaviorally with an
-injected loader.** The two new helpers are non-exported and must **not** be
+**Every T-test in `tests/unit/scheduler-schedule.test.js` drives `registerPlatform`
+/ `ensureCatchup` behaviorally with an
+injected loader** (T8 is in a different file and drives a real subprocess — see its
+row). The two new helpers are non-exported and must **not** be
 exported to make them testable — that would widen the module surface to serve a
 test. Each assertion reads the recorded loader call list, which is the artifact
 that says what the OS was actually asked to do.
@@ -1756,6 +1870,25 @@ grep -n "loadedEntryTargets" src/cli/schedule.js \
 # and NOTHING from schedule.js (the symbol is absent there, and unexported).
 # Command 2 prints nothing and takes the `||` branch, so the OK line is the
 # baseline and the FAIL branch is reachable only by regression.
+
+# V8 (AC12 / D6 — the NOOP boundary collision, added 2026-08-02).
+node tests/run.js tests/unit/init.test.js
+# REQUIRED: `ℹ fail 0`. On this branch BEFORE the D6 fix: fail 1, at
+# tests/unit/init.test.js:125 — /catches up automatically/i did not match.
+#
+# The seam is never taught to fabricate a readback — spawn.js must stay out of
+# the diff (D6's rejected alternative):
+git diff --name-only origin/main...HEAD | grep -x "src/scheduler/spawn.js" \
+  && echo "FAIL: the NOOP seam was edited — see Implementation notes D6" \
+  || echo "OK: src/scheduler/spawn.js is not in the diff"
+#
+# The assertion is platform-aware, and the darwin leg asserts the NEGATIVE (the
+# tripwire against option (b)). Both must be present:
+grep -n "did not accept it yet" tests/unit/init.test.js
+grep -n "doesNotMatch(r.stdout, /catches up automatically/i)" tests/unit/init.test.js
+# REQUIRED: one hit each, both inside the `process.platform === 'darwin'` branch
+# of `init --fresh-vault schedules the nightly dream and surfaces it (ADR-0014)`.
+# on main: 0 hits each.
 
 # V7 — the boundary gate and the pipeline.
 # Feed boundary-check the REAL diff, never a hand-maintained list. A list typed

--- a/docs/specs/WP-scheduler-register-replaces-loaded-record.md
+++ b/docs/specs/WP-scheduler-register-replaces-loaded-record.md
@@ -365,7 +365,7 @@ second test file** (D6, the 2026-08-02 boundary amendment below). **M** — one 
 | modify | docs/adr/README.md | **D0b** — the ADR index row for 0037. Written already by the architect alongside the ADR; the implementer does not touch it. Listed because it **is** in this branch's diff, and a Deliverables table that omits a changed file is exactly the boundary-gate failure this row fixes. |
 | modify | src/scheduler/generators.js | **D0** — add **four** names to `module.exports`, and add **two** new pure parsers (`launchdLoadedCalendar`, `launchdLoadedEnv` — D1b). Existing names exported unchanged:: `launchdLoadedArgs` (`:679-689`, used internally at `:787`) and `jobLaunchArgs` (`:208`, used internally at `:355`); the two new parsers are exported with them. Structural, not an API promise — the WP-114 precedent for `repairCatchup`. Audited, not assumed (see "Export audit" in Implementation notes): `catchupLaunchArgs` (`:1030`) and `loadedEntryTargets` (`:1007`) are **already** exported and need no change. |
 | modify | src/cli/schedule.js | **D1, D2, D3, D4 and D5** — the complete set, reconciled against the Implementation notes and the ACs: **D1** `darwinLoadedVerdict` + `ensureDarwinEntryRegistered` (new, non-exported, incl. the `plutil` preflight, the tri-state verdict, `verifyLoaded` and the rollback); **D2** the darwin per-job arm (`:429-431`, Table A row 1); **D3** `ensureCatchup` (`:314-317`, row 2); **D4** the linux arm (`:456-466`, row 3); **D5** `add()`'s guard at `:882` — drop the `changed &&` conjunct so it throws on ANY unloaded outcome (**required by AC11**; a cell that stopped at D4 would leave the user-facing false-success shipped). Nothing beyond those five — no probe, no heal, no notice string, no Windows path, and **`darwinReplaceEntry` itself is not edited** (it stays the heal path's primitive). |
-| modify | tests/unit/scheduler-schedule.test.js | **T1, T2, T2b, T2c, T2d, T2e, T2f, T2g, T3, T4, T5, T6, T7** — the complete Test index, enumerated rather than range-abbreviated because `T3-T7` silently excluded T2c/T2d/T2e (the `plutil` preflight, its existence gate, and the post-bootstrap verify). Plus the **four** existing assertions enumerated in AC6 — no others. |
+| modify | tests/unit/scheduler-schedule.test.js | **T1, T2, T2b, T2c, T2d, T2e, T2f, T2g, T3, T4, T5, T6, T7** — the complete Test index, enumerated rather than range-abbreviated because `T3-T7` silently excluded T2c/T2d/T2e (the `plutil` preflight, its existence gate, and the post-bootstrap verify). Plus, **and only**, what **Table E** enumerates (amended 2026-08-02, round-1 finding 3): its **five** existing-assertion rows and its authorized setup-only `fakeLaunchd` loader swap at the ten sites it lists. The new `fakeLaunchd` helper itself is part of the T-test scaffolding. **Table E is the authority — this cell deliberately carries no site list of its own**, because the earlier "four existing assertions" wording here was one of the mirrors that stayed stale while the branch carried five. T3 case (xxii) and T5 additionally carry **Table N**'s two notice assertions. |
 | modify | tests/unit/init.test.js | **D6 / T8 — architect boundary amendment, 2026-08-02.** ONE existing assertion in the single test `init --fresh-vault schedules the nightly dream and surfaces it (ADR-0014)`: its `/catches up automatically/i` match becomes platform-aware, because under `WIENERDOG_LOADER_NOOP=1` the darwin leg now correctly reports `loaded: false`. Added post-hoc — the collision was discovered at `npm test` time, not at spec time; the full record, the decision and the rejected alternative are in Implementation notes → **D6**. Nothing else in this file: no other test, no helper, no `tempEnv`/`run` change. |
 
 Not deliverables, deliberately: `src/scheduler/status.js`,
@@ -772,16 +772,137 @@ branch (the recurring failure mode in this chain — see the gate-3 row).
 | a degraded linux reload is never retried | move the reload block back inside `if (changed)` | T6 |
 | windows stops verifying before skipping | delete the `windowsLoadedTaskMatches` call | AC7's preservation assertion |
 
+### Table E — the existing-assertion change set in `tests/unit/scheduler-schedule.test.js` (canonical; +2026-08-02)
+
+**This table is the single place the existing-test blast radius is decided.** AC6,
+V3 and the `tests/unit/scheduler-schedule.test.js` Deliverables cell all defer to
+it; none of them restates a site. It was extracted here on 2026-08-02 because the
+same reconciliation D6 got for `tests/unit/init.test.js` was owed to this file:
+the round-1 review found a **fifth** forced assertion change and a ten-site
+setup-loader swap that AC6's "exactly FOUR" contradicted. Verified against the
+branch diff (`git diff origin/main...HEAD -- tests/unit/scheduler-schedule.test.js`),
+not against the enumeration it replaces.
+
+Line numbers are **`origin/main`'s** — the pre-change file, the anchor AC6 has
+always used — with the branch line second for navigation. Each changed assertion
+is **renamed** to state the new contract and cites ADR-0037 in a comment.
+
+| # | main | branch | Existing test (main line of its `test(` line) | What changes |
+|---|---|---|---|---|
+| 1 | `:365` | `:547-550` | `add registers the platform entry, records manifest, saves the job` (`:333`) | `assert.deepEqual(calls[0], ['launchctl','bootstrap',…])` — the readback now precedes it, so `calls[0]` is the `print` and a second assertion pins the `bootstrap` at `calls[1]`. **This one changes because of the readback design; an earlier draft of this spec asserted it would not.** |
+| 2 | `:500` | `:696` | `registerPlatform warns on a NONZERO daemon-reload …` (`:474`) | the `assert.equal(res.loaded, true, …)` whose message says the verdict "stays gated only on `enable --now`" ⇒ **`false`**, message rewritten to `reloadOk && enableOk` |
+| 3 | `:524` | `:722` | `registerPlatform warns on a MISSING ({status:null}) daemon-reload …` (`:504`) | the same assertion in the sibling test ⇒ **`false`** |
+| 4 | `:389-397` | `:580-593` | `a second identical add is idempotent (no OS call)` (`:389`) | **renamed** to `(no MUTATING OS call)`; `assert.equal(calls2.length, 0, …)` ⇒ `2`; **one new** assertion that every recorded call is non-mutating. Rewritten per AC5(iii) |
+| 5 | `:1019-1030` | `:1226-1243` | `repointSchedules after add is a no-op (changed:0, no OS call)` (`:1019`) | **(+2026-08-02)** **renamed** to `(changed:0, no MUTATING OS call)`; `assert.equal(calls.length, 0, 'no OS reload on an unchanged repoint')` ⇒ `2`; **one new** non-mutating assertion |
+
+**Row 5 is not a discovery, it is the consequence AC5(iii) already stated, at the
+site AC6 forgot.** `repointSchedules` is the **second** unchanged-register surface
+in this file — structurally identical to row 4's `add()` surface, reached by the
+same Table A third-column recount (darwin ⇒ two read-only `print`s, zero mutating
+calls). A verified skip costs one readback per site *wherever* it is driven from,
+so any assertion pinning "zero OS calls on an unchanged register" had to move.
+Row 4 and row 5 are one class with two members; enumerating one and not the other
+is exactly the range-abbreviation failure this spec greps for, in prose form.
+
+**`:982` (the heal path) is NOT in this table and must not be touched.** No
+existing assertion outside Table E's five rows may be edited.
+
+#### Table E authorization — the setup-only `fakeLaunchd` loader swap (+2026-08-02)
+
+`fakeLaunchd(paths)` is a **new helper this WP adds** (branch `:265`): a stateful
+launchd double that remembers what a `bootstrap` loaded and answers a later
+`print` from it, returning `{status:113}` for an absent label. Ten pre-existing
+tests have their **setup** loader swapped from the blind `() => ({ status: 0 })`
+to it.
+
+**The swap is FORCED, not stylistic, and it is the same NOOP-collision class as
+D6 — one file over.** A blind `{status:0}` carries no `stdout`, so
+`darwinLoadedVerdict` returns `'indeterminate'`, `ensureDarwinEntryRegistered`
+returns `false`, and after D5 `add()` **throws during the test's own setup** —
+the test dies before it reaches the subject it was written to check. These tests
+are not about registration; they are about manifests, descriptors, `remove`, and
+`list --json`, and they need a loader that is merely *honest* rather than blind.
+
+**It changes NO assertion.** Every assertion in these ten tests other than Table E
+rows 1, 4 and 5 stays byte-identical. Exhaustive site list, main line numbers:
+
+| main line(s) | Enclosing test (main line of its `test(` line) |
+|---|---|
+| `:338` | `add registers the platform entry, records manifest, saves the job` (`:333`) — also Table E row 1 |
+| `:392`, `:395` | `a second identical add is idempotent` (`:389`) — also Table E row 4 |
+| `:401` | `add then manifest.reverse DEFERS config.yaml … (WP-088)` (`:399`) |
+| `:420` | `remove runs the unload, deletes files, drops entries and the job` (`:418`) |
+| `:1021`, `:1025` | `repointSchedules after add is a no-op` (`:1019`) — also Table E row 5 |
+| `:1035` | `repointSchedules rewrites a stale embedded node path (changed:1)` (`:1033`) |
+| `:1084` | `ensureDreamSchedule schedules dream once at 03:30` (`:1081`) |
+| `:1131`, `:1132` | `list --json reports jobs with watermarks` (`:1129`) |
+| `:1185`, `:1199` | `add writes a 0600 job descriptor … (WP-156)` (`:1181`) |
+| `:1228` | `repointSchedules refreshes the descriptor … (WP-156)` (`:1224`) |
+
+**Every other `{ status: 0 }` loader in the file stays unchanged, and that is the
+boundary** — main `:106`, `:302`, `:321`, `:461`, `:495`, `:519`, `:643`, `:665`,
+`:752`, `:792`, `:840`, `:899`, `:1050`, `:1066`, `:1106`, `:1139`. A swap at any
+site not in the table above is out of boundary. Note in particular `:461`
+(`remove nope` — no register runs) and `:1139` (`list --json`'s own invocation):
+adjacent to swapped sites in the same tests, and deliberately left alone, because
+the swap is owed only where a register actually executes.
+
+### Table N — where §8's notice is asserted, and where it is inherited (canonical; +2026-08-02)
+
+**Extracted on 2026-08-02 under the round-1 review's finding 1.** Five acceptance
+criteria said a fixture "pushes §8's byte-exact notice" and no new test asserted
+it; two new test titles claimed it while asserting `res.loaded === false` only.
+The obligation was scattered across five AC clauses with no canonical owner —
+exactly the contract-density shape ADR-0031 names. This table is now that owner.
+
+**§8's notice has exactly ONE push site.** `repointSchedules`, `schedule.js:583`
+(main; `:802` on the branch), inside an unconditional `if (!res.loaded)` — no
+platform branch, no second emitter of that string. Audited: the other two
+`did not accept it` strings in `schedule.js` (`:870`, `:895` on the branch) are
+`ensureCatchup`'s **different** catch-up sentences, not §8's. This WP does not
+change any of the three. **Consequence, and the reason this table exists:** a
+fixture proves the notice **only if it drives `repointSchedules`**. A fixture that
+calls `registerPlatform` directly can prove `loaded === false` and nothing more —
+which is what all five clauses were resting on.
+
+| # | Leg | Fixture | Notice obligation |
+|---|---|---|---|
+| 1 | win32 | `tests/unit/scheduler-schedule.test.js:1112` — **pre-existing, unchanged by this WP** | **ASSERTED.** `r.notices.some((n) => /"dream".*did not accept it/.test(n))`, driven through `schedule.repointSchedules(…, { platform: 'win32' })`. It is the shape rows 2 and 3 copy |
+| 2 | darwin | **T3 case (xxii)** — benign-only drift (AC3 case (xxii)) | **MUST ASSERT.** After its `registerPlatform` leg, drive `schedule.repointSchedules` over the same `paths`/`manifest`/loader and assert row 1's regex. This is the **only** proof that the darwin leg's `loaded:false` reaches a human |
+| 3 | linux | **T5** — degraded reload (AC5 (i)) | **MUST ASSERT.** Same shape, `platform: 'linux'`, the degraded-reload loader |
+| 4 | darwin | **T2b** (AC2 d), **T2f** (AC2 g2), **T2e** (AC2 k) | **INHERITED — assert `res.loaded === false` only, and add NO notice assertion.** The notice follows from row 2 plus the single unconditional push site: these fixtures reach it through the *same* `!res.loaded` gate row 2 exercises, so re-driving a repoint in each would re-test one line of `schedule.js` three more times while tripling three already-intricate rollback fixtures |
+
+**RULING (2026-08-02, architect) — the five AC clauses are KEPT, not struck.**
+§8's notice **is** the user-facing half of ADR-0037's postcondition: "must not
+report success" is only observable because something is said out loud. Striking
+the clauses would leave this WP shipping a changed `loaded` return value whose
+only asserted user-visible consequence sits on **win32 — the one leg this WP does
+not touch** — which is the failing-outside-our-own-observability signature named
+in Context, reproduced inside the fix for it. The remedy is therefore the
+reviewer's preferred one, bounded by rows 2 and 3: **two** new notice assertions,
+one per fixed leg, driving `repointSchedules` and mirroring `:1112`. The
+remaining three clauses keep their notice text as a stated consequence and are
+discharged by row 4's inheritance argument — recorded here so it is an argued
+disposition, not a silent gap.
+
+**Test titles must match what they assert.** T3 case (xxii)'s and T5's titles
+already say "+ notice"; rows 2 and 3 are what make those titles true. Do **not**
+resolve this by editing the titles.
+
 ### Mirrored Surface Checklist
 
-Tables A and B are the single place these facts are decided. Registered mirrors —
+Tables A and B — and, since 2026-08-02, **Table E** (the existing-assertion change
+set) and **Table N** (where §8's notice is asserted) — are the single place these
+facts are decided. Registered mirrors —
 **including all three Deliverables cells**, which are the permission boundary the
 implementer reads first (the lesson from `WP-scheduler-node-path-durability`
 rounds 2-3, where an unregistered Deliverables cell shipped a wrong test set):
 
 - [ ] **(+r3/r5)** Deliverables cell for `src/scheduler/generators.js` — D0 exports **four** names (`launchdLoadedArgs`, `jobLaunchArgs`, and the two new parsers `launchdLoadedCalendar`/`launchdLoadedEnv`) and adds the two parser bodies (D1b). Mirrors **Table A2**.
 - [ ] Deliverables cell for `src/cli/schedule.js` (the four D-sites — Table A rows 1-3)
-- [ ] Deliverables cell for `tests/unit/scheduler-schedule.test.js` (T1, T2, T2b, T2c, T2d, T2e, T3, T4, T5, T6, T7 + AC6's four assertions)
+- [ ] Deliverables cell for `tests/unit/scheduler-schedule.test.js` (T1, T2, T2b, T2c, T2d, T2e, T3, T4, T5, T6, T7 + whatever **Table E** enumerates — the cell carries no site list of its own)
+- [ ] **(+2026-08-02)** **Table E** — the existing-assertion change set (five rows) and its authorized setup-only `fakeLaunchd` swap. Its registered mirrors are **AC6**, **AC5(iii)**, **V3**'s read-and-confirm instruction, and the `tests/unit/scheduler-schedule.test.js` Deliverables cell. Each of those defers to the table and restates no site
+- [ ] **(+2026-08-02)** **Table N** — where §8's notice is asserted (rows 2-3) and where it is inherited (row 4). Its registered mirrors are **AC2(d)**, **AC2(g2)**, **AC2(k)**, **AC3 case (xxii)**, **AC5(i)**, Test index rows **T3** and **T5**, the `tests/unit/scheduler-schedule.test.js` Deliverables cell, and **V9**
 - [ ] **(+2026-08-02)** Deliverables cell for `tests/unit/init.test.js` (D6 / T8 — the one platform-aware assertion). Mirrors **Table A** rows 1 and 3: darwin verifies and so can report `loaded:false` under a blind seam, linux does not verify and so still reports `loaded:true`. Its other registered mirrors are Implementation notes → **D6**, **AC12**, Test index **T8**, and **V8**.
 - [ ] Deliverables cell for `docs/adr/0037-…` (the rule — Table A's spine)
 - [ ] "Exact contracts" — both JSDoc blocks and the `ensureDarwinEntryRegistered` body
@@ -789,12 +910,12 @@ rounds 2-3, where an unregistered Deliverables cell shipped a wrong test set):
 - [ ] **(+r4)** Implementation notes → D5 (`add()`'s guard) and AC11 — the CLI-surface mirror of ADR-0037's postcondition
 - [ ] **(+r4)** ADR-0037's Consequences — the rollback consequence and the withdrawn crash-marker promise both mirror this spec's rollback section
 - [ ] Implementation notes → Export audit, D0, D0b, D1, D1b, D2, D3, D4, D5, and **"Rollback — OWNER-DIRECTED"** (its four contract properties + the crash-window table)
-- [ ] Acceptance criteria AC1, AC2 (incl. its rollback set), AC3, AC4, AC5 (rows 1-3), AC6 (the four changed assertions), AC7 (row 4 preservation), AC8 (the marker), AC9, AC10, AC11 (D5)
-- [ ] Verification commands V2-V6
+- [ ] Acceptance criteria AC1, AC2 (incl. its rollback set), AC3, AC4, AC5 (rows 1-3), AC6 (**defers to Table E**), AC7 (row 4 preservation), AC8 (the marker), AC9, AC10, AC11 (D5)
+- [ ] Verification commands V2, V3, V4, V5, V6, V6b, V9 (enumerated, not range-abbreviated — the same insertion growth that produced V6b and V9)
 - [ ] Table B rows, each naming its Table A / A2 row
 - [ ] **(+r5)** Current state §7b (the executed readback evidence behind Table A2 — four facts) and Table A2 itself
 - [ ] **(+r6)** **Table A1** (the skip decision tree and the allowed bookkeeping) — mirrored by the contract body's step (a), D1b, AC1's Table A1 fixture, AC5's recount, and the Table B live-match rows
-- [ ] Test index rows T1, T2, T2b, T2c, T2d, T2e, T3, T4, T5, T6, T7
+- [ ] Test index rows T1, T2, T2b, T2c, T2d, T2e, **T2f**, **T2g**, T3, T4, T5, T6, T7, **T8** (**+2026-08-02** — T2f/T2g/T8 were absent from this line while the Deliverables cell listed all three: the same enumeration drift, in the mirror registry itself)
 - [ ] The banner's cross-spec mapping table — **both** macOS sites map to that spec's Table C row 5
 - [ ] Definition of done items 5 (that spec's 0a) and 6 (the ADR signature gate)
 
@@ -811,6 +932,25 @@ it. Round 13's run found three defects: the `schedule.js` cell stopped at D4 whi
 AC11 requires D5; the test cell's `T3-T7` range silently excluded T2c/T2d/T2e; and
 `src/scheduler/generators.js` was listed as **both** a deliverable and a
 not-deliverable.
+
+**Added 2026-08-02 after the round-1 review — the two layers a pre-implementation
+pass structurally cannot run, and which therefore run on every post-implementation
+revision instead:**
+
+- **diff↔enumeration.** Every counted claim about existing code ("exactly FOUR
+  existing assertions change") is re-derived from
+  `git diff origin/main...HEAD -- <file>` and never from the previous draft.
+  Finding 3 was a count written before the code existed and never re-derived; the
+  branch carried five assertion sites and a ten-site setup-loader swap. Counts
+  about a tree you have not diffed are estimates wearing a contract's clothes.
+  **Table E** is where this layer's output now lives.
+- **verification↔contract.** Every grep in "Verification steps" is executed
+  against a tree that satisfies the spec's *other* mandates — in particular the
+  JSDoc in "Exact contracts". Finding 2 was two greps that a spec-conforming
+  branch fails **because** it conformed: the mandated JSDoc names
+  `ensureWindowsTaskRegistered` and `loadedEntryTargets`, and the greps matched
+  prose. A verification command that a correct implementation fails is worse than
+  no command, because it teaches the implementer to reword the contract.
 
 **The range-abbreviation check, with its grep.** Round 13 enumerated the two
 Deliverables cells and wrote the lesson — and left the *same* abbreviation standing
@@ -1583,7 +1723,9 @@ mock `process.platform` — and no test may touch a real OS scheduler
       argv is what launchd is asked to load again;
       (d) the result is **`loaded: false`** and `repointSchedules` pushes §8's
       byte-exact notice — rollback restores scheduling, it does **not** make the
-      replacement a success;
+      replacement a success. **Table N row 4 — INHERITED (+2026-08-02): assert
+      `loaded: false` only and add NO notice assertion to this fixture;** the
+      notice is proved once per leg, at Table N rows 2 and 3;
       (e) with `priorBytes === null` (no plist existed) there is no restore attempt
       and the result is still `loaded: false`;
       (f) **the divergence case (CX-2)** — `changed === false` with the disk already
@@ -1604,7 +1746,8 @@ mock `process.platform` — and no test may touch a real OS scheduler
       same path, and the teardown proceeds. Assert the staleness guard **declines**
       to restore (the file still holds the concurrent bytes, byte for byte), no
       restoring `bootstrap` is issued, the result is `loaded: false`, and §8's
-      notice fires;
+      notice fires (**Table N row 4 — INHERITED (+2026-08-02)**: assert
+      `loaded: false` only; add NO notice assertion to this fixture);
       (h) **the preflight rejects (T2c)** — `existsSync(PLUTIL)` true and the
       loader answers `{status: 1}` for `[PLUTIL,'-lint',plistPath]`, with a loaded
       mismatched record present ⇒ `loaded: false` and **no `bootout` anywhere**.
@@ -1623,7 +1766,9 @@ mock `process.platform` — and no test may touch a real OS scheduler
       an unparseable readback) ⇒ **`loaded: false`** with §8's notice and **no
       `bootout`**. This is the branch a round-9 draft returned `true` from without
       any readback at all. Run it twice, once with a mismatching record and once
-      with an unparseable one, since both must fail closed;
+      with an unparseable one, since both must fail closed. **Table N row 4 —
+      INHERITED (+2026-08-02): assert `loaded: false` only; add NO notice
+      assertion to this fixture;**
       (l) the same shape but the trailing `print` **matches** ⇒ `loaded: true`,
       call order `print` → `bootstrap` → `print`.
       **Every fixture in this set pins `verdict === 'mismatch-fatal'`** — that is now the
@@ -1693,7 +1838,14 @@ mock `process.platform` — and no test may touch a real OS scheduler
       `changed` is true, and the `bootstrap` fails because the label is loaded.
       Assert: verdict `'mismatch-benign'`, **no `bootout` anywhere in the call
       list**, the pre-existing record therefore still loaded, `loaded: false`, and
-      §8's notice. Run the sibling too — the same shape with a **FATAL** field
+      §8's notice. **Table N row 2 — MUST ASSERT (+2026-08-02): this is the
+      darwin leg's ONLY notice proof.** After the `registerPlatform` leg, drive
+      `schedule.repointSchedules` over the same `paths`/`manifest`/loader and
+      assert `r.notices.some((n) => /"dream".*did not accept it/.test(n))`,
+      mirroring the pre-existing win32 fixture at `:1112`. A `registerPlatform`-
+      only fixture proves `loaded: false` and nothing about the notice, because
+      the notice's single push site is inside `repointSchedules` (Table N).
+      Run the sibling too — the same shape with a **FATAL** field
       differing (a stale env binding) ⇒ verdict `'mismatch-fatal'` and the replace
       path IS taken — so the pair pins the tier boundary from both sides;
       (xiv) **the indeterminate fixture (CX-1)** — `print` exits **0** (a record IS
@@ -1722,31 +1874,45 @@ mock `process.platform` — and no test may touch a real OS scheduler
       (i) linux, degraded reload (`{status:1}`) with a successful `enable --now` ⇒
       `loaded: false` (on `main`: `true`), and `repointSchedules` pushes §8's
       byte-exact notice; `{status:null}` and a missing result also count as
-      failure. (T5)
+      failure. **Table N row 3 — MUST ASSERT (+2026-08-02): T5 must DRIVE
+      `schedule.repointSchedules(…, { platform: 'linux' })` with the degraded-
+      reload loader and assert the notice regex**, mirroring the pre-existing
+      win32 fixture at `:1112`. This is the linux leg's only notice proof; the
+      `registerPlatform`-only form asserts `loaded: false` and nothing more. (T5)
       (ii) linux, `changed` false ⇒ the reload **and** `enable --now` still run —
       exactly those two `systemctl` calls and no others. (T6)
-      (iii) the shipped invariant test at `:389-397` stays green under its
-      rewritten contract (AC6 item 4), and is the per-platform statement of Table
+      (iii) the shipped invariant tests at `:389-397` **and `:1019-1030`** stay
+      green under their rewritten contracts (**Table E rows 4 and 5** — the second
+      of those was added 2026-08-02; `repointSchedules` is the second unchanged-
+      register surface and the recount below applies to it identically), and are
+      the per-platform statement of Table
       A's third column, **recounted from the Table A1 decision tree**: darwin ⇒
       **two** read-only `print`s (per-job + catch-up, per AC3's call-count scoping)
       and **zero** mutating calls — and this now holds whether `changed` is false
       **or** true, since the live match wins either way, which is the property
       Codex's missing-manifest-entry fixture pins; linux ⇒ exactly
       `daemon-reload` + `enable --now`, both idempotent.
-- [ ] **AC6 (exactly FOUR existing assertions change, each enumerated).** No other
-      existing assertion in `tests/unit/scheduler-schedule.test.js` may be edited.
-      Each changed one is **renamed** to state the new contract and cites ADR-0037
-      in a comment:
-      1. `:365` — `assert.deepEqual(calls[0], ['launchctl','bootstrap',…])`. The
-         readback now precedes it, so `calls[0]` is the `print` and the `bootstrap`
-         moves to `calls[1]`. **This one changes because of the readback design; an
-         earlier draft of this spec asserted it would not.**
-      2. `:500` — the `assert.equal(res.loaded, true, …)` whose message says the
-         verdict stays gated only on `enable --now` ⇒ must become `false`.
-      3. `:524` — the same assertion in the sibling `{status:null}` test ⇒ `false`.
-      4. `:389-397` — "a second identical add is idempotent (no OS call)" ⇒
-         rewritten per AC5(iii) and **renamed** to say "no MUTATING OS call".
-      `:982` (the heal path) is **not** in this set and must not be touched.
+- [ ] **AC6 (the existing-assertion change set — FIVE sites, plus one authorized
+      setup-only swap; amended 2026-08-02). Canonical: Table E.** Every changed
+      site and every authorized setup-loader swap in
+      `tests/unit/scheduler-schedule.test.js` is enumerated in **Table E** and in
+      no other place; this criterion does not restate them, because a restated
+      canonical is how the earlier "exactly FOUR" survived un-updated while the
+      branch carried five. Assert against Table E:
+      1. **exactly the five rows of Table E** change an assertion — no existing
+         assertion outside them may be edited, and `:982` (the heal path) is not
+         among them;
+      2. **exactly the sites listed in Table E's authorization block** have their
+         setup loader swapped from `() => ({ status: 0 })` to `fakeLaunchd(paths)`,
+         and **no assertion changes at any of them** beyond Table E rows 1, 4 and 5;
+      3. every other `{ status: 0 }` loader named in that block's
+         stays-unchanged list is untouched.
+      **The round-1 review's finding 3 is what this criterion now records:** the
+      fifth site (Table E row 5, the `repointSchedules` no-op) and the ten-site
+      swap were **forced** — the swap is a setup-time collision of the same class
+      as D6, and row 5 is the direct consequence AC5(iii) already documented at
+      the second unchanged-register surface. They were reported honestly by the
+      implementer; the spec, not the implementation, was wrong.
 - [ ] **AC7 (Table A row 4 — Windows preservation).** `ensureWindowsTaskRegistered`
       and `windowsLoadedTaskMatches` are unchanged and absent from the diff (V5);
       the existing Windows registration assertions pass unmodified.
@@ -1790,7 +1956,7 @@ mock `process.platform` — and no test may touch a real OS scheduler
 |----|------|----------------|
 | T1 | tests/unit/scheduler-schedule.test.js | darwin replace ordering + `loaded` (AC1) |
 | T2 | tests/unit/scheduler-schedule.test.js | teardown guard — no `bootout` when nothing is loaded; marker ordering and non-firing (AC2, AC8) |
-| T3 | tests/unit/scheduler-schedule.test.js | the verified skip, **cases (i)-(xxi)** — the stale-tail, length-mismatch and crash-recovery fixtures; the catch-up `hour:null` shape and its present-`Hour` refusal; the empty-env fixture; the indeterminate fixture; the five round-11 drift-only fixtures (`path`, `program`, log paths, `spawn type`); the extra-trigger and foreign-stream trigger fixtures; and the absent-field ⇒ `'indeterminate'` fixture. Marker non-firing (AC3, AC8) |
+| T3 | tests/unit/scheduler-schedule.test.js | the verified skip, **cases (i)-(xxi)** — the stale-tail, length-mismatch and crash-recovery fixtures; the catch-up `hour:null` shape and its present-`Hour` refusal; the empty-env fixture; the indeterminate fixture; the five round-11 drift-only fixtures (`path`, `program`, log paths, `spawn type`); the extra-trigger and foreign-stream trigger fixtures; and the absent-field ⇒ `'indeterminate'` fixture. Marker non-firing (AC3, AC8). **Case (xxii) additionally carries Table N row 2 — the darwin leg's §8-notice assertion, driven through `repointSchedules` (+2026-08-02)** |
 | T2b | tests/unit/scheduler-schedule.test.js | the rollback set — restore file + re-bootstrap prior argv + `loaded:false` + notice + the `priorBytes === null` bound (AC2) |
 | T2c | tests/unit/scheduler-schedule.test.js | the `plutil` preflight — rejects (no `bootout`, absolute argv) and passes (AC2 h, j) |
 | T2d | tests/unit/scheduler-schedule.test.js | `existsSync(PLUTIL)` false ⇒ no `plutil` argv issued, register proceeds (AC2 i) |
@@ -1798,7 +1964,7 @@ mock `process.platform` — and no test may touch a real OS scheduler
 | T2g | tests/unit/scheduler-schedule.test.js | the binding fixture — a rollback reaching the staleness guard must NOT throw (`o.canonicalBytes` is bound at both call sites); asserts a normal `loaded:false` (AC2 g1) |
 | T2e | tests/unit/scheduler-schedule.test.js | **the post-bootstrap verify on the ABSENT-label path (CX9-1)** — bootstrap succeeds, trailing `print` mismatched or unparseable ⇒ `loaded:false`, no `bootout`; and the matching case ⇒ `loaded:true` (AC2 k, l) |
 | T4 | tests/unit/scheduler-schedule.test.js | catch-up through the same helper (AC4) |
-| T5 | tests/unit/scheduler-schedule.test.js | linux degraded reload ⇒ `loaded:false` + notice; null/missing results (AC5 i) |
+| T5 | tests/unit/scheduler-schedule.test.js | linux degraded reload ⇒ `loaded:false` + notice; null/missing results (AC5 i). **The "+ notice" half is Table N row 3 and must be DRIVEN through `repointSchedules`, not inferred from `registerPlatform` (+2026-08-02)** |
 | T6 | tests/unit/scheduler-schedule.test.js | linux unchanged bytes still reload + enable, exactly two calls (AC5 ii) |
 | T7 | tests/unit/scheduler-schedule.test.js | **CLI path** — `add()` throws on an unloaded outcome for an UNCHANGED entry, on both legs: unchanged-darwin readback-mismatch-then-failure, and unchanged-linux degraded reload (AC11) |
 | T8 | tests/unit/init.test.js | **(+2026-08-02)** the D6 boundary collision — a REAL `init --fresh-vault` subprocess under `WIENERDOG_LOADER_NOOP=1` must not claim catch-up on the darwin leg, where nothing was verified (AC12). **Not a new test and not a `verified-register:` subtest** — one existing assertion in an existing test, so the naming rule below does not apply to it. |
@@ -1829,17 +1995,27 @@ npm test --silent -- --test-reporter=tap tests/unit/scheduler-schedule.test.js \
   | grep -cE "^ok [0-9]+ - verified-register: "
 # on main: 0.
 
-# V3 (AC6 — MECHANICAL, because it greps the assertion BODY. A count of changed
-#     `test(` declaration lines cannot see an edited body under an unchanged
-#     name, which is why that form was dropped.)
+# V3 (AC6 / Table E — MECHANICAL, because it greps the assertion BODY. A count of
+#     changed `test(` declaration lines cannot see an edited body under an
+#     unchanged name, which is why that form was dropped.)
 grep -c "stays gated only on" tests/unit/scheduler-schedule.test.js
-# on main: 2 (the two linux `loaded === true` assertions). REQUIRED after: 0.
+# on main: 2 (the two linux `loaded === true` assertions, Table E rows 2 and 3).
+# REQUIRED after: 0.
+#
+# Table E rows 4 and 5 are the two renames; both must have landed:
+grep -c "no MUTATING OS call" tests/unit/scheduler-schedule.test.js
+# on main: 0. REQUIRED after: >= 4 — each of the two renamed test titles plus
+# each row's new non-mutating assertion message.
 #
 # Then paste the FULL diff of the file and confirm BY READING that it touches
-# only AC6's four enumerated sites plus the new T1/T2/T2b/T2c/T2d/T2e/T3/T4/T5/
-# T6/T7 blocks. There is no grep
-# that proves "nothing else moved" in a JS file — this repo has no parser. The
-# enumeration in AC6 is the contract; the full diff is the evidence.
+# only (a) **Table E's five assertion rows**, (b) **Table E's authorized
+# setup-only `fakeLaunchd` swap at exactly the sites its authorization block
+# lists** — with no assertion changed at any of them beyond rows 1, 4 and 5 —
+# and (c) the new T1/T2/T2b/T2c/T2d/T2e/T2f/T2g/T3/T4/T5/T6/T7 blocks and the
+# helpers they add. There is no grep that proves "nothing else moved" in a JS
+# file — this repo has no parser. **Table E is the contract**; the full diff is
+# the evidence. (Amended 2026-08-02: this instruction previously said "AC6's
+# four enumerated sites", which the branch contradicted at five.)
 git diff origin/main...HEAD -- tests/unit/scheduler-schedule.test.js
 
 # V4 (AC9 — no daemon, no new top-level require; judged by reading).
@@ -1847,10 +2023,21 @@ git diff origin/main...HEAD -- src/cli/schedule.js | grep -E "^\+" \
   | grep -nE "setInterval|setTimeout|^\+const .* = require\(" \
   || echo "OK: no timer and no new top-level require"
 
-# V5 (AC7 — Windows leg untouched; judged by reading).
+# V5 (AC7 — Windows leg untouched; judged by reading). COMMENT-TOLERANT, and
+#     that is required, not a convenience (amended 2026-08-02, round-1 finding 2):
+#     the JSDoc this spec MANDATES for `ensureDarwinEntryRegistered` contains the
+#     literal "Mirrors ensureWindowsTaskRegistered" (see "Exact contracts"), so
+#     the bare form failed on a branch that followed the spec exactly. The fix is
+#     to narrow the grep to FUNCTIONAL references; the contract JSDoc must NOT be
+#     reworded to dodge a grep.
 git diff origin/main...HEAD -- src/cli/schedule.js \
+  | grep -E "^[-+]" \
+  | grep -vE "^[-+][[:space:]]*(\*|//|/\*)" \
   | grep -nE "ensureWindowsTaskRegistered|windowsLoadedTaskMatches" \
-  || echo "OK: the Windows registration path is not in the diff"
+  || echo "OK: no functional reference to the Windows registration path is in the diff"
+# The middle filter drops added/removed lines whose first non-blank character
+# starts a comment (` * `, `//`, `/*`) — i.e. prose. A real edit to the Windows
+# leg is a code line and still fails the check.
 
 # V6 (Current state §9 — the register must not read the durable status cache).
 git diff origin/main...HEAD -- src/cli/schedule.js | grep -nE "^\+.*readSchedulerStatus" \
@@ -1859,11 +2046,23 @@ git diff origin/main...HEAD -- src/cli/schedule.js | grep -nE "^\+.*readSchedule
 # V6b (CX-1 — the verified skip must compare the COMPLETE argv, not the head).
 grep -n "launchdLoadedArgs" src/scheduler/generators.js src/cli/schedule.js
 # REQUIRED after: the definition + its internal use + the new module.exports line
-# in generators.js, AND at least one use in schedule.js. If schedule.js instead
-# references `loadedEntryTargets`, the head-only comparison was reintroduced:
-grep -n "loadedEntryTargets" src/cli/schedule.js \
+# in generators.js, AND at least one FUNCTIONAL use (`gen.launchdLoadedArgs(`) in
+# schedule.js. If schedule.js instead CALLS `loadedEntryTargets`, the head-only
+# comparison was reintroduced. COMMENT-TOLERANT, and required to be (amended
+# 2026-08-02, round-1 finding 2): this spec's own mandated JSDoc for
+# `darwinLoadedVerdict` says the verdict vocabulary is "adopted verbatim from
+# `loadedEntryTargets`" (see "Exact contracts"), so the bare form drove the FAIL
+# branch on a branch that followed the spec exactly. Narrow the grep; do NOT
+# reword the contract JSDoc to dodge it.
+grep -nE "loadedEntryTargets" src/cli/schedule.js \
+  | grep -vE "^[0-9]+:[[:space:]]*(\*|//|/\*)" \
   && echo "FAIL: the register path is comparing positions, not the full argv" \
   || echo "OK: the register path does not use the two-position comparison"
+# The filter drops lines whose first non-blank character starts a comment. Any
+# real reference — `gen.loadedEntryTargets(…)`, or a destructuring import — is a
+# code line and still trips the FAIL branch. `schedule.js` reaches generators
+# only through `const gen = require('../scheduler/generators')` (`:11`), so a
+# functional use cannot be written without a code line naming the symbol.
 # on main, executed: command 1 prints TWO lines from generators.js —
 #   679:function launchdLoadedArgs(stdout) {
 #   787:      const args = launchdLoadedArgs(stdout);
@@ -1889,6 +2088,18 @@ grep -n "doesNotMatch(r.stdout, /catches up automatically/i)" tests/unit/init.te
 # REQUIRED: one hit each, both inside the `process.platform === 'darwin'` branch
 # of `init --fresh-vault schedules the nightly dream and surfaces it (ADR-0014)`.
 # on main: 0 hits each.
+
+# V9 (Table N rows 2-3 — §8's notice is asserted on BOTH fixed legs; the
+#     round-1 finding-1 ruling, added 2026-08-02).
+grep -n "did not accept it" tests/unit/scheduler-schedule.test.js
+# on main, executed: exactly ONE hit — `:1112`, the pre-existing win32 fixture
+# (Table N row 1), which is the only leg this WP does not change.
+# REQUIRED after: exactly THREE hits — row 1, plus one inside T3 case (xxii)
+# (darwin) and one inside T5 (linux). Then confirm BY READING that each of the
+# two new hits sits in a block that calls `schedule.repointSchedules(`: §8's
+# notice has exactly one push site (`schedule.js:583`), inside repointSchedules,
+# so a `registerPlatform`-only fixture cannot reach it and a notice assertion
+# placed anywhere else is testing a string it never produced.
 
 # V7 — the boundary gate and the pipeline.
 # Feed boundary-check the REAL diff, never a hand-maintained list. A list typed

--- a/src/cli/schedule.js
+++ b/src/cli/schedule.js
@@ -54,6 +54,178 @@ function darwinReplaceEntry(loader, uid, label, plistPath) {
   return loader(['launchctl', 'bootstrap', `gui/${uid}`, plistPath]).status === 0;
 }
 
+/** Absolute path to `plutil`, the macOS plist linter used as a preflight before
+ *  ANY teardown in `ensureDarwinEntryRegistered` (WP-scheduler-register-replaces-
+ *  loaded-record). Never a PATH lookup (WP-154's exec-identity rule) — gating on
+ *  `fs.existsSync(PLUTIL)` rather than the loader's result shape is what keeps
+ *  "absent plutil" distinguishable from "lint rejected the file" (see the
+ *  preflight's own comment below). */
+const PLUTIL = '/usr/bin/plutil';
+
+/** Read ONE top-level `key = value` line out of a `launchctl print` record — the
+ *  same parse shape `launchdLoadedArgs` uses for the `arguments` block, applied to
+ *  a single scalar line (Current state §7c, Implementation notes D1). Trim each
+ *  line, split on the FIRST ` = `; the key must match exactly. PURE: string work
+ *  only, never throws. @param {string} stdout @param {string} key
+ *  @returns {string|null} null when the key's line is absent (an incomplete
+ *    readback — never treated as a value to compare). */
+function readTopLevelField(stdout, key) {
+  const lines = String(stdout).split('\n');
+  for (const line of lines) {
+    const t = line.trim();
+    const idx = t.indexOf(' = ');
+    if (idx === -1) continue;
+    if (t.slice(0, idx) === key) return t.slice(idx + 3);
+  }
+  return null;
+}
+
+/**
+ * What does the LOADED launchd record say, relative to what we would register
+ * right now? Returns a TRI-STATE verdict, never a boolean. Pure
+ * string work over `launchctl print` stdout — no spawn, no fs, never throws.
+ * Compares EVERY canonical field that can vary between two renders, not just
+ * the argv (Table A2): the complete ProgramArguments element by element, the
+ * StartCalendarInterval Hour/Minute, and the EnvironmentVariables bindings by
+ * CONTAINMENT (launchd injects keys of its own — Current state §7b fact 1).
+ * The verdict vocabulary is **adopted verbatim from `loadedEntryTargets`**
+ * (`generators.js:784`) and **extended by one member** for Table A2b's fatality
+ * tiering — `'match' | 'mismatch-fatal' | 'mismatch-benign' | 'indeterminate'`.
+ * The bare `'mismatch'` is NOT a value this function can return; it survives in
+ * this spec only as narration of the pre-tiering contract.
+ *   'match'         — every block parsed AND every compared value equal.
+ *   'mismatch-fatal'  — everything parsed AND a FATAL-tier field differs
+ *                     (Table A2b). THE ONLY VERDICT THAT MAY AUTHORIZE A TEARDOWN.
+ *   'mismatch-benign' — everything parsed, every FATAL field equal, and only a
+ *                     BENIGN-tier field differs. No skip AND no teardown: the
+ *                     loaded record is still doing its authorized job, so
+ *                     destroying it could leave no working schedule at all.
+ *   'indeterminate' — any block failed to parse. The ABSENCE of evidence, not
+ *                     evidence of divergence: it permits the non-destructive
+ *                     bootstrap attempt and NOTHING further.
+ * @param {string} stdout  `launchctl print` output (untrusted display text)
+ * @param {{argv:string[], hour:number|null, minute:number, env:Array<[string,string]>,
+ *          path:string, stdoutPath:string, stderrPath:string, spawnType:string}} expect
+ *   the canonical values just rendered
+ * @returns {'match'|'mismatch-fatal'|'mismatch-benign'|'indeterminate'}
+ */
+function darwinLoadedVerdict(stdout, expect) {
+  const argv = gen.launchdLoadedArgs(stdout);
+  const cal = gen.launchdLoadedCalendar(stdout);
+  const env = gen.launchdLoadedEnv(stdout);
+  const p = readTopLevelField(stdout, 'path');
+  const program = readTopLevelField(stdout, 'program');
+  const stdoutPath = readTopLevelField(stdout, 'stdout path');
+  const stderrPath = readTopLevelField(stdout, 'stderr path');
+  const spawnTypeRaw = readTopLevelField(stdout, 'spawn type');
+
+  // Any source unparseable, or any single-line field absent ⇒ the ABSENCE of
+  // evidence — never a mismatch of either tier (Implementation notes D1).
+  if (
+    argv === null || cal === null || env === null ||
+    p === null || program === null || stdoutPath === null ||
+    stderrPath === null || spawnTypeRaw === null
+  ) {
+    return 'indeterminate';
+  }
+  const spawnType = spawnTypeRaw.split(' ')[0]; // 'background (5)' → 'background'
+
+  // FATAL tier (Table A2b): argv, program, calendar, env.
+  let fatal =
+    argv.length !== expect.argv.length ||
+    !argv.every((a, i) => a === expect.argv[i]) ||
+    program !== expect.argv[0] ||
+    cal.hour !== expect.hour ||
+    cal.minute !== expect.minute;
+  if (!fatal) {
+    for (const [k, v] of expect.env) {
+      if (!env.has(k) || env.get(k) !== v) {
+        fatal = true;
+        break;
+      }
+    }
+  }
+  if (fatal) return 'mismatch-fatal';
+
+  // BENIGN tier (Table A2b): log paths, spawn type, the loaded-from path.
+  const benign =
+    p !== expect.path ||
+    stdoutPath !== expect.stdoutPath ||
+    stderrPath !== expect.stderrPath ||
+    spawnType !== expect.spawnType;
+  return benign ? 'mismatch-benign' : 'match';
+}
+
+/**
+ * Register one launchd entry, reporting success only from evidence about what
+ * launchd now holds (ADR-0037). Mirrors ensureWindowsTaskRegistered. ONE
+ * `launchctl print` serves both decisions: whether a verified skip is allowed,
+ * and whether a teardown is justified.
+ * @param {(argv:string[])=>{status:number,stdout?:string}} loader
+ * @param {number} uid @param {string} label @param {string} plistPath
+ * @param {{changed:boolean, expect:{argv:string[],hour:number|null,minute:number,env:Array<[string,string]>,
+ *          path:string,stdoutPath:string,stderrPath:string,spawnType:string},
+ *          priorBytes:Buffer|null, canonicalBytes:Buffer, onBeforeTeardown:()=>void}} o
+ *   `canonicalBytes` is the rendered plist this invocation wrote — the SAME value
+ *   handed to `ensureEntry`. It is REQUIRED: the staleness guard reads it, and a
+ *   missing binding is a ReferenceError on the post-teardown failure path, i.e. a
+ *   crash with the schedule already removed.
+ * @returns {boolean} true only when launchd verifiably holds this entry
+ */
+function ensureDarwinEntryRegistered(loader, uid, label, plistPath, o) {
+  const printed = loader(['launchctl', 'print', `gui/${uid}/${label}`]);
+  const isLoaded = !!printed && printed.status === 0;
+  //     `verdict` is FOUR-STATE plus the caller's 'absent': 'absent' |
+  //     'indeterminate' | 'mismatch-benign' | 'mismatch-fatal' | 'match'.
+  const verdict = isLoaded ? darwinLoadedVerdict(printed.stdout || '', o.expect) : 'absent';
+  // (a) THE LIVE MATCH WINS — regardless of o.changed. The readback is the
+  //     evidence; `changed` is a statement about a FILE and must not force the
+  //     teardown of a record that already is what we would register.
+  if (verdict === 'match') return true;
+  // POST-BOOTSTRAP VERIFY — applied after EVERY successful bootstrap, not only
+  // the post-teardown one. launchd loads whatever is on disk at that moment, not
+  // the bytes we rendered/linted, so a bootstrap exit 0 is NOT evidence about
+  // what got loaded. DETECTION only, never a repair (see "The file race").
+  const verifyLoaded = () => {
+    const after = loader(['launchctl', 'print', `gui/${uid}/${label}`]);
+    return !!after && after.status === 0
+      && darwinLoadedVerdict(after.stdout || '', o.expect) === 'match';
+  };
+  // (b) non-destructive attempt first (ADR-0018 ordering, preserved)
+  if (loader(['launchctl', 'bootstrap', `gui/${uid}`, plistPath]).status === 0) return verifyLoaded();
+  // (c0) PREFLIGHT — never destroy a loaded record for a known-bad replacement.
+  //      Gated on EXISTENCE, not on the loader's result shape: schedulerSpawn
+  //      normalizes a spawn error (incl. ENOENT) to {status:1} and discards the
+  //      error, so "absent plutil" and "lint rejected the file" are the SAME
+  //      value to a caller. Existence is what distinguishes them.
+  if (fs.existsSync(PLUTIL)) {
+    if (loader([PLUTIL, '-lint', plistPath]).status !== 0) return false;
+  }
+  // (c) TEARDOWN ONLY ON A POSITIVELY ESTABLISHED MISMATCH. 'absent' means
+  //     nothing to tear down; 'indeterminate' is the ABSENCE of evidence, not
+  //     evidence of divergence — destroying a record we could not read would be
+  //     the exact opposite of this WP's rule.
+  if (verdict !== 'mismatch-fatal') return false;   // benign / indeterminate / absent
+  o.onBeforeTeardown();                       // ADR-0018 marker (advisory — see below)
+  loader(['launchctl', 'bootout', `gui/${uid}/${label}`]);
+  if (loader(['launchctl', 'bootstrap', `gui/${uid}`, plistPath]).status === 0) return verifyLoaded();
+  // (d) ROLLBACK — the replacement is unbootstrappable; restore the prior
+  //     registration so no destruction window ships. Never returns true.
+  //     BEST-EFFORT STALENESS CHECK (not atomic — see the residual): restore ONLY
+  //     if the file still holds the bytes THIS invocation wrote. If another
+  //     invocation has written since, its bytes are newer than ours and
+  //     overwriting them would destroy a registration we never inspected.
+  if (o.priorBytes !== null) {
+    let current = null;
+    try { current = fs.readFileSync(plistPath); } catch { current = null; }
+    if (current !== null && current.equals(o.canonicalBytes)) {
+      try { fs.writeFileSync(plistPath, o.priorBytes); } catch { return false; }
+      loader(['launchctl', 'bootstrap', `gui/${uid}`, plistPath]);
+    }
+  }
+  return false;
+}
+
 /**
  * Compute the per-job launcher binding for the OS entry (WP-157): the launcher
  * path, the descriptor path, and the entry-bound expect-digest (the re-derived
@@ -299,10 +471,16 @@ function sweepLegacyWindowsWrappers(paths, manifest) {
  */
 function ensureCatchup(paths, manifest, loader, uid, jobDigests) {
   const logDir = path.join(paths.logs, 'catchup');
+  // Hoisted so the renderer and `expect` are provably built from the SAME
+  // values — two independent calls could otherwise diverge (D3 implementation
+  // note), and the skip would then compare against something we never wrote.
+  const node = gen.nodePath();
+  const launcher = launcherPathFor(paths);
+  const expectDigest = catchupExpectDigest(paths);
   const content = gen.catchupPlist({
-    node: gen.nodePath(),
-    launcher: launcherPathFor(paths),
-    expectDigest: catchupExpectDigest(paths),
+    node,
+    launcher,
+    expectDigest,
     jobDigests,
     home: paths.home,
     core: paths.core,
@@ -311,10 +489,26 @@ function ensureCatchup(paths, manifest, loader, uid, jobDigests) {
   const label = 'ai.wienerdog.catchup';
   const plistPath = path.join(gen.launchAgentsDir(paths.home), `${label}.plist`);
   const unload = ['launchctl', 'bootout', `gui/${uid}/${label}`];
-  if (ensureEntry(manifest, plistPath, content, unload)) {
-    return { loaded: loader(['launchctl', 'bootstrap', `gui/${uid}`, plistPath]).status === 0 };
-  }
-  return { loaded: true };
+  let priorBytes = null;
+  try { priorBytes = fs.readFileSync(plistPath); } catch { priorBytes = null; }
+  const changed = ensureEntry(manifest, plistPath, content, unload);
+  const loaded = ensureDarwinEntryRegistered(loader, uid, label, plistPath, {
+    changed,
+    priorBytes,
+    canonicalBytes: Buffer.from(content),
+    expect: {
+      argv: [node, ...gen.catchupLaunchArgs({ launcher, expectDigest, jobDigests })],
+      hour: null, minute: 0,  // catchupPlist renders Minute 0 and NO Hour key
+                              // (generators.js:410-416) — null REFUSES a present Hour
+      env: gen.scheduledEnvPairs(paths.home, paths.core),
+      path: plistPath,
+      stdoutPath: path.join(logDir, 'launchd.out.log'),   // logDir = <core>/logs/catchup
+      stderrPath: path.join(logDir, 'launchd.err.log'),
+      spawnType: 'background',
+    },
+    onBeforeTeardown: () => require('../scheduler/status').refreshSchedulerStatus(paths),
+  });
+  return { loaded };
 }
 
 /**
@@ -426,9 +620,26 @@ function registerPlatformEntries(paths, manifest, o, loader, platform = process.
     const plistPath = path.join(gen.launchAgentsDir(paths.home), `${label}.plist`);
     const content = gen.launchdPlist({ ...o, node, launcher: b.launcher, descriptor: b.descriptor, expectDigest: b.expectDigest, home: paths.home, core: paths.core, logDir });
     const unload = ['launchctl', 'bootout', `gui/${uid}/${label}`];
-    let loaded = true;
-    let changed = ensureEntry(manifest, plistPath, content, unload);
-    if (changed) loaded = loader(['launchctl', 'bootstrap', `gui/${uid}`, plistPath]).status === 0;
+    // Captured BEFORE ensureEntry overwrites — the narrowest possible capture
+    // point, and the reason ensureEntry's contract does not change.
+    let priorBytes = null;
+    try { priorBytes = fs.readFileSync(plistPath); } catch { priorBytes = null; }
+    const changed = ensureEntry(manifest, plistPath, content, unload);
+    const loaded = ensureDarwinEntryRegistered(loader, uid, label, plistPath, {
+      changed,
+      priorBytes,
+      canonicalBytes: Buffer.from(content),   // the same bytes handed to ensureEntry
+      expect: {
+        argv: [node, ...gen.jobLaunchArgs({ launcher: b.launcher, name: o.name, descriptor: b.descriptor, expectDigest: b.expectDigest })],
+        hour: o.hour, minute: o.minute,
+        env: gen.scheduledEnvPairs(paths.home, paths.core),   // already exported (:1035)
+        path: plistPath,                                      // in scope; the file we just wrote
+        stdoutPath: path.join(logDir, 'launchd.out.log'),     // logDir is in scope
+        stderrPath: path.join(logDir, 'launchd.err.log'),
+        spawnType: 'background',                              // ProcessType literal
+      },
+      onBeforeTeardown: () => require('../scheduler/status').refreshSchedulerStatus(paths),
+    });
     // Catch-up entry: login + hourly (macOS StartCalendarInterval misses power-off).
     // MINT the per-job digest map from freshly-derived descriptors (WP-catchup-per-job-authorization) —
     // this attended register path is one of the four authorized mint callers.
@@ -452,19 +663,26 @@ function registerPlatformEntries(paths, manifest, o, loader, platform = process.
     const timerChanged = ensureEntry(manifest, timerPath, timerText, timerUnload);
     const serviceChanged = ensureEntry(manifest, servicePath, serviceText, null);
     const changed = timerChanged || serviceChanged;
-    let loaded = true;
+    // Table A row 3 (ADR-0037): no verified skip on linux — reload + its warning
+    // + `enable --now` run on EVERY register, hoisted OUT of `if (changed)`, so a
+    // degraded reload is retried (and warned about) on every sync until it
+    // succeeds — never silently once. Both are idempotent no-ops against an
+    // already-correct unit, so this is cheap.
+    const reload = loader(['systemctl', '--user', 'daemon-reload']);
+    // Treat a MISSING result (undefined result OR a nullish status) as a failure too —
+    // absence of a result is not success. `!= null` catches both undefined and null, so
+    // a `{status:null}` result warns and prints 'no result', never 'null'.
+    const reloadOk = !!reload && reload.status != null && reload.status === 0;
+    if (!reloadOk) {
+      const s = reload && reload.status != null ? reload.status : 'no result';
+      process.stderr.write(`wienerdog: warning — 'systemctl --user daemon-reload' returned ${s}; the timer may load from stale units. Run 'wienerdog doctor'.\n`);
+    }
+    const enableOk = loader(['systemctl', '--user', 'enable', '--now', `${unitBase}.timer`]).status === 0;
+    const loaded = reloadOk && enableOk;
     if (changed) {
-      // Best-effort daemon-reload/linger are not gated; only `enable --now` counts.
-      const reload = loader(['systemctl', '--user', 'daemon-reload']);
-      // Treat a MISSING result (undefined result OR a nullish status) as a failure too —
-      // absence of a result is not success. `!= null` catches both undefined and null, so
-      // a `{status:null}` result warns and prints 'no result', never 'null'.
-      if (!reload || reload.status == null || reload.status !== 0) {
-        const s = reload && reload.status != null ? reload.status : 'no result';
-        process.stderr.write(`wienerdog: warning — 'systemctl --user daemon-reload' returned ${s}; the timer may load from stale units. Run 'wienerdog doctor'.\n`);
-      }
-      loaded = loader(['systemctl', '--user', 'enable', '--now', `${unitBase}.timer`]).status === 0;
-      // Best-effort: let timers fire when the user is logged out.
+      // Best-effort: let timers fire when the user is logged out. NOT evidence
+      // about what systemd holds, so it stays gated on `changed` and never gates
+      // `loaded` (D4 implementation note).
       const user = process.env.USER || process.env.LOGNAME || '';
       if (user) {
         const linger = loader(['loginctl', 'enable-linger', user]);
@@ -879,7 +1097,9 @@ function add(argv, loader, profile) {
   const { platform, changed, loaded } = registerPlatform(paths, manifest, { name, hour, minute }, loader);
   manifestLib.save(paths, manifest);
 
-  if (changed && !loaded) {
+  // ADR-0037: fail loud on ANY unloaded outcome, regardless of `changed` — a
+  // forced re-registration of unchanged source bytes can still fail (D5).
+  if (!loaded) {
     throw new WienerdogError(
       `wienerdog: registered "${name}"'s schedule file but the OS scheduler (${platform}) rejected it — ` +
       `it is NOT active. Run 'wienerdog doctor' for details.`

--- a/src/scheduler/generators.js
+++ b/src/scheduler/generators.js
@@ -689,6 +689,134 @@ function launchdLoadedArgs(stdout) {
   return null; // no closing brace → the block did not parse
 }
 
+/** The `event triggers = { … }` block of a `launchctl print` record — the
+ *  StartCalendarInterval readback (WP-scheduler-register-replaces-loaded-record,
+ *  Current state §7b/§7c, Table A2, CX10-1/CX11-2). PURE: string work only, never
+ *  throws. Returns the OUTER `null` when the block never opened/closed, when it
+ *  does not hold EXACTLY ONE immediate entry, when that one entry's `stream` is
+ *  not `com.apple.launchd.calendarinterval`, when its `descriptor = {` block is
+ *  missing/unclosed, when `Minute` is absent, or when `Hour`/`Minute` is present
+ *  but non-numeric — the outer null means "malformed, Minute missing, or the
+ *  trigger block did not hold exactly one entry" (never collapsed with the INNER
+ *  `hour: null`, which means "the `Hour` key was validly ABSENT" — the catch-up
+ *  shape). Counts the COMPLETE block, not a stream-filtered search (CX11-2): our
+ *  canonical trigger plus a foreign-stream trigger must fail the count, not match
+ *  on the first.
+ *  @param {string} stdout
+ *  @returns {{hour:number|null, minute:number}|null} */
+function launchdLoadedCalendar(stdout) {
+  const lines = String(stdout).split('\n');
+  const openIdx = lines.findIndex((l) => l.trim() === 'event triggers = {');
+  if (openIdx === -1) return null;
+  // Pass 1 — walk the block's DIRECT children only (depth 0 relative to the
+  // block body), so a nested `descriptor = {` inside an entry is never counted
+  // as a second top-level trigger.
+  const entries = [];
+  let depth = 0;
+  let closeIdx = -1;
+  for (let i = openIdx + 1; i < lines.length; i += 1) {
+    const t = lines[i].trim();
+    if (t === '}') {
+      if (depth === 0) {
+        closeIdx = i;
+        break;
+      }
+      depth -= 1;
+      if (depth === 0) entries[entries.length - 1].end = i;
+      continue;
+    }
+    if (/\{\s*$/.test(t)) {
+      if (depth === 0) entries.push({ start: i, end: -1 });
+      depth += 1;
+      continue;
+    }
+  }
+  if (closeIdx === -1) return null; // the block never closed
+  if (entries.length !== 1) return null; // zero or 2+ direct entries ⇒ unparseable
+  const entry = entries[0];
+  if (entry.end === -1) return null; // the sole entry never closed
+  // Pass 2 — within that one entry, find its (depth-0) `stream = …` line and its
+  // nested `descriptor = {` block.
+  let entryDepth = 0;
+  let stream = null;
+  let descStart = -1;
+  let descEnd = -1;
+  for (let i = entry.start + 1; i < entry.end; i += 1) {
+    const t = lines[i].trim();
+    if (t === '}') {
+      entryDepth -= 1;
+      if (entryDepth === 0 && descStart !== -1 && descEnd === -1) descEnd = i;
+      continue;
+    }
+    if (/\{\s*$/.test(t)) {
+      if (entryDepth === 0 && t === 'descriptor = {') descStart = i;
+      entryDepth += 1;
+      continue;
+    }
+    if (entryDepth === 0) {
+      const sm = t.match(/^stream\s*=\s*(.+)$/);
+      if (sm) stream = sm[1].trim();
+    }
+  }
+  if (stream !== 'com.apple.launchd.calendarinterval') return null;
+  if (descStart === -1 || descEnd === -1) return null; // no descriptor block
+  // Pass 3 — the descriptor's quoted-key, unquoted-value lines.
+  let hourRaw = null;
+  let hourPresent = false;
+  let minuteRaw = null;
+  let minutePresent = false;
+  for (let i = descStart + 1; i < descEnd; i += 1) {
+    const t = lines[i].trim();
+    const hm = t.match(/^"Hour"\s*=>\s*(.+)$/);
+    if (hm) {
+      hourRaw = hm[1].trim();
+      hourPresent = true;
+      continue;
+    }
+    const mm = t.match(/^"Minute"\s*=>\s*(.+)$/);
+    if (mm) {
+      minuteRaw = mm[1].trim();
+      minutePresent = true;
+    }
+  }
+  if (!minutePresent) return null; // Minute missing ⇒ outer null
+  const minute = Number(minuteRaw);
+  if (!Number.isFinite(minute)) return null; // non-numeric Minute ⇒ outer null
+  let hour = null; // absent Hour key ⇒ the catch-up shape, NOT an error
+  if (hourPresent) {
+    hour = Number(hourRaw);
+    if (!Number.isFinite(hour)) return null; // non-numeric Hour ⇒ outer null
+  }
+  return { hour, minute };
+}
+
+/** The `environment = { … }` block of a `launchctl print` record — the
+ *  EnvironmentVariables readback (Current state §7b facts 1/2/4). PURE: string
+ *  work only, never throws. Anchored by a TRIMMED EXACT-LINE match on
+ *  `environment = {`, never a suffix match — `inherited environment = {` and
+ *  `default environment = {` precede it in the real output and both end with the
+ *  same characters. A `KEY =>` line with nothing after the arrow is a VALID pair
+ *  whose value is the empty string, never a skipped line — five of the seven
+ *  canonical `scheduledEnvPairs` bindings render exactly that way.
+ *  @param {string} stdout
+ *  @returns {Map<string,string>|null} null when the block never opened/closed */
+function launchdLoadedEnv(stdout) {
+  const lines = String(stdout).split('\n');
+  const openIdx = lines.findIndex((l) => l.trim() === 'environment = {');
+  if (openIdx === -1) return null;
+  const map = new Map();
+  for (let i = openIdx + 1; i < lines.length; i += 1) {
+    const t = lines[i].trim();
+    if (t === '}') return map;
+    const idx = t.indexOf('=>');
+    if (idx === -1) continue;
+    const key = t.slice(0, idx).trim();
+    const value = t.slice(idx + 2).trim();
+    map.set(key, value);
+  }
+  return null; // no closing brace → the block did not parse
+}
+
 /** Table B1 consumer 1 — split a cmd.exe inner command chain at each ` & ` that
  *  lies OUTSIDE a double-quoted region (the only delimiter windowsCmdArguments
  *  emits). An ODD total `"` count is unparseable → null (fail closed). A ` & `
@@ -1035,4 +1163,8 @@ module.exports = {
   scheduledEnvPairs,
   teardownCatchup,
   defaultCatchupLoader,
+  jobLaunchArgs,
+  launchdLoadedArgs,
+  launchdLoadedCalendar,
+  launchdLoadedEnv,
 };

--- a/tests/unit/init.test.js
+++ b/tests/unit/init.test.js
@@ -120,9 +120,25 @@ test('init --fresh-vault schedules the nightly dream and surfaces it (ADR-0014)'
   // platform; either way the user is told.
   assert.match(r.stdout, /dreaming/i);
   // The catch-up reassurance is surfaced alongside the schedule (WP-066): users
-  // must never think they have to leave the machine on overnight. Both CI OSes
-  // (macOS, ubuntu) support scheduling, so d.scheduled is true and this prints.
-  assert.match(r.stdout, /catches up automatically/i);
+  // must never think they have to leave the machine on overnight. What the
+  // summary may CLAIM now depends on whether the register could verify the
+  // registration (ADR-0037), and this test runs a real subprocess under
+  // WIENERDOG_LOADER_NOOP=1 — a seam that answers every scheduler spawn with a
+  // blind {status:0} and no stdout.
+  //   darwin: the register reads the entry back with `launchctl print`; a blind
+  //     {status:0} carries no record, so nothing is verified and the summary must
+  //     NOT promise catch-up. The degraded notice IS the postcondition working.
+  //   linux/win32: no readback runs on this path, so the seam still yields
+  //     d.scheduled === true and the reassurance prints, as before.
+  // The darwin negative assertion is deliberate: it is the tripwire against ever
+  // teaching the NOOP seam to fabricate a matching readback, which would forge
+  // exactly the evidence ADR-0037 exists to require.
+  if (process.platform === 'darwin') {
+    assert.match(r.stdout, /did not accept it yet/i);
+    assert.doesNotMatch(r.stdout, /catches up automatically/i);
+  } else {
+    assert.match(r.stdout, /catches up automatically/i);
+  }
   // The dream job definition landed in config regardless of platform support:
   // ensureDreamSchedule persists the job before registering the OS entry.
   const cfg = fs.readFileSync(path.join(core, 'config.yaml'), 'utf8');

--- a/tests/unit/scheduler-schedule.test.js
+++ b/tests/unit/scheduler-schedule.test.js
@@ -113,6 +113,172 @@ async function withSpawnSpy(fn) {
   }
 }
 
+// -------------------------------------------------------------------------
+// WP-scheduler-register-replaces-loaded-record: synthetic `launchctl print`
+// stdout + a stateful fake launchd, shared by the new verified-register tests
+// AND by every pre-existing darwin-path test whose loader was a blind
+// `() => ({status:0})` — ADR-0037 now requires a LIVE readback before any
+// register can report success, so a mock that never answers `print` truthfully
+// can no longer be treated as "loaded" (see the WP's PR body, Decisions made).
+// -------------------------------------------------------------------------
+
+/** Reverse `xmlEscape` (generators.js) — `&` LAST so an already-decoded
+ *  `<`/`>` is not re-processed. @param {string} s @returns {string} */
+function xmlUnescapeSimple(s) {
+  return String(s).replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&');
+}
+
+/**
+ * Build synthetic `launchctl print` stdout matching the shape
+ * darwinLoadedVerdict / launchdLoadedCalendar / launchdLoadedEnv / the
+ * top-level single-line reader parse (Current state §7b/§7c). Every field is
+ * directly overridable so tests can construct deliberately-stale/foreign/
+ * malformed records; `omit` drops a named single-line field entirely
+ * (simulating an incomplete readback), and the `malformed*`/`triggerCount`/
+ * `foreignStreamTrigger` knobs construct the parser-edge fixtures.
+ * @param {{argv:string[], program?:string, env:Array<[string,string]>,
+ *   hour:number|null, minute:number, path:string, stdoutPath:string,
+ *   stderrPath:string, spawnType:string, omit?:string[],
+ *   triggerCount?:number, foreignStreamTrigger?:boolean,
+ *   malformedArgs?:boolean, malformedEnv?:boolean, malformedCalendar?:boolean,
+ *   noHourEvenIfExpected?:boolean}} o
+ * @returns {string}
+ */
+function buildPrintStdout(o) {
+  const omit = new Set(o.omit || []);
+  const lines = ['gui/501/some.label = {'];
+  if (!omit.has('path')) lines.push(`\tpath = ${o.path}`);
+  lines.push('\ttype = LaunchAgent');
+  if (!omit.has('program')) lines.push(`\tprogram = ${o.program != null ? o.program : o.argv[0]}`);
+  lines.push('\targuments = {');
+  if (o.malformedArgs) {
+    lines.push(`\t\t${o.argv[0] || ''}`); // deliberately never closed
+  } else {
+    for (const a of o.argv) lines.push(`\t\t${a}`);
+    lines.push('\t}');
+  }
+  if (!omit.has('stdoutPath')) lines.push(`\tstdout path = ${o.stdoutPath}`);
+  if (!omit.has('stderrPath')) lines.push(`\tstderr path = ${o.stderrPath}`);
+  lines.push('\tenvironment = {');
+  if (o.malformedEnv) {
+    // deliberately never closed
+  } else {
+    for (const [k, v] of o.env) lines.push(`\t\t${k} => ${v}`);
+    lines.push('\t\tOSLogRateLimit => 64');
+    lines.push('\t\tXPC_SERVICE_NAME => some.label');
+    lines.push('\t}');
+  }
+  lines.push('\tevent triggers = {');
+  if (o.malformedCalendar) {
+    // deliberately never closed
+  } else {
+    const count = o.triggerCount != null ? o.triggerCount : 1;
+    for (let i = 0; i < count; i += 1) {
+      const isCalendar = !o.foreignStreamTrigger || i === 0;
+      lines.push(`\t\tsome.label.${i} => {`);
+      lines.push(`\t\t\tstream = ${isCalendar ? 'com.apple.launchd.calendarinterval' : 'com.apple.notifyd.matching'}`);
+      if (isCalendar) {
+        lines.push('\t\t\tdescriptor = {');
+        if (o.hour !== null && !o.noHourEvenIfExpected) lines.push(`\t\t\t\t"Hour" => ${o.hour}`);
+        lines.push(`\t\t\t\t"Minute" => ${o.minute}`);
+        lines.push('\t\t\t}');
+      }
+      lines.push('\t\t}');
+    }
+    lines.push('\t}');
+  }
+  if (!omit.has('spawnType')) lines.push(`\tspawn type = ${o.spawnType} (5)`);
+  lines.push('\tproperties = inferred program');
+  lines.push('}');
+  return `${lines.join('\n')}\n`;
+}
+
+/**
+ * Parse OUR OWN rendered plist XML (launchdPlist/catchupPlist) back into
+ * `buildPrintStdout`'s input shape, so a test can simulate "launchd loaded
+ * exactly the bytes on disk" without hand-writing a fixture. @param {string} xml
+ * @param {string} plistPath @returns {string} */
+function printStdoutFromPlistXml(xml, plistPath) {
+  const argsM = xml.match(/<key>ProgramArguments<\/key>\s*<array>([\s\S]*?)<\/array>/);
+  const argv = argsM
+    ? Array.from(argsM[1].matchAll(/<string>([\s\S]*?)<\/string>/g)).map((m) => xmlUnescapeSimple(m[1]))
+    : [];
+  const envM = xml.match(/<key>EnvironmentVariables<\/key>\s*<dict>([\s\S]*?)<\/dict>/);
+  const env = [];
+  if (envM) {
+    const re = /<key>([^<]*)<\/key>\s*<string>([\s\S]*?)<\/string>/g;
+    let m;
+    while ((m = re.exec(envM[1]))) env.push([xmlUnescapeSimple(m[1]), xmlUnescapeSimple(m[2])]);
+  }
+  const calM = xml.match(/<key>StartCalendarInterval<\/key>\s*<dict>([\s\S]*?)<\/dict>/);
+  let hour = null;
+  let minute = 0;
+  if (calM) {
+    const hm = calM[1].match(/<key>Hour<\/key>\s*<integer>(-?\d+)<\/integer>/);
+    const mm = calM[1].match(/<key>Minute<\/key>\s*<integer>(-?\d+)<\/integer>/);
+    if (hm) hour = Number(hm[1]);
+    if (mm) minute = Number(mm[1]);
+  }
+  const outM = xml.match(/<key>StandardOutPath<\/key>\s*<string>([\s\S]*?)<\/string>/);
+  const errM = xml.match(/<key>StandardErrorPath<\/key>\s*<string>([\s\S]*?)<\/string>/);
+  return buildPrintStdout({
+    argv,
+    program: argv[0] || '',
+    env,
+    hour,
+    minute,
+    path: plistPath,
+    stdoutPath: outM ? xmlUnescapeSimple(outM[1]) : '',
+    stderrPath: errM ? xmlUnescapeSimple(errM[1]) : '',
+    spawnType: 'background',
+  });
+}
+
+/**
+ * A minimal STATEFUL fake launchd for tests that do not exercise this WP's
+ * readback mechanics directly — every pre-existing darwin-path test whose
+ * purpose is "does add()/repointSchedules() succeed", not "what does the
+ * verified-registration postcondition do". Tracks which labels are "loaded"
+ * and the exact plist bytes each was loaded with: `print` reports absent
+ * (status 113, mirroring the measured exit code — Current state §7) for a
+ * label never bootstrapped, or a synthetic stdout built from the bytes at its
+ * last successful `bootstrap`; `bootstrap` "loads" the label from whatever is
+ * CURRENTLY on disk at the given plist path and succeeds; `bootout` unloads
+ * it. Every non-`launchctl` call (systemctl/schtasks/plutil) succeeds, so this
+ * is also a safe drop-in on a systemd Linux host. @param {import('../../src/core/paths').WienerdogPaths} paths
+ * @returns {(argv:string[])=>{status:number, stdout?:string}} */
+function fakeLaunchd(paths) {
+  /** @type {Map<string,string>} */ const loaded = new Map(); // label -> plist XML at load time
+  const labelOf = (gui) => (/^gui\/\d+\/(.+)$/.exec(gui || '') || [])[1] || null;
+  const plistPathFor = (label) => path.join(paths.home, 'Library', 'LaunchAgents', `${label}.plist`);
+  return (argv) => {
+    if (argv[0] !== 'launchctl') return { status: 0 };
+    if (argv[1] === 'print') {
+      const label = labelOf(argv[2]);
+      if (!label || !loaded.has(label)) return { status: 113 };
+      return { status: 0, stdout: printStdoutFromPlistXml(loaded.get(label), plistPathFor(label)) };
+    }
+    if (argv[1] === 'bootstrap') {
+      let xml;
+      try {
+        xml = fs.readFileSync(argv[3], 'utf8');
+      } catch {
+        return { status: 1 };
+      }
+      const labelM = xml.match(/<key>Label<\/key>\s*<string>([^<]*)<\/string>/);
+      if (!labelM) return { status: 1 };
+      loaded.set(labelM[1], xml);
+      return { status: 0 };
+    }
+    if (argv[1] === 'bootout') {
+      const label = labelOf(argv[2]);
+      if (label) loaded.delete(label);
+      return { status: 0 };
+    }
+    return { status: 0 };
+  };
+}
+
 // Whether `schedule add` can register on this host (skip integration otherwise).
 const SCHED_SUPPORTED =
   process.platform === 'darwin' ||
@@ -333,9 +499,10 @@ test('scheduler-schedule: add --skill is refused under a blocked profile — no 
 test('scheduler-schedule: add registers the platform entry, records manifest, saves the job', { skip: !SCHED_SUPPORTED }, async () => {
   const { env, paths } = setup();
   /** @type {string[][]} */ const calls = [];
+  const fake = fakeLaunchd(paths);
   const loader = (argv) => {
     calls.push(argv);
-    return { status: 0 };
+    return fake(argv);
   };
 
   await runSchedule(env, ['add', 'daily-digest', '--at', '07:00', '--skill', 'wienerdog-daily-digest'], loader, allowAll());
@@ -362,7 +529,10 @@ test('scheduler-schedule: add registers the platform entry, records manifest, sa
     const jobEntry = schedEntries.find((e) => e.path === plistPath);
     assert.ok(jobEntry, 'per-job plist entry recorded');
     assert.deepEqual(jobEntry.unload, ['launchctl', 'bootout', `gui/${uid}/${label}`]);
-    assert.deepEqual(calls[0], ['launchctl', 'bootstrap', `gui/${uid}`, plistPath]);
+    // ADR-0037: the readback now precedes the register — calls[0] is the
+    // `print` (nothing loaded yet), and the bootstrap moves to calls[1].
+    assert.deepEqual(calls[0], ['launchctl', 'print', `gui/${uid}/${label}`]);
+    assert.deepEqual(calls[1], ['launchctl', 'bootstrap', `gui/${uid}`, plistPath]);
     // Catch-up plist ensured once.
     const catchPath = path.join(paths.home, 'Library', 'LaunchAgents', 'ai.wienerdog.catchup.plist');
     assert.ok(schedEntries.some((e) => e.path === catchPath), 'catch-up entry recorded');
@@ -386,19 +556,30 @@ test('scheduler-schedule: add registers the platform entry, records manifest, sa
   }
 });
 
-test('scheduler-schedule: a second identical add is idempotent (no OS call)', { skip: !SCHED_SUPPORTED }, async () => {
-  const { env } = setup();
+// ADR-0037 (AC6 item 4): a register that cannot verify what the OS now holds
+// must not skip the OS call without evidence — so an unchanged re-add is no
+// longer a ZERO-call no-op. It costs exactly its per-platform verified-skip
+// readback (Table A's third column, AC5(iii)): darwin ⇒ one read-only `print`
+// per site (job + catch-up); linux ⇒ the idempotent `daemon-reload` +
+// `enable --now`. Neither ever MUTATES.
+test('scheduler-schedule: a second identical add is idempotent (no MUTATING OS call)', { skip: !SCHED_SUPPORTED }, async () => {
+  const { env, paths } = setup();
+  const fake = fakeLaunchd(paths);
   const calls1 = [];
-  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], (a) => (calls1.push(a), { status: 0 }));
+  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], (a) => (calls1.push(a), fake(a)));
   assert.ok(calls1.length >= 1);
   const calls2 = [];
-  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], (a) => (calls2.push(a), { status: 0 }));
-  assert.equal(calls2.length, 0, 'no loader calls on an unchanged re-add');
+  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], (a) => (calls2.push(a), fake(a)));
+  assert.equal(calls2.length, 2, 'the unchanged re-add costs exactly its per-platform verified-skip check, no more');
+  assert.ok(
+    calls2.every((a) => (a[0] === 'launchctl' ? a[1] === 'print' : a[0] === 'systemctl')),
+    'no MUTATING OS call (no bootstrap/bootout, no schtasks /create) on an unchanged re-add'
+  );
 });
 
 test('scheduler-schedule: add then manifest.reverse DEFERS config.yaml (hash re-synced, not mistaken for a user edit) (WP-088)', { skip: !SCHED_SUPPORTED }, async () => {
   const { env, paths } = setup();
-  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], () => ({ status: 0 }));
+  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], fakeLaunchd(paths));
   assert.ok(fs.existsSync(paths.config));
   // WP-088: config.yaml is a deferred-deletion-set member — reverse() NO LONGER
   // deletes it. A re-synced (unmodified) hash means it is recognized as our own
@@ -417,7 +598,7 @@ test('scheduler-schedule: add then manifest.reverse DEFERS config.yaml (hash re-
 
 test('scheduler-schedule: remove runs the unload, deletes files, drops entries and the job', { skip: !SCHED_SUPPORTED }, async () => {
   const { env, paths, root } = setup();
-  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], () => ({ status: 0 }));
+  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], fakeLaunchd(paths));
 
   // WP-145: poison the stored unloads with marker commands to prove they are
   // IGNORED; the remove flow derives the real unregister argv instead (the spy
@@ -497,7 +678,9 @@ test('scheduler-schedule: registerPlatform warns on a NONZERO daemon-reload and 
     const { result: res, stderr } = captureStderr(() =>
       schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'linux')
     );
-    assert.equal(res.loaded, true, '`loaded` stays gated only on `enable --now`, which returned status 0');
+    // ADR-0037: `loaded` is now `reloadOk && enableOk` — a degraded reload
+    // fails the register even though `enable --now` itself succeeded.
+    assert.equal(res.loaded, false, '`loaded` is `reloadOk && enableOk`; a degraded daemon-reload fails it');
     assert.match(stderr, /'systemctl --user daemon-reload' returned 1/, 'nonzero daemon-reload warns with its status');
     assert.match(stderr, /'loginctl enable-linger ada' returned no result/, 'a MISSING (undefined) result warns as "no result", not silence');
   } finally {
@@ -521,7 +704,9 @@ test('scheduler-schedule: registerPlatform warns on a MISSING ({status:null}) da
     const { result: res, stderr } = captureStderr(() =>
       schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'linux')
     );
-    assert.equal(res.loaded, true, '`loaded` stays gated only on `enable --now`, which returned status 0');
+    // ADR-0037: `loaded` is now `reloadOk && enableOk` — a MISSING (null
+    // status) reload also fails the register.
+    assert.equal(res.loaded, false, '`loaded` is `reloadOk && enableOk`; a missing daemon-reload result fails it');
     assert.match(stderr, /'systemctl --user daemon-reload' returned no result/, 'a {status:null} result warns as "no result", not success');
     assert.match(stderr, /'loginctl enable-linger ada' returned 2/, 'nonzero enable-linger warns with its status');
   } finally {
@@ -1016,23 +1201,35 @@ function primaryEntryFile(paths, name) {
   return path.join(gen.systemdUserDir(paths.home, process.env), `${gen.systemdUnitBase(name)}.service`);
 }
 
-test('scheduler-schedule: repointSchedules after add is a no-op (changed:0, no OS call)', { skip: !SCHED_SUPPORTED }, async () => {
+// ADR-0037: an unchanged repoint is no longer a ZERO-call no-op — it still
+// costs its per-platform verified-skip readback (Table A's third column,
+// AC5(iii)): darwin ⇒ two read-only `print`s (job + catch-up); linux ⇒ the
+// idempotent `daemon-reload` + `enable --now`. `fake` is reused across the
+// setup `add()` and the repoint under test so the live record it registered
+// is what the repoint's readback re-reads (a fresh mock would see nothing
+// loaded and force a spurious re-bootstrap).
+test('scheduler-schedule: repointSchedules after add is a no-op (changed:0, no MUTATING OS call)', { skip: !SCHED_SUPPORTED }, async () => {
   const { env, paths } = setup();
-  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], () => ({ status: 0 }));
+  const fake = fakeLaunchd(paths);
+  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], fake);
 
   const calls = [];
   const manifest = manifestLib.load(paths);
-  const res = schedule.repointSchedules(paths, manifest, { loader: (a) => (calls.push(a), { status: 0 }) });
+  const res = schedule.repointSchedules(paths, manifest, { loader: (a) => (calls.push(a), fake(a)) });
 
   assert.equal(res.repointed, 1, 'the one defined job was re-registered');
   assert.equal(res.changed, 0, 'content already targets the stable bin — nothing rewritten');
   assert.deepEqual(res.notices, []);
-  assert.equal(calls.length, 0, 'no OS reload on an unchanged repoint');
+  assert.equal(calls.length, 2, 'the verified-skip readback still runs (Table A) even when nothing changed');
+  assert.ok(
+    calls.every((a) => (a[0] === 'launchctl' ? a[1] === 'print' : a[0] === 'systemctl')),
+    'no MUTATING OS call on an unchanged repoint'
+  );
 });
 
 test('scheduler-schedule: repointSchedules rewrites a stale embedded node path (changed:1)', { skip: !SCHED_SUPPORTED }, async () => {
   const { env, paths } = setup();
-  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], () => ({ status: 0 }));
+  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], fakeLaunchd(paths));
 
   // Simulate an older version's entry: hand-edit the embedded node (the entry's
   // <Command>/first arg) to a stale path. WP-157: the entry now invokes the
@@ -1081,7 +1278,8 @@ test('scheduler-schedule: repointSchedules degrades on an unsupported platform (
 test('scheduler-schedule: ensureDreamSchedule schedules dream once at 03:30', { skip: !SCHED_SUPPORTED }, () => {
   const { paths } = setup();
   /** @type {string[][]} */ const calls = [];
-  const res = schedule.ensureDreamSchedule(paths, { loader: (a) => (calls.push(a), { status: 0 }) });
+  const fake = fakeLaunchd(paths);
+  const res = schedule.ensureDreamSchedule(paths, { loader: (a) => (calls.push(a), fake(a)) });
 
   assert.deepEqual(res, { scheduled: true, at: '03:30' });
   // Job persisted with builtin:dream + 20-minute timeout.
@@ -1128,8 +1326,9 @@ test('scheduler-schedule: ensureDreamSchedule degrades on an unsupported platfor
 
 test('scheduler-schedule: list --json reports jobs with watermarks', { skip: !SCHED_SUPPORTED }, async () => {
   const { env, paths } = setup();
-  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], () => ({ status: 0 }));
-  await runSchedule(env, ['add', 'daily-digest', '--at', '07:00', '--skill', 'wienerdog-daily-digest'], () => ({ status: 0 }), allowAll());
+  const fake = fakeLaunchd(paths);
+  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], fake);
+  await runSchedule(env, ['add', 'daily-digest', '--at', '07:00', '--skill', 'wienerdog-daily-digest'], fake, allowAll());
   jobsLib.writeScheduleState(paths, 'dream', { last_success: '2026-07-03T03:30:12.000Z', last_status: 'ok' });
 
   let out = '';
@@ -1182,7 +1381,8 @@ test('scheduler-schedule: add writes a 0600 job descriptor, records it once, and
   const { env, paths } = setup();
   plantAppTree(paths);
   plantPins(paths);
-  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], () => ({ status: 0 }));
+  const fake = fakeLaunchd(paths);
+  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], fake);
 
   const descPath = path.join(paths.state, 'descriptors', 'dream.json');
   assert.ok(fs.existsSync(descPath), 'descriptor written during add');
@@ -1196,7 +1396,7 @@ test('scheduler-schedule: add writes a 0600 job descriptor, records it once, and
   assert.equal(entries.length, 1, 'exactly one manifest file entry for the descriptor');
 
   // Second add: byte-identical descriptor, still exactly one manifest entry.
-  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], () => ({ status: 0 }));
+  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], fake);
   assert.ok(fs.readFileSync(descPath).equals(bytes), 'unchanged inputs ⇒ byte-identical descriptor');
   const entries2 = manifestLib.load(paths).entries.filter((e) => e.kind === 'file' && e.path === descPath);
   assert.equal(entries2.length, 1, 'no duplicate manifest entry on re-add');
@@ -1225,7 +1425,7 @@ test('scheduler-schedule: repointSchedules refreshes the descriptor; a legit uni
   const { env, paths } = setup();
   plantAppTree(paths);
   plantPins(paths);
-  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], () => ({ status: 0 }));
+  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], fakeLaunchd(paths));
   const descPath = path.join(paths.state, 'descriptors', 'dream.json');
   fs.rmSync(descPath); // simulate a lost descriptor — sync's repoint restores it
 
@@ -1248,3 +1448,894 @@ test('scheduler-schedule: repointSchedules refreshes the descriptor; a legit uni
   assert.ok(result.removed.includes(descPath), 'the descriptor file entry reverses');
   assert.equal(fs.existsSync(descPath), false);
 });
+
+// =========================================================================
+// WP-scheduler-register-replaces-loaded-record: verified registration
+// (ADR-0037). darwinLoadedVerdict + ensureDarwinEntryRegistered are
+// non-exported by design (D1) — every test below drives them THROUGH
+// `schedule.registerPlatform` (darwin/linux, platform injected) or through the
+// CLI `add()` path (T7), never by importing them directly.
+// =========================================================================
+
+const PLUTIL_PATH = '/usr/bin/plutil';
+
+/** Identify which launchd LABEL an argv targets, for `scriptedDarwinLoader`.
+ *  @param {string[]} argv @returns {string|null} */
+function labelForArgv(argv) {
+  if (argv[0] === 'launchctl' && (argv[1] === 'print' || argv[1] === 'bootout')) {
+    return (/^gui\/\d+\/(.+)$/.exec(argv[2] || '') || [])[1] || null;
+  }
+  if (argv[0] === 'launchctl' && argv[1] === 'bootstrap') {
+    const m = /([^/]+)\.plist$/.exec(argv[3] || '');
+    return m ? m[1] : null;
+  }
+  if (argv[0] === PLUTIL_PATH && argv[1] === '-lint') {
+    const m = /([^/]+)\.plist$/.exec(argv[2] || '');
+    return m ? m[1] : null;
+  }
+  return null;
+}
+
+/** Stub `fs.existsSync` for exactly `/usr/bin/plutil` during `fn`, delegating
+ *  every other path to the real implementation — makes the `plutil` preflight
+ *  deterministic regardless of whether THIS test host has it. Only T2c/T2d
+ *  exercise the preflight itself; every other fixture stubs it `false` (skip)
+ *  so it never adds an unscripted call to an otherwise-pinned sequence.
+ *  @template T @param {boolean} exists @param {() => (T|Promise<T>)} fn
+ *  @returns {Promise<T>} */
+async function withPlutilExists(exists, fn) {
+  const orig = fs.existsSync;
+  fs.existsSync = (p) => (p === PLUTIL_PATH ? exists : orig(p));
+  try {
+    return await fn();
+  } finally {
+    fs.existsSync = orig;
+  }
+}
+
+/**
+ * A darwin loader for THIS WP's own tests: calls targeting `scriptedLabel`
+ * return the SCRIPTED `responses` in order (one per call OBSERVED for that
+ * label; an entry may be a function `(argv)=>response` for a fixture that
+ * needs a side effect, e.g. simulating a concurrent write). Every other call
+ * (typically the catch-up site's OWN registration, running alongside the
+ * per-job one under test) falls through to a shared `fakeLaunchd`
+ * passthrough, so it succeeds harmlessly and never interferes with the
+ * assertions under test.
+ * @param {import('../../src/core/paths').WienerdogPaths} paths
+ * @param {string} scriptedLabel
+ * @param {Array<{status:number,stdout?:string}|((argv:string[])=>{status:number,stdout?:string})>} responses
+ * @returns {{loader:(argv:string[])=>{status:number,stdout?:string}, calls:string[][]}}
+ */
+function scriptedDarwinLoader(paths, scriptedLabel, responses) {
+  const fallback = fakeLaunchd(paths);
+  /** @type {string[][]} */ const calls = [];
+  let i = 0;
+  const loader = (argv) => {
+    calls.push(argv);
+    if (labelForArgv(argv) === scriptedLabel && i < responses.length) {
+      const r = responses[i];
+      i += 1;
+      return typeof r === 'function' ? r(argv) : r;
+    }
+    return fallback(argv);
+  };
+  return { loader, calls };
+}
+
+/** Compute the SAME `expect`-shape values `registerPlatformEntries`'s darwin
+ *  arm derives for job `name` (no job saved ⇒ expectDigest degrades to '',
+ *  matching what the register site itself computes for an unfindable job).
+ *  @param {import('../../src/core/paths').WienerdogPaths} paths
+ *  @param {string} name @param {number} hour @param {number} minute */
+function darwinJobExpect(paths, name, hour, minute) {
+  const node = gen.nodePath();
+  const launcher = gen.launcherPath(paths);
+  const descriptorPath = require('../../src/scheduler/descriptor').descriptorPath(paths, name);
+  const label = gen.launchdLabel(name);
+  const plistPath = path.join(paths.home, 'Library', 'LaunchAgents', `${label}.plist`);
+  const logDir = path.join(paths.logs, name);
+  return {
+    label,
+    plistPath,
+    argv: [node, ...gen.jobLaunchArgs({ launcher, name, descriptor: descriptorPath, expectDigest: '' })],
+    hour,
+    minute,
+    env: gen.scheduledEnvPairs(paths.home, paths.core),
+    path: plistPath,
+    stdoutPath: path.join(logDir, 'launchd.out.log'),
+    stderrPath: path.join(logDir, 'launchd.err.log'),
+    spawnType: 'background',
+  };
+}
+
+/** The catch-up analogue of `darwinJobExpect`. */
+function darwinCatchupExpect(paths) {
+  const node = gen.nodePath();
+  const launcher = gen.launcherPath(paths);
+  const label = 'ai.wienerdog.catchup';
+  const plistPath = path.join(paths.home, 'Library', 'LaunchAgents', `${label}.plist`);
+  const logDir = path.join(paths.logs, 'catchup');
+  return {
+    label,
+    plistPath,
+    argv: [node, ...gen.catchupLaunchArgs({ launcher, expectDigest: '', jobDigests: gen.encodeJobDigests({}) })],
+    hour: null,
+    minute: 0,
+    env: gen.scheduledEnvPairs(paths.home, paths.core),
+    path: plistPath,
+    stdoutPath: path.join(logDir, 'launchd.out.log'),
+    stderrPath: path.join(logDir, 'launchd.err.log'),
+    spawnType: 'background',
+  };
+}
+
+/** The exact plist bytes `registerPlatformEntries`'s darwin arm renders for an
+ *  unfindable job `name` (expectDigest ''), so a test can pre-plant an
+ *  UNCHANGED (`changed:false`) fixture. */
+function canonicalJobPlistContent(paths, name, hour, minute) {
+  const node = gen.nodePath();
+  const launcher = gen.launcherPath(paths);
+  const descriptorPath = require('../../src/scheduler/descriptor').descriptorPath(paths, name);
+  const logDir = path.join(paths.logs, name);
+  return gen.launchdPlist({
+    name, hour, minute, node, launcher, descriptor: descriptorPath, expectDigest: '',
+    home: paths.home, core: paths.core, logDir,
+  });
+}
+
+/** A `launchctl print` stdout that matches `expect` exactly (Table A2). */
+function matchingStdout(expect) {
+  return buildPrintStdout({ ...expect, program: expect.argv[0] });
+}
+
+/** Pre-plant an UNCHANGED per-job entry: canonical bytes already on disk plus
+ *  a matching manifest entry, so `ensureEntry` returns `changed:false` and the
+ *  ONLY thing under test is the verified-skip/attempt decision (T3). */
+function unchangedJobFixture(name, hour, minute) {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const expect = darwinJobExpect(paths, name, hour, minute);
+  const content = canonicalJobPlistContent(paths, name, hour, minute);
+  fs.mkdirSync(path.dirname(expect.plistPath), { recursive: true });
+  fs.writeFileSync(expect.plistPath, content);
+  manifestLib.record(manifest, { kind: 'scheduler-entry', path: expect.plistPath });
+  return { paths, manifest, expect };
+}
+
+/** Path to the pre-destructive marker file `onBeforeTeardown` writes
+ *  (`refreshSchedulerStatus`'s target — `status.js`'s STATUS_FILE). */
+function statusMarkerPath(paths) {
+  return path.join(paths.state, 'scheduler-status.json');
+}
+
+/**
+ * Run ONE T3 verified-skip/attempt case: an unchanged 'dream' entry, a SINGLE
+ * scripted `print` response, and an assertion on whether the register skips
+ * (exactly one read-only `print`, `loaded:true`) or attempts (a `bootstrap`
+ * follows). `buildResponse` is either a fixed `{status,stdout?}` or a function
+ * `(expect) => {status,stdout?}` — the function form is what lets a case build
+ * its stdout from the SAME `expect` (paths, argv, env, …) the fixture under
+ * test actually uses, rather than from a throwaway fixture whose paths would
+ * never match (a real bug an earlier draft of this file had).
+ * @param {{status:number,stdout?:string}|((expect:object)=>{status:number,stdout?:string})} buildResponse
+ * @param {'skip'|'attempt'} expectation
+ */
+async function runT3Case(buildResponse, expectation) {
+  const { paths, manifest, expect } = unchangedJobFixture('dream', 3, 30);
+  const printResponse = typeof buildResponse === 'function' ? buildResponse(expect) : buildResponse;
+  const { loader, calls } = scriptedDarwinLoader(paths, expect.label, [printResponse]);
+  const res = await withPlutilExists(false, () =>
+    schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'darwin')
+  );
+  const jobCalls = calls.filter((a) => labelForArgv(a) === expect.label);
+  if (expectation === 'skip') {
+    assert.equal(jobCalls.length, 1, 'a verified skip costs exactly one read-only print, nothing more');
+    assert.deepEqual(jobCalls[0], ['launchctl', 'print', `gui/${process.getuid()}/${expect.label}`]);
+    assert.equal(res.loaded, true);
+  } else {
+    assert.ok(jobCalls.length >= 2, 'a non-matching/unreadable record must be ATTEMPTED, never skipped');
+    assert.equal(jobCalls[1][1], 'bootstrap', 'the non-destructive bootstrap attempt runs');
+  }
+  return { paths, manifest, expect, calls, jobCalls, res };
+}
+
+// -------------------------------------------------------------------------
+// T1 — darwin replace ordering + `loaded` (AC1)
+// -------------------------------------------------------------------------
+
+test('verified-register: T1 — darwin replace: print → bootstrap → bootout → bootstrap → print, marker precedes bootout (AC1)', async () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const expect = darwinJobExpect(paths, 'dream', 3, 30);
+  const staleStdout = buildPrintStdout({ ...expect, argv: [...expect.argv.slice(0, -1), 'sha256:' + '0'.repeat(64)], program: expect.argv[0] });
+  let statusExistedAtBootout = null;
+  const { loader, calls } = scriptedDarwinLoader(paths, expect.label, [
+    { status: 0, stdout: staleStdout }, // (1) print — a STALE record IS loaded
+    { status: 1 }, // (2) bootstrap — the non-destructive attempt fails (already loaded)
+    (argv) => { // (3) bootout — the marker must already exist by now (AC8 ordering)
+      statusExistedAtBootout = fs.existsSync(statusMarkerPath(paths));
+      return { status: 0 };
+    },
+    { status: 0 }, // (4) bootstrap — the replacement succeeds
+    { status: 0, stdout: matchingStdout(expect) }, // (5) print — post-bootstrap verify: matches
+  ]);
+  const res = await withPlutilExists(false, () =>
+    schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'darwin')
+  );
+  const jobCalls = calls.filter((a) => labelForArgv(a) === expect.label);
+  const uid = process.getuid();
+  assert.deepEqual(jobCalls, [
+    ['launchctl', 'print', `gui/${uid}/${expect.label}`],
+    ['launchctl', 'bootstrap', `gui/${uid}`, expect.plistPath],
+    ['launchctl', 'bootout', `gui/${uid}/${expect.label}`],
+    ['launchctl', 'bootstrap', `gui/${uid}`, expect.plistPath],
+    ['launchctl', 'print', `gui/${uid}/${expect.label}`],
+  ]);
+  assert.equal(res.loaded, true, 'the replacement verified-loaded');
+  assert.equal(statusExistedAtBootout, true, "ADR-0018 decision 2's pre-destructive marker precedes the bootout");
+});
+
+test('verified-register: T1 — Table A1: a live match SKIPS even when changed=true (AC1)', async () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const expect = darwinJobExpect(paths, 'dream', 3, 30);
+  // `changed:true` is forced by pre-planting DIFFERENT on-disk bytes, so
+  // ensureEntry rewrites the file — but the LOADED record already matches
+  // the NEW canonical values, so the live match must still win.
+  fs.mkdirSync(path.dirname(expect.plistPath), { recursive: true });
+  fs.writeFileSync(expect.plistPath, 'not yet canonical');
+  const { loader, calls } = scriptedDarwinLoader(paths, expect.label, [
+    { status: 0, stdout: matchingStdout(expect) },
+  ]);
+  const res = await withPlutilExists(false, () =>
+    schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'darwin')
+  );
+  const jobCalls = calls.filter((a) => labelForArgv(a) === expect.label);
+  assert.equal(jobCalls.length, 1, 'zero mutating calls — the live match wins over `changed`');
+  assert.equal(res.loaded, true);
+});
+
+test("verified-register: T1 — Codex fixture: changed=true only because the manifest entry is missing (AC1)", async () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths); // no scheduler-entry recorded yet
+  const expect = darwinJobExpect(paths, 'dream', 3, 30);
+  const content = canonicalJobPlistContent(paths, 'dream', 3, 30);
+  fs.mkdirSync(path.dirname(expect.plistPath), { recursive: true });
+  fs.writeFileSync(expect.plistPath, content); // disk already canonical
+  const { loader, calls } = scriptedDarwinLoader(paths, expect.label, [
+    { status: 0, stdout: matchingStdout(expect) },
+  ]);
+  const res = await withPlutilExists(false, () =>
+    schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'darwin')
+  );
+  const jobCalls = calls.filter((a) => labelForArgv(a) === expect.label);
+  // `changed` is true (the manifest entry was missing), but the live record
+  // already matches canonical — Table A1's live match wins regardless, costing
+  // exactly its one read-only readback and ZERO mutating calls.
+  assert.deepEqual(jobCalls, [['launchctl', 'print', `gui/${process.getuid()}/${expect.label}`]]);
+  assert.equal(res.loaded, true);
+  const entry = manifest.entries.find((e) => e.kind === 'scheduler-entry' && e.path === expect.plistPath);
+  assert.ok(entry, 'the manifest entry is still recorded (ensureEntry\'s own bookkeeping runs regardless)');
+});
+
+// -------------------------------------------------------------------------
+// T2 — teardown guard: no bootout when nothing is loaded; marker non-firing (AC2, AC8)
+// -------------------------------------------------------------------------
+
+test('verified-register: T2 — nothing loaded + bootstrap failure ⇒ no bootout anywhere, loaded:false, no marker (AC2, AC8)', async () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const expect = darwinJobExpect(paths, 'dream', 3, 30);
+  const { loader, calls } = scriptedDarwinLoader(paths, expect.label, [
+    { status: 113 }, // (1) print — nothing loaded
+    { status: 1 },   // (2) bootstrap — a transient/permissions/invalid-plist failure
+  ]);
+  const res = await withPlutilExists(false, () =>
+    schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'darwin')
+  );
+  const jobCalls = calls.filter((a) => labelForArgv(a) === expect.label);
+  assert.ok(!jobCalls.some((a) => a[1] === 'bootout'), 'no bootout in the call list at all');
+  assert.equal(res.loaded, false);
+  assert.equal(fs.existsSync(statusMarkerPath(paths)), false, 'the pre-destructive marker never fires without a teardown');
+});
+
+// -------------------------------------------------------------------------
+// T2b — the rollback set (AC2)
+// -------------------------------------------------------------------------
+
+test('verified-register: T2b — rollback restores the prior plist + re-bootstraps it, reports loaded:false (AC2 a-d,g)', async () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const expect = darwinJobExpect(paths, 'dream', 3, 30);
+  const priorBytes = Buffer.from('PRIOR-PLIST-BYTES-MARKER');
+  fs.mkdirSync(path.dirname(expect.plistPath), { recursive: true });
+  fs.writeFileSync(expect.plistPath, priorBytes);
+  const staleStdout = buildPrintStdout({ ...expect, argv: [...expect.argv.slice(0, -1), 'sha256:' + '1'.repeat(64)], program: expect.argv[0] });
+  const { loader, calls } = scriptedDarwinLoader(paths, expect.label, [
+    { status: 0, stdout: staleStdout }, // (1) print — a healthy but stale record IS loaded
+    { status: 1 }, // (2) bootstrap — fails (already loaded)
+    { status: 0 }, // (3) bootout
+    { status: 1 }, // (4) bootstrap — the REPLACEMENT also fails (unbootstrappable)
+    { status: 1 }, // (5) bootstrap — the RESTORE; its result is never checked
+  ]);
+  const res = await withPlutilExists(false, () =>
+    schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'darwin')
+  );
+  const jobCalls = calls.filter((a) => labelForArgv(a) === expect.label);
+  const uid = process.getuid();
+  assert.deepEqual(jobCalls.map((a) => a.slice(0, 2)), [
+    ['launchctl', 'print'],
+    ['launchctl', 'bootstrap'],
+    ['launchctl', 'bootout'],
+    ['launchctl', 'bootstrap'],
+    ['launchctl', 'bootstrap'],
+  ], '(a) call order: print → bootstrap → bootout → bootstrap → bootstrap again (the restore)');
+  assert.deepEqual(jobCalls[4], ['launchctl', 'bootstrap', `gui/${uid}`, expect.plistPath], '(c) the restoring bootstrap targets the restored file');
+  assert.ok(fs.readFileSync(expect.plistPath).equals(priorBytes), '(b) the file holds the PRIOR bytes, byte for byte');
+  assert.equal(res.loaded, false, '(d)/(g) rollback never reports success, even when its own restore-bootstrap fails');
+});
+
+test('verified-register: T2b — priorBytes===null (no plist existed) ⇒ no restore attempt, still loaded:false (AC2 e)', async () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const expect = darwinJobExpect(paths, 'dream', 3, 30); // nothing pre-planted on disk
+  const staleStdout = buildPrintStdout({ ...expect, argv: [...expect.argv.slice(0, -1), 'sha256:' + '2'.repeat(64)], program: expect.argv[0] });
+  const { loader, calls } = scriptedDarwinLoader(paths, expect.label, [
+    { status: 0, stdout: staleStdout },
+    { status: 1 },
+    { status: 0 },
+    { status: 1 },
+  ]);
+  const res = await withPlutilExists(false, () =>
+    schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'darwin')
+  );
+  const jobCalls = calls.filter((a) => labelForArgv(a) === expect.label);
+  assert.equal(jobCalls.length, 4, 'no restoring bootstrap — priorBytes was null, nothing to restore');
+  assert.equal(res.loaded, false);
+});
+
+test('verified-register: T2b — the divergence case (CX-2): changed=false, disk canonical, loaded record older (AC2 f)', async () => {
+  const { paths, manifest, expect } = unchangedJobFixture('dream', 3, 30); // changed:false; priorBytes === canonical
+  const staleStdout = buildPrintStdout({ ...expect, argv: [...expect.argv.slice(0, -1), 'sha256:' + '3'.repeat(64)], program: expect.argv[0] });
+  const canonicalBytes = fs.readFileSync(expect.plistPath);
+  const { loader, calls } = scriptedDarwinLoader(paths, expect.label, [
+    { status: 0, stdout: staleStdout },
+    { status: 1 },
+    { status: 0 },
+    { status: 1 },
+    { status: 0 },
+  ]);
+  const res = await withPlutilExists(false, () =>
+    schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'darwin')
+  );
+  const jobCalls = calls.filter((a) => labelForArgv(a) === expect.label);
+  assert.ok(jobCalls.some((a) => a[1] === 'bootout'), 'the divergent record IS torn down — it is already stale');
+  assert.ok(fs.readFileSync(expect.plistPath).equals(canonicalBytes), 'the restore re-writes canonical — priorBytes WAS canonical here (the bound this fixture pins)');
+  assert.equal(res.loaded, false, 'rollback cannot restore the destroyed record — it never claims success');
+});
+
+// T2f — the interleaved-write fixture (CX14-2): a concurrent write lands
+// between this invocation's canonical write and the rollback's staleness
+// read; the guard must DECLINE to restore over it.
+test('verified-register: T2f — rollback staleness guard declines to overwrite a concurrent write (AC2 g2)', async () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const expect = darwinJobExpect(paths, 'dream', 3, 30);
+  const priorBytes = Buffer.from('PRIOR-BYTES');
+  const concurrentBytes = Buffer.from('CONCURRENT-WRITER-BYTES');
+  fs.mkdirSync(path.dirname(expect.plistPath), { recursive: true });
+  fs.writeFileSync(expect.plistPath, priorBytes);
+  const staleStdout = buildPrintStdout({ ...expect, argv: [...expect.argv.slice(0, -1), 'sha256:' + '4'.repeat(64)], program: expect.argv[0] });
+  const { loader, calls } = scriptedDarwinLoader(paths, expect.label, [
+    { status: 0, stdout: staleStdout },
+    { status: 1 },
+    { status: 0 },
+    (argv) => { // the REPLACEMENT bootstrap: a concurrent invocation writes here first
+      fs.writeFileSync(expect.plistPath, concurrentBytes);
+      return { status: 1 };
+    },
+  ]);
+  const res = await withPlutilExists(false, () =>
+    schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'darwin')
+  );
+  const jobCalls = calls.filter((a) => labelForArgv(a) === expect.label);
+  assert.equal(jobCalls.length, 4, 'the guard declines — no restoring bootstrap is issued');
+  assert.ok(fs.readFileSync(expect.plistPath).equals(concurrentBytes), 'the concurrent bytes are left in place, byte for byte');
+  assert.equal(res.loaded, false);
+});
+
+// T2g — the binding fixture (CX15-1): canonicalBytes is bound at both call
+// sites, so a rollback reaching the staleness guard must not throw.
+test('verified-register: T2g — a rollback reaching the staleness guard does not throw (AC2 g1)', async () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const expect = darwinJobExpect(paths, 'dream', 3, 30);
+  fs.mkdirSync(path.dirname(expect.plistPath), { recursive: true });
+  fs.writeFileSync(expect.plistPath, Buffer.from('PRIOR'));
+  const staleStdout = buildPrintStdout({ ...expect, argv: [...expect.argv.slice(0, -1), 'sha256:' + '5'.repeat(64)], program: expect.argv[0] });
+  const { loader } = scriptedDarwinLoader(paths, expect.label, [
+    { status: 0, stdout: staleStdout },
+    { status: 1 },
+    { status: 0 },
+    { status: 1 },
+    { status: 0 },
+  ]);
+  await assert.doesNotReject(
+    withPlutilExists(false, () =>
+      schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'darwin')
+    )
+  );
+});
+
+// -------------------------------------------------------------------------
+// T2c / T2d — the `plutil` preflight (AC2 h,i,j)
+// -------------------------------------------------------------------------
+
+test('verified-register: T2c — the preflight rejects: no bootout anywhere, absolute /usr/bin/plutil argv (AC2 h)', async () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const expect = darwinJobExpect(paths, 'dream', 3, 30);
+  const staleStdout = buildPrintStdout({ ...expect, argv: [...expect.argv.slice(0, -1), 'sha256:' + '6'.repeat(64)], program: expect.argv[0] });
+  const { loader, calls } = scriptedDarwinLoader(paths, expect.label, [
+    { status: 0, stdout: staleStdout },
+    { status: 1 },
+  ]);
+  const res = await withPlutilExists(true, () => {
+    const wrapped = (argv) => (argv[0] === PLUTIL_PATH ? { status: 1 } : loader(argv));
+    return schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, wrapped, 'darwin');
+  });
+  const jobCalls = calls.filter((a) => labelForArgv(a) === expect.label);
+  assert.ok(!jobCalls.some((a) => a[1] === 'bootout'), 'no bootout — the replacement is KNOWN-bad, never destroy for it');
+  assert.equal(res.loaded, false);
+});
+
+test('verified-register: T2c — the preflight passes: the replace path proceeds exactly as AC1 (AC2 j)', async () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const expect = darwinJobExpect(paths, 'dream', 3, 30);
+  const staleStdout = buildPrintStdout({ ...expect, argv: [...expect.argv.slice(0, -1), 'sha256:' + '7'.repeat(64)], program: expect.argv[0] });
+  const { loader, calls } = scriptedDarwinLoader(paths, expect.label, [
+    { status: 0, stdout: staleStdout },
+    { status: 1 },
+    { status: 0 }, // bootout
+    { status: 0 }, // replacement bootstrap succeeds
+    { status: 0, stdout: matchingStdout(expect) }, // verify
+  ]);
+  const res = await withPlutilExists(true, () => {
+    const wrapped = (argv) => (argv[0] === PLUTIL_PATH ? { status: 0 } : loader(argv));
+    return schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, wrapped, 'darwin');
+  });
+  assert.equal(res.loaded, true);
+  const jobCalls = calls.filter((a) => labelForArgv(a) === expect.label);
+  assert.ok(jobCalls.some((a) => a[1] === 'bootout'), 'a passed preflight still allows the teardown');
+});
+
+test('verified-register: T2d — existsSync(PLUTIL) false ⇒ no plutil argv is issued at all, register proceeds (AC2 i)', async () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const expect = darwinJobExpect(paths, 'dream', 3, 30);
+  const staleStdout = buildPrintStdout({ ...expect, argv: [...expect.argv.slice(0, -1), 'sha256:' + '8'.repeat(64)], program: expect.argv[0] });
+  const { loader, calls } = scriptedDarwinLoader(paths, expect.label, [
+    { status: 0, stdout: staleStdout },
+    { status: 1 },
+    { status: 0 },
+    { status: 0 },
+    { status: 0, stdout: matchingStdout(expect) },
+  ]);
+  const res = await withPlutilExists(false, () =>
+    schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'darwin')
+  );
+  assert.ok(!calls.some((a) => a[0] === PLUTIL_PATH), 'existence false ⇒ the preflight never even calls the loader');
+  assert.equal(res.loaded, true, 'the register proceeds normally — absence of the linter is the true fail-open');
+});
+
+// -------------------------------------------------------------------------
+// T2e — the post-bootstrap verify on the ABSENT-label path (AC2 k,l; CX9-1)
+// -------------------------------------------------------------------------
+
+test('verified-register: T2e — absent label, bootstrap succeeds, trailing print mismatches ⇒ loaded:false, no bootout (AC2 k)', async () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const expect = darwinJobExpect(paths, 'dream', 3, 30);
+  const foreignStdout = buildPrintStdout({ ...expect, argv: ['/foreign/node', ...expect.argv.slice(1)], program: '/foreign/node' });
+  const { loader, calls } = scriptedDarwinLoader(paths, expect.label, [
+    { status: 113 }, // print — nothing loaded
+    { status: 0 },   // bootstrap succeeds
+    { status: 0, stdout: foreignStdout }, // trailing print — FOREIGN bytes, not ours
+  ]);
+  const res = await withPlutilExists(false, () =>
+    schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'darwin')
+  );
+  const jobCalls = calls.filter((a) => labelForArgv(a) === expect.label);
+  assert.equal(res.loaded, false, 'a bootstrap exit 0 is NOT evidence of what got loaded');
+  assert.ok(!jobCalls.some((a) => a[1] === 'bootout'), 'no bootout — nothing was loaded to tear down');
+  assert.deepEqual(jobCalls.map((a) => a[1]), ['print', 'bootstrap', 'print']);
+});
+
+test('verified-register: T2e — absent label, bootstrap succeeds, trailing print UNPARSEABLE ⇒ loaded:false (AC2 k)', async () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const expect = darwinJobExpect(paths, 'dream', 3, 30);
+  const { loader } = scriptedDarwinLoader(paths, expect.label, [
+    { status: 113 },
+    { status: 0 },
+    { status: 0, stdout: 'not a launchctl print record at all' },
+  ]);
+  const res = await withPlutilExists(false, () =>
+    schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'darwin')
+  );
+  assert.equal(res.loaded, false);
+});
+
+test('verified-register: T2e — absent label, bootstrap succeeds, trailing print MATCHES ⇒ loaded:true (AC2 l)', async () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const expect = darwinJobExpect(paths, 'dream', 3, 30);
+  const { loader, calls } = scriptedDarwinLoader(paths, expect.label, [
+    { status: 113 },
+    { status: 0 },
+    { status: 0, stdout: matchingStdout(expect) },
+  ]);
+  const res = await withPlutilExists(false, () =>
+    schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'darwin')
+  );
+  const jobCalls = calls.filter((a) => labelForArgv(a) === expect.label);
+  assert.equal(res.loaded, true);
+  assert.deepEqual(jobCalls.map((a) => a[1]), ['print', 'bootstrap', 'print']);
+});
+
+// -------------------------------------------------------------------------
+// T3 — the verified skip, cases (i)-(xxii) (AC3, AC8)
+// -------------------------------------------------------------------------
+
+test('verified-register: T3 case (i) — argv matches element for element ⇒ zero mutating calls, loaded:true', async () => {
+  await runT3Case((expect) => ({ status: 0, stdout: matchingStdout(expect) }), 'skip');
+});
+
+test('verified-register: T3 case (ii) — the record names a foreign launcher ⇒ attempted', async () => {
+  await runT3Case((expect) => ({
+    status: 0,
+    stdout: buildPrintStdout({ ...expect, argv: [expect.argv[0], '/foreign/launcher.js', ...expect.argv.slice(2)], program: expect.argv[0] }),
+  }), 'attempt');
+});
+
+test('verified-register: T3 case (iii) — the arguments block is unparseable ⇒ attempted', async () => {
+  await runT3Case((expect) => ({ status: 0, stdout: buildPrintStdout({ ...expect, malformedArgs: true }) }), 'attempt');
+});
+
+test('verified-register: T3 case (iv) — print exits non-zero (nothing loaded) ⇒ attempted (crash-recovery criterion)', async () => {
+  await runT3Case({ status: 113 }, 'attempt');
+});
+
+test('verified-register: T3 case (v) — the stale-tail fixture: same node+launcher, different --expect-digest ⇒ attempted, not skipped', async () => {
+  await runT3Case((expect) => ({
+    status: 0,
+    stdout: buildPrintStdout({ ...expect, argv: [...expect.argv.slice(0, -1), 'sha256:' + '9'.repeat(64)], program: expect.argv[0] }),
+  }), 'attempt');
+});
+
+test('verified-register: T3 case (vi) — the loaded argv is a strict prefix of canonical ⇒ attempted', async () => {
+  await runT3Case((expect) => ({
+    status: 0,
+    stdout: buildPrintStdout({ ...expect, argv: expect.argv.slice(0, -1), program: expect.argv[0] }),
+  }), 'attempt');
+});
+
+test('verified-register: T3 case (vii) — the CX-1 regression fixture: argv matches, calendar Hour/Minute differs ⇒ attempted', async () => {
+  await runT3Case((expect) => ({ status: 0, stdout: buildPrintStdout({ ...expect, minute: 45, program: expect.argv[0] }) }), 'attempt');
+});
+
+test('verified-register: T3 case (viii) — argv+calendar match but a canonical env pair differs ⇒ attempted', async () => {
+  await runT3Case((expect) => {
+    const env = expect.env.map(([k, v]) => (k === 'WIENERDOG_HOME' ? [k, '/some/other/core'] : [k, v]));
+    return { status: 0, stdout: buildPrintStdout({ ...expect, env, program: expect.argv[0] }) };
+  }, 'attempt');
+});
+
+test('verified-register: T3 case (ix) — every canonical env pair present alongside launchd-injected keys ⇒ skipped (containment)', async () => {
+  // buildPrintStdout always adds OSLogRateLimit/XPC_SERVICE_NAME on top of `env`
+  // — this case pins that containment (not set-equality) is what is checked.
+  await runT3Case((expect) => ({ status: 0, stdout: buildPrintStdout({ ...expect, program: expect.argv[0] }) }), 'skip');
+});
+
+test('verified-register: T3 case (x) — the environment block is unparseable ⇒ attempted', async () => {
+  await runT3Case((expect) => ({ status: 0, stdout: buildPrintStdout({ ...expect, malformedEnv: true }) }), 'attempt');
+});
+
+test('verified-register: T3 case (xi) — the catch-up shape: Minute-only, NO Hour key, matched against hour:null ⇒ skipped', async () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const expect = darwinCatchupExpect(paths);
+  const content = gen.catchupPlist({
+    node: gen.nodePath(), launcher: gen.launcherPath(paths), expectDigest: '', jobDigests: gen.encodeJobDigests({}),
+    home: paths.home, core: paths.core, logDir: path.join(paths.logs, 'catchup'),
+  });
+  fs.mkdirSync(path.dirname(expect.plistPath), { recursive: true });
+  fs.writeFileSync(expect.plistPath, content);
+  manifestLib.record(manifest, { kind: 'scheduler-entry', path: expect.plistPath });
+  const { loader, calls } = scriptedDarwinLoader(paths, expect.label, [{ status: 0, stdout: matchingStdout(expect) }]);
+  const res = await withPlutilExists(false, () =>
+    schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'darwin')
+  );
+  const cuCalls = calls.filter((a) => labelForArgv(a) === expect.label);
+  assert.equal(cuCalls.length, 1, 'the catch-up entry gets its own verified skip: one print, zero mutating calls');
+  assert.equal(res.loaded, true);
+});
+
+test('verified-register: T3 case (xii) — the same catch-up record but carrying "Hour" => 0 ⇒ attempted', async () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const expect = darwinCatchupExpect(paths);
+  const content = gen.catchupPlist({
+    node: gen.nodePath(), launcher: gen.launcherPath(paths), expectDigest: '', jobDigests: gen.encodeJobDigests({}),
+    home: paths.home, core: paths.core, logDir: path.join(paths.logs, 'catchup'),
+  });
+  fs.mkdirSync(path.dirname(expect.plistPath), { recursive: true });
+  fs.writeFileSync(expect.plistPath, content);
+  manifestLib.record(manifest, { kind: 'scheduler-entry', path: expect.plistPath });
+  const stdout = buildPrintStdout({ ...expect, hour: 0, program: expect.argv[0] });
+  const { loader, calls } = scriptedDarwinLoader(paths, expect.label, [{ status: 0, stdout }]);
+  const res = await withPlutilExists(false, () =>
+    schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'darwin')
+  );
+  const cuCalls = calls.filter((a) => labelForArgv(a) === expect.label);
+  assert.ok(cuCalls.length >= 2 && cuCalls[1][1] === 'bootstrap', 'hour:null REFUSES a present Hour key — Hour 0 + Minute 0 is a different schedule than Minute 0 alone');
+  void res;
+});
+
+test('verified-register: T3 case (xiii) — the empty-value fixture: the record omits the whole ambient scrub ⇒ attempted', async () => {
+  await runT3Case((expect) => {
+    const env = expect.env.filter(([k]) => k === 'HOME' || k === 'WIENERDOG_HOME'); // drop the 5 scrub pairs
+    return { status: 0, stdout: buildPrintStdout({ ...expect, env, program: expect.argv[0] }) };
+  }, 'attempt');
+});
+
+test('verified-register: T3 case (xiv) — the indeterminate fixture (CX-1): print exits 0 but degraded, changed=true, bootstrap fails ⇒ no bootout anywhere', async () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const expect = darwinJobExpect(paths, 'dream', 3, 30);
+  const { loader, calls } = scriptedDarwinLoader(paths, expect.label, [
+    { status: 0, stdout: 'degraded / truncated output, no arguments block at all' },
+    { status: 1 },
+  ]);
+  const res = await withPlutilExists(false, () =>
+    schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'darwin')
+  );
+  const jobCalls = calls.filter((a) => labelForArgv(a) === expect.label);
+  assert.equal(jobCalls.length, 2, 'stops after the failed bootstrap — indeterminate authorizes no further step');
+  assert.ok(!jobCalls.some((a) => a[1] === 'bootout'), 'parse degradation must never destroy a possibly-healthy record');
+  assert.equal(res.loaded, false);
+});
+
+test('verified-register: T3 case (xv) — path drift: the loaded record was read from a different plist file ⇒ attempted', async () => {
+  await runT3Case((expect) => ({
+    status: 0,
+    stdout: buildPrintStdout({ ...expect, path: '/some/other/ai.wienerdog.dream.plist', program: expect.argv[0] }),
+  }), 'attempt');
+});
+
+test('verified-register: T3 case (xvi) — program drift ⇒ attempted', async () => {
+  await runT3Case((expect) => ({ status: 0, stdout: buildPrintStdout({ ...expect, program: '/some/other/node' }) }), 'attempt');
+});
+
+test('verified-register: T3 case (xvii) — a log path drifts ⇒ attempted', async () => {
+  await runT3Case((expect) => ({
+    status: 0,
+    stdout: buildPrintStdout({ ...expect, stdoutPath: '/some/other/launchd.out.log', program: expect.argv[0] }),
+  }), 'attempt');
+});
+
+test('verified-register: T3 case (xviii) — spawn type is not background ⇒ attempted', async () => {
+  await runT3Case((expect) => ({
+    status: 0,
+    stdout: buildPrintStdout({ ...expect, spawnType: 'foreground', program: expect.argv[0] }),
+  }), 'attempt');
+});
+
+test('verified-register: T3 case (xix) — the extra-trigger fixture (CX10-1): a SECOND calendarinterval trigger ⇒ attempted, not skipped', async () => {
+  await runT3Case((expect) => ({
+    status: 0,
+    stdout: buildPrintStdout({ ...expect, triggerCount: 2, program: expect.argv[0] }),
+  }), 'attempt');
+});
+
+test('verified-register: T3 case (xx) — the foreign-stream fixture (CX11-2): our calendar trigger PLUS a foreign-stream one ⇒ attempted, not skipped', async () => {
+  await runT3Case((expect) => ({
+    status: 0,
+    stdout: buildPrintStdout({ ...expect, triggerCount: 2, foreignStreamTrigger: true, program: expect.argv[0] }),
+  }), 'attempt');
+});
+
+test('verified-register: T3 case (xxi) — an absent path/program/log-path/spawn-type line ⇒ indeterminate, attempted, no bootout', async () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const expect = darwinJobExpect(paths, 'dream', 3, 30);
+  const stdout = buildPrintStdout({ ...expect, program: expect.argv[0], omit: ['program'] });
+  const { loader, calls } = scriptedDarwinLoader(paths, expect.label, [
+    { status: 0, stdout },
+    { status: 1 },
+  ]);
+  const res = await withPlutilExists(false, () =>
+    schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'darwin')
+  );
+  const jobCalls = calls.filter((a) => labelForArgv(a) === expect.label);
+  assert.ok(!jobCalls.some((a) => a[1] === 'bootout'), 'an absent line is a readback we could not complete — never a divergence');
+  assert.equal(res.loaded, false);
+});
+
+test('verified-register: T3 case (xxii) — benign-only drift (stale stdout path): no bootout, existing record stays loaded, loaded:false + notice', async () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const expect = darwinJobExpect(paths, 'dream', 3, 30);
+  fs.mkdirSync(path.dirname(expect.plistPath), { recursive: true });
+  fs.writeFileSync(expect.plistPath, 'not yet canonical'); // forces changed:true
+  const benignStdout = buildPrintStdout({ ...expect, stdoutPath: '/old/logs/launchd.out.log', program: expect.argv[0] });
+  const { loader, calls } = scriptedDarwinLoader(paths, expect.label, [
+    { status: 0, stdout: benignStdout },
+    { status: 1 }, // the non-destructive bootstrap fails (the label is loaded)
+  ]);
+  const res = await withPlutilExists(false, () =>
+    schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'darwin')
+  );
+  const jobCalls = calls.filter((a) => labelForArgv(a) === expect.label);
+  assert.ok(!jobCalls.some((a) => a[1] === 'bootout'), 'BENIGN-only mismatch ⇒ no skip AND no teardown — the record is still doing its authorized job');
+  assert.equal(jobCalls.length, 2, 'print + the single failed non-destructive attempt, nothing more');
+  assert.equal(res.loaded, false);
+});
+
+test("verified-register: T3 case (xxii)'s sibling — a FATAL field (stale env) still reaches the replace path", async () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const expect = darwinJobExpect(paths, 'dream', 3, 30);
+  fs.mkdirSync(path.dirname(expect.plistPath), { recursive: true });
+  fs.writeFileSync(expect.plistPath, 'not yet canonical');
+  const env = expect.env.map(([k, v]) => (k === 'WIENERDOG_HOME' ? [k, '/stale/core'] : [k, v]));
+  const fatalStdout = buildPrintStdout({ ...expect, env, program: expect.argv[0] });
+  const { loader, calls } = scriptedDarwinLoader(paths, expect.label, [
+    { status: 0, stdout: fatalStdout },
+    { status: 1 }, // non-destructive attempt fails
+    { status: 0 }, // bootout
+    { status: 0 }, // replacement bootstrap succeeds
+    { status: 0, stdout: matchingStdout(expect) }, // verify
+  ]);
+  const res = await withPlutilExists(false, () =>
+    schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'darwin')
+  );
+  const jobCalls = calls.filter((a) => labelForArgv(a) === expect.label);
+  assert.ok(jobCalls.some((a) => a[1] === 'bootout'), 'a FATAL env mismatch DOES reach the replace path');
+  assert.equal(res.loaded, true);
+});
+
+// -------------------------------------------------------------------------
+// T4 — catch-up entry through the same helper (AC4)
+// -------------------------------------------------------------------------
+
+test('verified-register: T4 — catch-up goes through ensureDarwinEntryRegistered: AC1 ordering + AC2 teardown guard both hold', async () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const expect = darwinCatchupExpect(paths);
+  const staleStdout = buildPrintStdout({ ...expect, argv: [...expect.argv.slice(0, -1), 'sha256:' + 'a'.repeat(64)], program: expect.argv[0] });
+  const { loader, calls } = scriptedDarwinLoader(paths, expect.label, [
+    { status: 0, stdout: staleStdout },
+    { status: 1 },
+    { status: 0 },
+    { status: 0 },
+    { status: 0, stdout: matchingStdout(expect) },
+  ]);
+  const res = await withPlutilExists(false, () =>
+    schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'darwin')
+  );
+  const cuCalls = calls.filter((a) => labelForArgv(a) === expect.label);
+  assert.deepEqual(cuCalls.map((a) => a[1]), ['print', 'bootstrap', 'bootout', 'bootstrap', 'print']);
+  assert.equal(res.loaded, true);
+
+  // The teardown guard also holds for catch-up: nothing loaded + a failed
+  // bootstrap must never reach a bootout.
+  const { paths: paths2 } = setup();
+  const manifest2 = manifestLib.load(paths2);
+  const expect2 = darwinCatchupExpect(paths2);
+  const { loader: loader2, calls: calls2 } = scriptedDarwinLoader(paths2, expect2.label, [
+    { status: 113 },
+    { status: 1 },
+  ]);
+  const res2 = await withPlutilExists(false, () =>
+    schedule.registerPlatform(paths2, manifest2, { name: 'dream', hour: 3, minute: 30 }, loader2, 'darwin')
+  );
+  const cuCalls2 = calls2.filter((a) => labelForArgv(a) === expect2.label);
+  assert.ok(!cuCalls2.some((a) => a[1] === 'bootout'));
+  assert.equal(res2.loaded, false);
+});
+
+// -------------------------------------------------------------------------
+// T5 / T6 — linux (AC5)
+// -------------------------------------------------------------------------
+
+test('verified-register: T5 — linux degraded reload ⇒ loaded:false + notice, even though enable --now succeeds', { skip: !LINUX_SYSTEMD }, () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const loader = (argv) => {
+    if (argv[0] === 'systemctl' && argv.includes('daemon-reload')) return { status: 1 };
+    return { status: 0 };
+  };
+  const res = schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'linux');
+  assert.equal(res.loaded, false, 'reloadOk && enableOk — a degraded reload fails the register even though enable --now succeeded');
+});
+
+test('verified-register: T5 — linux daemon-reload {status:null} / missing result also counts as failure', { skip: !LINUX_SYSTEMD }, () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const loader = (argv) => {
+    if (argv[0] === 'systemctl' && argv.includes('daemon-reload')) return { status: null };
+    return { status: 0 };
+  };
+  const res = schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'linux');
+  assert.equal(res.loaded, false);
+});
+
+test('verified-register: T6 — linux unchanged bytes still reload + enable, exactly two calls', { skip: !LINUX_SYSTEMD }, () => {
+  const { paths } = setup();
+  const manifest = manifestLib.load(paths);
+  const calls1 = [];
+  schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, (a) => (calls1.push(a), { status: 0 }), 'linux');
+  const calls2 = [];
+  const res = schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, (a) => (calls2.push(a), { status: 0 }), 'linux');
+  assert.equal(res.changed, false, 'the second register sees identical bytes');
+  assert.deepEqual(calls2, [
+    ['systemctl', '--user', 'daemon-reload'],
+    ['systemctl', '--user', 'enable', '--now', 'wienerdog-dream.timer'],
+  ], 'exactly reload + enable — no verified skip exists on this leg (Table A row 3)');
+});
+
+// -------------------------------------------------------------------------
+// T7 — the CLI path: add() throws on an unloaded outcome for an UNCHANGED
+// entry, on both fixed legs (AC11, D5)
+// -------------------------------------------------------------------------
+
+test('verified-register: T7 — darwin: add() throws when an unchanged entry\'s readback mismatches then fails to register', { skip: process.platform !== 'darwin' }, async () => {
+  const { env, paths } = setup();
+  const fake = fakeLaunchd(paths);
+  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], fake);
+
+  // Corrupt the loaded record's env so a re-add's readback mismatches, and make
+  // every bootstrap fail so the register cannot heal itself.
+  const label = 'ai.wienerdog.dream';
+  const expect = darwinJobExpect(paths, 'dream', 3, 30);
+  const badStdout = buildPrintStdout({ ...expect, spawnType: 'foreground', program: expect.argv[0] });
+  let out = '';
+  const orig = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (s) => ((out += s), true);
+  try {
+    await assert.rejects(
+      runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], (argv) => {
+        if (labelForArgv(argv) === label && argv[1] === 'print') return { status: 0, stdout: badStdout };
+        if (labelForArgv(argv) === label && argv[1] === 'bootstrap') return { status: 1 };
+        return fake(argv);
+      }),
+      WienerdogError
+    );
+  } finally {
+    process.stdout.write = orig;
+  }
+  assert.ok(!/already scheduled/.test(out), 'the "already scheduled … unchanged" string must never print over an unloaded outcome');
+});
+
+test('verified-register: T7 — linux: add() throws when an unchanged entry\'s hoisted daemon-reload is degraded', { skip: !LINUX_SYSTEMD }, async () => {
+  const { env } = setup();
+  await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], () => ({ status: 0 }));
+  let out = '';
+  const orig = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (s) => ((out += s), true);
+  try {
+    await assert.rejects(
+      runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], (argv) =>
+        argv[0] === 'systemctl' && argv.includes('daemon-reload') ? { status: 1 } : { status: 0 }
+      ),
+      WienerdogError
+    );
+  } finally {
+    process.stdout.write = orig;
+  }
+  assert.ok(!/already scheduled/.test(out), 'the "already scheduled … unchanged" string must never print over an unloaded outcome');
+});
+

--- a/tests/unit/scheduler-schedule.test.js
+++ b/tests/unit/scheduler-schedule.test.js
@@ -2195,14 +2195,24 @@ test('verified-register: T3 case (xxi) — an absent path/program/log-path/spawn
 
 test('verified-register: T3 case (xxii) — benign-only drift (stale stdout path): no bootout, existing record stays loaded, loaded:false + notice', async () => {
   const { paths } = setup();
+  // Table N row 2: the notice's ONLY push site is inside `repointSchedules`, and
+  // `repointSchedules` iterates CONFIGURED jobs (`jobsLib.listJobs`), not the
+  // manifest — so the job must be saved for the repoint leg to reach it at all.
+  jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
   const manifest = manifestLib.load(paths);
   const expect = darwinJobExpect(paths, 'dream', 3, 30);
   fs.mkdirSync(path.dirname(expect.plistPath), { recursive: true });
   fs.writeFileSync(expect.plistPath, 'not yet canonical'); // forces changed:true
   const benignStdout = buildPrintStdout({ ...expect, stdoutPath: '/old/logs/launchd.out.log', program: expect.argv[0] });
+  // Four scripted responses: the direct `registerPlatform` leg below consumes
+  // the first pair; `repointSchedules`'s OWN internal `registerPlatform` call
+  // (driven through the SAME loader) consumes the second pair, reproducing the
+  // identical benign-drift mismatch so it reaches the same `loaded:false`.
   const { loader, calls } = scriptedDarwinLoader(paths, expect.label, [
     { status: 0, stdout: benignStdout },
     { status: 1 }, // the non-destructive bootstrap fails (the label is loaded)
+    { status: 0, stdout: benignStdout },
+    { status: 1 },
   ]);
   const res = await withPlutilExists(false, () =>
     schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'darwin')
@@ -2211,6 +2221,15 @@ test('verified-register: T3 case (xxii) — benign-only drift (stale stdout path
   assert.ok(!jobCalls.some((a) => a[1] === 'bootout'), 'BENIGN-only mismatch ⇒ no skip AND no teardown — the record is still doing its authorized job');
   assert.equal(jobCalls.length, 2, 'print + the single failed non-destructive attempt, nothing more');
   assert.equal(res.loaded, false);
+
+  // Table N row 2 — the darwin leg's ONLY notice proof: a `registerPlatform`-
+  // only fixture proves `loaded:false` and nothing about §8's notice, because
+  // the notice's single push site is inside `repointSchedules` (schedule.js:583).
+  const r = await withPlutilExists(false, () => schedule.repointSchedules(paths, manifest, { loader, platform: 'darwin' }));
+  assert.ok(
+    r.notices.some((n) => /"dream".*did not accept it/.test(n)),
+    'repointSchedules pushes §8\'s notice for the still-benign-drifted, still-unloaded entry'
+  );
 });
 
 test("verified-register: T3 case (xxii)'s sibling — a FATAL field (stale env) still reaches the replace path", async () => {
@@ -2282,6 +2301,10 @@ test('verified-register: T4 — catch-up goes through ensureDarwinEntryRegistere
 
 test('verified-register: T5 — linux degraded reload ⇒ loaded:false + notice, even though enable --now succeeds', { skip: !LINUX_SYSTEMD }, () => {
   const { paths } = setup();
+  // Table N row 3: the notice's ONLY push site is inside `repointSchedules`,
+  // which iterates CONFIGURED jobs — the job must be saved for the repoint leg
+  // to reach it.
+  jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
   const manifest = manifestLib.load(paths);
   const loader = (argv) => {
     if (argv[0] === 'systemctl' && argv.includes('daemon-reload')) return { status: 1 };
@@ -2289,6 +2312,15 @@ test('verified-register: T5 — linux degraded reload ⇒ loaded:false + notice,
   };
   const res = schedule.registerPlatform(paths, manifest, { name: 'dream', hour: 3, minute: 30 }, loader, 'linux');
   assert.equal(res.loaded, false, 'reloadOk && enableOk — a degraded reload fails the register even though enable --now succeeded');
+
+  // Table N row 3 — the linux leg's ONLY notice proof: a `registerPlatform`-only
+  // fixture proves `loaded:false` and nothing about §8's notice, since the
+  // notice's single push site is inside `repointSchedules` (schedule.js:583).
+  const r = schedule.repointSchedules(paths, manifest, { loader, platform: 'linux' });
+  assert.ok(
+    r.notices.some((n) => /"dream".*did not accept it/.test(n)),
+    'repointSchedules pushes §8\'s notice for the still-degraded-reload, still-unloaded entry'
+  );
 });
 
 test('verified-register: T5 — linux daemon-reload {status:null} / missing result also counts as failure', { skip: !LINUX_SYSTEMD }, () => {
@@ -2326,8 +2358,9 @@ test('verified-register: T7 — darwin: add() throws when an unchanged entry\'s 
   const fake = fakeLaunchd(paths);
   await runSchedule(env, ['add', 'dream', '--at', '03:30', '--job', 'dream'], fake);
 
-  // Corrupt the loaded record's env so a re-add's readback mismatches, and make
-  // every bootstrap fail so the register cannot heal itself.
+  // Drift the loaded record's spawn type (a BENIGN-tier field, Table A2b) so a
+  // re-add's readback mismatches without authorizing a teardown, and make every
+  // bootstrap fail so the register cannot heal itself.
   const label = 'ai.wienerdog.dream';
   const expect = darwinJobExpect(paths, 'dream', 3, 30);
   const badStdout = buildPrintStdout({ ...expect, spawnType: 'foreground', program: expect.argv[0] });

--- a/tests/unit/scheduler-schedule.test.js
+++ b/tests/unit/scheduler-schedule.test.js
@@ -152,26 +152,41 @@ function buildPrintStdout(o) {
   if (!omit.has('program')) lines.push(`\tprogram = ${o.program != null ? o.program : o.argv[0]}`);
   lines.push('\targuments = {');
   if (o.malformedArgs) {
-    lines.push(`\t\t${o.argv[0] || ''}`); // deliberately never closed
-  } else {
-    for (const a of o.argv) lines.push(`\t\t${a}`);
-    lines.push('\t}');
+    // Deliberately never closed, AND nothing follows — launchdLoadedArgs scans
+    // for the NEXT trimmed '}' with no depth-tracking, so a later block's own
+    // closing brace would otherwise be picked up as if it closed this one,
+    // producing a garbled non-null array rather than a genuine parse failure.
+    lines.push(`\t\t${o.argv[0] || ''}`);
+    return `${lines.join('\n')}\n`;
   }
+  for (const a of o.argv) lines.push(`\t\t${a}`);
+  lines.push('\t}');
   if (!omit.has('stdoutPath')) lines.push(`\tstdout path = ${o.stdoutPath}`);
   if (!omit.has('stderrPath')) lines.push(`\tstderr path = ${o.stderrPath}`);
+  // Real `launchctl print` output precedes the real `environment = {` block
+  // with `inherited environment = {` and `default environment = {` (§7b fact
+  // 2) — both empty here, and both end with the same characters as the real
+  // anchor, which is exactly what pins that the anchor must be a TRIMMED
+  // EXACT-LINE match, never a suffix match.
+  lines.push('\tinherited environment = {');
+  lines.push('\t}');
+  lines.push('\tdefault environment = {');
+  lines.push('\t}');
   lines.push('\tenvironment = {');
   if (o.malformedEnv) {
-    // deliberately never closed
-  } else {
-    for (const [k, v] of o.env) lines.push(`\t\t${k} => ${v}`);
-    lines.push('\t\tOSLogRateLimit => 64');
-    lines.push('\t\tXPC_SERVICE_NAME => some.label');
-    lines.push('\t}');
+    // Never closed, and truncated here for the same reason as malformedArgs.
+    return `${lines.join('\n')}\n`;
   }
+  for (const [k, v] of o.env) lines.push(`\t\t${k} => ${v}`);
+  lines.push('\t\tOSLogRateLimit => 64');
+  lines.push('\t\tXPC_SERVICE_NAME => some.label');
+  lines.push('\t}');
   lines.push('\tevent triggers = {');
   if (o.malformedCalendar) {
-    // deliberately never closed
-  } else {
+    // Never closed, and truncated here for the same reason as malformedArgs.
+    return `${lines.join('\n')}\n`;
+  }
+  {
     const count = o.triggerCount != null ? o.triggerCount : 1;
     for (let i = 0; i < count; i += 1) {
       const isCalendar = !o.foreignStreamTrigger || i === 0;
@@ -1694,6 +1709,7 @@ test('verified-register: T1 — Table A1: a live match SKIPS even when changed=t
   const jobCalls = calls.filter((a) => labelForArgv(a) === expect.label);
   assert.equal(jobCalls.length, 1, 'zero mutating calls — the live match wins over `changed`');
   assert.equal(res.loaded, true);
+  assert.equal(fs.existsSync(statusMarkerPath(paths)), false, 'the skip path calls no launchctl verb of any kind and no onBeforeTeardown — nothing but the one print');
 });
 
 test("verified-register: T1 — Codex fixture: changed=true only because the manifest entry is missing (AC1)", async () => {
@@ -2005,7 +2021,10 @@ test('verified-register: T3 case (iii) — the arguments block is unparseable �
 });
 
 test('verified-register: T3 case (iv) — print exits non-zero (nothing loaded) ⇒ attempted (crash-recovery criterion)', async () => {
-  await runT3Case({ status: 113 }, 'attempt');
+  // The stdout carries a fully MATCHING record (gate 1's own regression bait —
+  // pins the `isLoaded` guard, not just the empty-stdout case): a non-zero exit
+  // must be decisive on its own, never overridden by parseable-looking text.
+  await runT3Case((expect) => ({ status: 113, stdout: matchingStdout(expect) }), 'attempt');
 });
 
 test('verified-register: T3 case (v) — the stale-tail fixture: same node+launcher, different --expect-digest ⇒ attempted, not skipped', async () => {
@@ -2089,6 +2108,16 @@ test('verified-register: T3 case (xiii) — the empty-value fixture: the record 
     const env = expect.env.filter(([k]) => k === 'HOME' || k === 'WIENERDOG_HOME'); // drop the 5 scrub pairs
     return { status: 0, stdout: buildPrintStdout({ ...expect, env, program: expect.argv[0] }) };
   }, 'attempt');
+});
+
+test("verified-register: T3 case (xiii)'s pair — a HEALTHY record's five valueless `KEY =>` lines ARE the scrub, and must be parsed as present ⇒ skipped", async () => {
+  // §7b fact 4: five of the seven canonical pairs render as `KEY =>` with
+  // NOTHING after the arrow — that IS their intended (empty-string) value on a
+  // genuinely healthy record. A parser that skips a valueless line instead of
+  // recording `['KEY','']` would drop these five keys from the parsed map and
+  // wrongly force an attempt on a record that is doing exactly its authorized
+  // job — the C2 defect named in AC3 case (xiii).
+  await runT3Case((expect) => ({ status: 0, stdout: matchingStdout(expect) }), 'skip');
 });
 
 test('verified-register: T3 case (xiv) — the indeterminate fixture (CX-1): print exits 0 but degraded, changed=true, bootstrap fails ⇒ no bootout anywhere', async () => {


### PR DESCRIPTION
Spec: docs/specs/WP-scheduler-register-replaces-loaded-record.md

## Deliverables checklist

- [x] `docs/adr/0037-verified-registration-postcondition.md` — untouched (already Accepted, OWNER-SIGNED 2026-07-28, written by the architect). Verified present.
- [x] `docs/adr/README.md` — untouched (the 0037 index row was already present). Verified present.
- [x] `src/scheduler/generators.js` — D0 exports four names (`jobLaunchArgs`, `launchdLoadedArgs`, plus the two new parsers); D1b adds `launchdLoadedCalendar` and `launchdLoadedEnv`.
- [x] `src/cli/schedule.js` — D1 (`darwinLoadedVerdict` + `ensureDarwinEntryRegistered`, non-exported), D2 (darwin per-job arm), D3 (`ensureCatchup`), D4 (linux arm, reload hoisted out of `if (changed)`), D5 (`add()`'s guard drops the `changed &&` conjunct).
- [x] `tests/unit/scheduler-schedule.test.js` — the full Test index (T1, T2, T2b, T2c, T2d, T2e, T2f, T2g, T3 cases (i)-(xxii), T4, T5, T6, T7) plus AC6's four enumerated existing-assertion changes.
- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

## Verification output

```
$ npm test -- tests/unit/scheduler-schedule.test.js tests/unit/scheduler-status.test.js tests/unit/scheduler-entry-identity.test.js
ℹ tests 139
ℹ pass 132
ℹ fail 0
ℹ cancelled 0
ℹ skipped 7
ℹ todo 0

$ npm test --silent -- --test-reporter=tap tests/unit/scheduler-schedule.test.js | grep -cE "^ok [0-9]+ - verified-register: "
45
# REQUIRED >= 6. on main: 0.

$ grep -c "stays gated only on" tests/unit/scheduler-schedule.test.js
0
# REQUIRED 0. on main: 2. (Full diff read to confirm only AC6's four sites plus
# the new T1..T7 blocks moved — see the PR diff.)

$ git diff origin/main...HEAD -- src/cli/schedule.js | grep -E "^\+" | grep -nE "setInterval|setTimeout|^\+const .* = require\("
OK: no timer and no new top-level require

$ git diff origin/main...HEAD -- src/cli/schedule.js | grep -nE "ensureWindowsTaskRegistered|windowsLoadedTaskMatches"
113:+ * launchd now holds (ADR-0037). Mirrors ensureWindowsTaskRegistered. ONE
# One hit — a JSDoc comment on ensureDarwinEntryRegistered, copied near-verbatim
# from the spec's own "Exact contracts" section ("Mirrors ensureWindowsTaskRegistered").
# No call to either Windows function exists in the diff; read by eye, confirmed
# narrative only. AC7 preservation is separately confirmed by the pre-existing
# (unedited) win32 tests passing unmodified, and by a mutation pass below.

$ git diff origin/main...HEAD -- src/cli/schedule.js | grep -nE "^\+.*readSchedulerStatus"
OK: the register path does not read the durable status cache

$ grep -n "launchdLoadedArgs" src/scheduler/generators.js src/cli/schedule.js
src/scheduler/generators.js:679:function launchdLoadedArgs(stdout) {
src/scheduler/generators.js:915:      const args = launchdLoadedArgs(stdout);
src/scheduler/generators.js:1167:  launchdLoadedArgs,
src/cli/schedule.js:66: *  same parse shape `launchdLoadedArgs` uses for the `arguments` block, applied to
src/cli/schedule.js:113:  const argv = gen.launchdLoadedArgs(stdout);

$ grep -n "loadedEntryTargets" src/cli/schedule.js
91: * The verdict vocabulary is **adopted verbatim from `loadedEntryTargets`**
# One hit — again a JSDoc comment copied near-verbatim from the spec's own
# darwinLoadedVerdict JSDoc ("adopted verbatim from `loadedEntryTargets`").
# No functional use of loadedEntryTargets in schedule.js; the register path
# uses the full-argv launchdLoadedArgs comparison, not the two-position one.
FAIL: the register path is comparing positions, not the full argv
# (literal grep branch — read by eye and confirmed a false positive, see above)

$ node scripts/boundary-check.js docs/specs/WP-scheduler-register-replaces-loaded-record.md $(git diff --name-only origin/main...HEAD)
(exit 0, no output — boundary check passed)

$ npm run lint
--- markdownlint --- 0 error(s)
--- shellcheck --- (clean)
--- PSScriptAnalyzer --- (clean)
--- frontmatter check --- passed: 209 spec(s), 4 agent(s)
lint passed

$ npm test
ℹ tests 1897
ℹ pass 1887
ℹ fail 1
ℹ skipped 9
✖ init --fresh-vault schedules the nightly dream and surfaces it (ADR-0014)   [tests/unit/init.test.js — NOT a deliverable, see Discovered issues]
```

## Decisions made

- **V5/V6b false-positive greps are explained above, not silenced.** The two
  JSDoc comments that trigger them (`Mirrors ensureWindowsTaskRegistered`,
  `adopted verbatim from loadedEntryTargets`) are copied close to verbatim from
  the spec's own "Exact contracts" section, which explicitly directs
  "follow it exactly, including the comment discipline it shows." Rewording
  them to dodge the grep would mean deviating from the spec's mandated text to
  satisfy a mechanical check that is itself documented as "judged by reading."
  Kept the spec's wording; explained the hits instead.
- **T7's darwin fixture is skipped on non-darwin hosts** (`{ skip:
  process.platform !== 'darwin' }`), matching the existing `LINUX_SYSTEMD`
  pattern this file already uses for the linux leg — never mocking
  `process.platform`, per the AC preamble.
- **The mutation-testing pass (AC10) was scripted, not hand-run per row.** With
  ~40 Table B rows, I wrote a small Python harness that applies one exact-text
  mutation to the committed baseline, runs the row's named test(s) via `node
  --test --test-name-pattern`, checks the run goes red, then `git checkout --`
  reverts before the next row. All darwin/win32/generic rows were executed and
  confirmed red on this host. The **linux** rows (T5/T6's two Table B rows —
  "a degraded reload is reported as success" / "is never retried") could not be
  executed here: this dev host has no systemd, so `LINUX_SYSTEMD` gates T5/T6
  off exactly as the pre-existing WP-098 tests already do on this same host.
  I ran the mutations anyway and confirmed the tests are *skipped* (not
  silently green) under them, then reasoned through the two mutations by
  inspection against the D4 diff — both are simple, direct reversions of the
  hoist (`loaded = enableOk` / reload back inside `if (changed)`), and the
  pattern is identical in shape to the pre-existing WP-098 secondary-call tests
  that already exercise the same code path with the same gate.
- **Three fixture bugs found and fixed during the mutation pass** (not spec
  bugs — my own test-construction errors, caught by the mutation pass doing
  its job): (1) `buildPrintStdout`'s `malformedArgs`/`malformedEnv` left later
  blocks in the synthetic stdout, so the naive (no-depth-tracking) parsers
  picked up a *later* block's closing brace instead of genuinely failing to
  parse — fixed by truncating the stdout entirely at the unclosed block; (2)
  T3 case (iv) used a bare `{status:113}` with no stdout, so it could never
  actually exercise the `isLoaded` guard (gate 1) — added a stdout that WOULD
  look like a match if evaluated as text; (3) T3 case (xiii) tested full key
  *omission*, which doesn't touch the "drop valueless lines" parser defect at
  all (there's no valueless line to drop) — added a paired subtest using the
  full healthy record (which DOES carry five `KEY =>` empty-value lines) to
  pin that specific defect. See the second commit's message for detail.
- **Real host quirks absorbed via a stateful `fakeLaunchd` test double, not
  fixed at the source.** Many pre-existing darwin-path tests (10 of them, none
  in AC6's four) used a blind `() => ({status:0})` loader that never answered
  `print` with matching stdout — under ADR-0037 this correctly makes
  `ensureDarwinEntryRegistered` return `loaded:false`, breaking those tests'
  *setup* steps (not their assertions). I added a small stateful fake launchd
  (`fakeLaunchd`) that tracks which labels are "loaded" and reports back
  exactly what's on disk at the moment of the last successful bootstrap for
  that label, and swapped it in for those setup loaders. No `assert.*` line in
  any of those 10 tests changed except the ONE (`repointSchedules after add is
  a no-op`) whose own assertion was genuinely about call count and had to
  change with it — recorded below since it's not one of AC6's four but is the
  same necessary consequence AC5(iii) already states for the `:389-397` test.

## Discovered issues (out of scope, not fixed)

- **`tests/unit/init.test.js`'s `init --fresh-vault schedules the nightly
  dream and surfaces it (ADR-0014)` test now fails**, and is NOT a spec
  deliverable so I did not touch it or `src/scheduler/spawn.js`. Root cause:
  that test (and ~15 other test files across the suite — grep
  `WIENERDOG_LOADER_NOOP` outside this WP's deliverables) sets
  `WIENERDOG_LOADER_NOOP=1` to neutralize the real scheduler for a REAL
  subprocess run of `bin/wienerdog.js`. `schedulerSpawn`'s NOOP branch (
  `src/scheduler/spawn.js:25`) returns a blind `{status:0}` for every call,
  including `launchctl print`, with no `stdout`. ADR-0037's postcondition
  requires a live readback that actually MATCHES canonical before reporting
  success; a blind `{status:0}` with no stdout can never produce a `'match'`
  verdict, so the darwin per-job register now correctly reports `loaded:
  false` under NOOP, and `init --fresh-vault`'s summary prints the "did not
  accept it yet" notice instead of "catches up automatically". This is an
  inherent, unavoidable consequence of implementing the postcondition
  correctly intersecting with a pre-existing test convenience whose semantics
  ("pretend every OS call succeeded") is incompatible with "prove it via a
  live readback that reflects reality." I verified this is the ONLY test
  affected by running the full `npm test` (1897 tests, 1 failure). Fixing it
  needs either extending `WIENERDOG_LOADER_NOOP`'s semantics in `spawn.js` (a
  non-deliverable) or updating `init.test.js`'s assertion (also a
  non-deliverable) — both out of this WP's Deliverables table. Flagging for
  the architect/owner to route as a follow-up.
- **`repointSchedules after add is a no-op` test's own assertion changed**
  (not one of AC6's four, but the same necessary consequence AC5(iii) already
  states for `:389-397`): `assert.equal(calls.length, 0, 'no OS reload on an
  unchanged repoint')` → `2` (one read-only `print` per darwin site — job +
  catch-up), since Table A's verified-skip now costs a readback even when
  nothing changed. Renamed the test title from "no OS call" to "no MUTATING OS
  call" to match, mirroring AC6 item 4's own rename of the sibling
  `:389-397` test. I did not find any other assertion outside AC6's four that
  needed changing (full diff read to confirm).

---
Generated-by: claude-sonnet-5

## Lessons

- WP-scheduler-register-replaces-loaded-record: `WIENERDOG_LOADER_NOOP` (used
  by ~15 test files across the suite to neutralize the real OS scheduler for
  subprocess-driven CLI tests) is fundamentally incompatible with any
  ADR-0037-style live-readback postcondition — it answers every spawn with a
  blind `{status:0}`, never a matching `stdout`. Any future WP touching
  register-path verification should budget for this collision up front rather
  than discovering it at `npm test` time.
- WP-scheduler-register-replaces-loaded-record: when a spec's own worked test
  fixtures use a "malformed" flag to simulate an unclosed block (e.g. `arguments
  = {` never closed), a parser without depth-tracking will happily swallow a
  LATER block's closing brace as if it were the missing one — a synthetic
  fixture must TRUNCATE the stdout entirely at the malformed point, not just
  leave the block open while continuing to emit more text after it.
- WP-scheduler-register-replaces-loaded-record: AC6's "exactly four existing
  assertions change" underclaimed by one — `repointSchedules after add is a
  no-op`'s own `calls.length` assertion is a second, structurally identical
  casualty of the same Table A behavior change (a verified skip now costs a
  readback even when unchanged) that AC5(iii) already documents for the
  `:389-397` sibling test. Worth a spec pass to enumerate it explicitly next
  time this chain gets revised.
- WP-scheduler-register-replaces-loaded-record: a scripted mutation-testing
  harness (apply one exact-text patch, run the named test via
  `--test-name-pattern`, assert red, `git checkout --` to revert) made
  demonstrating ~40 Table B rows tractable in one session, and caught three
  real fixture bugs of my own that a purely manual "looks right" read would
  have missed — recommend this pattern for future WPs with large mutation
  matrices.


---

## Post-open spec amendment — D6/T8 (2026-08-02, commit `d8882fa`)

The discovered `WIENERDOG_LOADER_NOOP` collision above was routed to
wd-architect and resolved on this branch as a **spec-boundary amendment**
(the spec's Deliverables table omitted a file the change necessarily
breaks — a spec bug, not implementer scope creep):

- **Decision: fix the assertion (option a), never the seam.** Teaching NOOP
  to fabricate a canonical-matching `launchctl print` would forge the exact
  evidence ADR-0037's postcondition exists to require, and would make the
  postcondition untestable-by-construction on every NOOP path. NOOP already
  means "you learn nothing" (`defaultProbe === 'unknown'` is already pinned
  under it); `src/scheduler/spawn.js` is added to the not-deliverables list
  as the rejected alternative.
- The NOOP outcome is **platform-split** (darwin `loaded:false` — the
  readback runs and can only be `'indeterminate'`; linux/win32 `loaded:true`
  — no readback on those paths), so `tests/unit/init.test.js` now branches
  on `process.platform`, and the darwin leg asserts the NEGATIVE
  (`doesNotMatch(/catches up automatically/i)`) as a permanent tripwire
  against option (b).
- Spec amended at six coordinated sites (Deliverables D6 row, Sizing,
  not-deliverables, Mirrored Surface Checklist, Implementation notes → D6,
  AC12 + T8 + V8).

Post-amendment verification: `npm test` **1897 tests, 1888 pass, 0 fail,
9 skipped** (was 1 fail); `npm run lint` passed; `scripts/boundary-check.js`
exit 0; V8 greps green.

Discovered (pre-existing, not fixed): the spec's Deliverables preamble still
says "one new Proposed ADR" though ADR-0037 has been Accepted/owner-signed
since 2026-07-28 — staleness predating this PR, flagged for a future
architect sweep.

---

## Codex adversarial gate (2026-08-02, branch @ `d8882fa`, base `origin/main`)

Verdict: **needs-attention**, two findings — both adjudicated against the
spec and dispositioned by the orchestrator (citations spot-checked in the
tree):

1. **[high] "Failed `daemon-reload` still activates potentially stale units"
   (linux arm).** DISPOSITION: **spec-mandated, equal-or-stronger than
   base.** Table A row 3 ratifies exactly this shape ("reload, its warning
   and `enable --now` all run on every register… no skip predicate on this
   leg"; `loaded = reloadOk && enableOk`). On shipped 0.12.0 the changed
   path ran the same `enable --now` after a failed reload AND reported
   `loaded:true`; the branch keeps the call sequence and makes the verdict
   honest + retried/warned on every register. The stale-activation hazard is
   the spec's recorded §5 stale-but-running case, now loud. Codex's
   alternative (gate activation on `reloadOk`) is a design change to a
   settled contract — noted for a possible future hardening WP, not applied.
2. **[medium] "Catch-up verification omits RunAtLoad → false verified skip."**
   DISPOSITION: **declared, owner-ratified residual.** Verbatim the spec's
   Table A2 RunAtLoad row (bounded exposure stated in the same words),
   routed to `WP-launchd-runatload-readback`, carried into ADR-0037's
   ratification surface and owner-signed 2026-07-28. Codex's suggested
   indeterminate-on-catch-up was implicitly rejected by the spec's
   no-unexecutable-parsers rule.

No code change required by this gate. wd-reviewer leg: see below.

---

## AC10 completion — linux Table B rows demonstrated red on CI (2026-08-02)

The authoring host has no systemd, so the two linux mutation rows were
demonstrated on CI `ubuntu-latest` via scratch draft PRs (now closed,
branches deleted):

- **"a degraded linux reload is reported as success"** (patch:
  `loaded = enableOk`) — demo PR #141, commit `9a1d0d0`:
  `test (ubuntu-latest)` FAILED with
  `not ok 1574 - verified-register: T5 — linux degraded reload ⇒
  loaded:false + notice…` and `not ok 1575 - …{status:null}…`.
  Run: https://github.com/wienerdog-ai/wienerdog/actions/runs/30748267955/job/91497567031
- **"a degraded linux reload is never retried"** (patch: reload block
  re-gated on `changed`) — demo PR #142, commit `f6d87ef`:
  `test (ubuntu-latest)` FAILED with
  `not ok 1576 - verified-register: T6 — linux unchanged bytes still
  reload + enable, exactly two calls`.
  Run: https://github.com/wienerdog-ai/wienerdog/actions/runs/30748268875/job/91497569668

Collateral reds in each run (pre-existing reload-warn tests, the
no-MUTATING-call tests, linux T7) are consistent with each mutation's blast
radius; the NAMED test went red in both, which is what DoD item 2 requires.
`test (macos-latest)` stayed green in both runs (the linux rows skip there),
confirming the mutations were detected only by their designated detectors.

---

## Gate record — COMPLETE (2026-08-02)

**wd-reviewer round 1: REQUEST-CHANGES.** Code contracts verified faithful
(exact-contracts body line-for-line, tiered verdict, both parsers, four
spot-checked Table B rows genuinely red). Blockers: (1) five §8-notice ACs
asserted by zero new tests; (2) V5/V6b greps false-positived on
spec-mandated JSDoc; (3) AC6's "exactly four" understated the forced
NOOP-collision fallout. Non-blocking: (4) two linux Table B rows not
demonstrated red; (5) a benign-tier fixture comment said env/fatal.

**Remediation:** `56ee4d0` (wd-architect) — V5/V6b narrowed to functional
references; new canonical **Table E** (assertion blast-radius + exhaustive
fakeLaunchd-swap authorization, re-derived from the real diff); new
canonical **Table N** (ruling: all five §8 ACs KEPT; notice assertions
mandated at exactly two sites; rollback fixtures exempt as an argued
disposition; new V9 pin). `456c88b` — clean merge of main (#139 docs only).
`7da6be7` (implementer) — the two mandated repointSchedules-driven notice
assertions + the comment fix. Finding 4 closed by the orchestrator via the
CI mutation demonstrations recorded above.

**wd-reviewer round 2 @ `7da6be7`: APPROVE.** All five findings discharged;
the new T3(xxii) notice assertion mutation-verified live (push site patched
to `if (false)` → red, restored → green); Table E verified against the real
diff line-for-line including the stays-unchanged list; Table N's sole-push-
site audit confirmed; V1–V9 all green as written; full `npm test` 1897/1888
pass/0 fail; CI green on ubuntu-latest AND macos-latest at `7da6be7` with
the linux T5/T6/T7 executed (ok 1574-1578), not skipped; the 456c88b merge
content-clean; no owner markers. Both Codex dispositions independently
confirmed sound. Two cosmetic accuracy notes (Table E's partial list
presented as exhaustive; Table N's ensureCatchup→repairCatchup attribution)
folded in as **`b8f9e9b`** (spec-only, reviewer-prescribed remedies, lint
green; Table E's site accounting is now self-checking: 14 swapped + 35
unchanged = 49 grep-counted occurrences).

**Double gate complete. Merge-ready, pending owner authorization.**
