### PR TITLE
docs(specs): flip WP-scheduler-register-replaces-loaded-record to Done (post-merge housekeeping)

### DIFF
--- a/docs/specs/done/WP-scheduler-register-replaces-loaded-record.md
+++ b/docs/specs/done/WP-scheduler-register-replaces-loaded-record.md
@@ -1,7 +1,7 @@
 ---
 id: WP-scheduler-register-replaces-loaded-record
 title: A register that cannot verify what the OS now holds must not report success
-status: In-Review
+status: Done
 model: sonnet
 size: M
 depends_on: []


### PR DESCRIPTION
One-file post-merge housekeeping: PR #140 merged as `7b22d71` and verified (full suite on main: 1888 pass / 0 fail), so the spec flips `In-Review` → `Done` and moves to `docs/specs/done/`. Lint + frontmatter green.

This satisfies the second dispatch gate of `WP-scheduler-node-path-durability` (sibling now Done; the ADR-0028 signature gate was discharged in PR #138). Its dispatch remains a separate owner queue decision.

---
Generated-by: Claude Fable 5 (claude-fable-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THDN8Y8Syk7Lft4GDpBBhP