### PR TITLE
fix(scheduler): register entries against an upgrade-durable node path (WP-scheduler-node-path-durability)

### DIFF
--- a/docs/specs/WP-scheduler-node-path-durability.md
+++ b/docs/specs/WP-scheduler-node-path-durability.md
@@ -508,10 +508,11 @@ history of the branch that did not occur. Definition of done item 9 is now a
 
 **Sizing (recorded, not left implicit).** One new pure function plus its export in
 `generators.js`; six one-token call-site swaps in `schedule.js`; one test file
-extended. No renderer, no descriptor, no ADR, no glossary, no runbook. **M** — one
-session. It is not split further: the function and its six call sites are
-meaningless apart, and splitting them would ship an exported function nothing
-calls.
+extended; **plus seven one-token oracle swaps across two further test files
+(D3/D4, the 2026-08-02 boundary amendment below)**. No renderer, no descriptor, no
+ADR, no glossary, no runbook. **M** — one session. It is not split further: the
+function and its six call sites are meaningless apart, and splitting them would
+ship an exported function nothing calls.
 
 **Re-confirmed 2026-08-02 against `1093e51` (PR #140).** The sizing is
 **unchanged**: still six sites, still one-token swaps, still no new file. PR #140
@@ -525,6 +526,8 @@ adds the D2 consistency rule rather than a new deliverable.
 | modify | src/scheduler/generators.js | **D1** — add `entryNodePath(execPath?, opts?)` per Table A and export it. `nodePath()` keeps its body **byte-for-byte** (Table A row 6, Table B row 2). No renderer, no other function. |
 | modify | src/cli/schedule.js | **D2** — replace `gen.nodePath()` with `gen.entryNodePath()` at exactly the six ENTRY sites, **re-anchored to `1093e51`: `:477`, `:536`, `:611`, `:856`, `:885`, `:970`** (Current state §2; `5f0ffc0`'s `:303 :342 :417 :638 :667 :752` are dead line numbers — do not use them). Nothing else in this file changes: **no change to `ensureDarwinEntryRegistered`, `darwinLoadedVerdict`, `darwinReplaceEntry`, the `plutil` preflight, the linux `reloadOk`/`enableOk` gate**, no probe change, no notice change. |
 | modify | tests/unit/scheduler-generators.test.js | **T1, T2, T4 and T5** — the exact set in the Test index. **There is no T3** (round 1's descriptor-digest test was vacuous and is deleted — see AC5), and **T5 is not optional**: it is the ONLY detector for Table E row 7, the role split. Building T1/T2/T4 without T5 reproduces the round-1 test set that shipped an undetectable mutation. The existing test at `:421` (`nodePath/wienerdogBin are absolute`) must pass **unmodified** — and note it does **not** protect the role split, which is exactly why T5 exists. |
+| modify | tests/unit/scheduler-schedule.test.js | **D3 / T6 — architect boundary amendment, 2026-08-02.** Exactly the **six** oracle sites **Table H** rows 1-6 enumerate, and nothing else: `gen.nodePath()` → `gen.entryNodePath()` at each, plus the one added `//` comment line per site. **Table H is the authority — this cell carries no site list of its own.** No new test, no deleted test, no renamed subtest, no helper signature change, no `fakeLaunchd`/`buildPrintStdout`/`printStdoutFromPlistXml` change, and **no change to any of the seven `process.execPath` occurrences** (RUNTIME role — Table B row 2). The collision was discovered at `npm test` time on the authoring host, not at spec time; the full record, the decision and the rejected alternatives are in Implementation notes → **D3/D4**. |
+| modify | tests/unit/sync-repoint.test.js | **D4 / T7 — architect boundary amendment, 2026-08-02.** Exactly the **one** oracle site **Table H** row 7 enumerates, plus its added `//` comment line. Nothing else in this file: no other test, no `primaryEntry`/`runSync` helper change, no fixture change, no `oldNode` change. Same record as D3. |
 
 Not deliverables, deliberately: `src/scheduler/descriptor.js`,
 `src/scheduler/status.js`, `src/scheduler/launcher.js`, `src/cli/run-job.js`,
@@ -532,10 +535,33 @@ Not deliverables, deliberately: `src/scheduler/descriptor.js`,
 `docs/adr/0028-scheduler-app-executable-integrity.md`,
 `docs/adr/0018-windows-scheduled-dreaming.md`,
 `docs/runbooks/scheduler-and-executable-integrity.md`,
-`tests/unit/scheduler-schedule.test.js`, `tests/unit/sync-repoint.test.js`,
-`tests/unit/descriptor.test.js`. Several of those contain assertions that must
-pass **unmodified** — that is this WP's proof that nothing else moved. See "Out of
-scope" for why each is untouched.
+`tests/unit/descriptor.test.js`, and — **added 2026-08-02 with the D3/D4
+amendment, because promoting two scheduler test files must not read as promoting
+all of them** — `tests/unit/scheduler-entry-identity.test.js`, whose shipped test
+`entry-identity: a systemd entry yields unknown, not a health claim` (`:423-430`)
+Table C's row-6 note relies on being unchanged.
+*(Removed from this list on the same date, into the Deliverables table above:
+`tests/unit/scheduler-schedule.test.js` and `tests/unit/sync-repoint.test.js` —
+Table H, Implementation notes → D3/D4.)*
+
+**What the untouched-assertions proof now claims — RESTATED 2026-08-02, and
+NARROWED.** This paragraph used to end: *"Several of those contain assertions that
+must pass **unmodified** — that is this WP's proof that nothing else moved",* with
+`tests/unit/scheduler-schedule.test.js` and `tests/unit/sync-repoint.test.js` named
+in the list above it. **That claim was host-shape-dependent and is withdrawn**
+(Implementation notes → D3/D4). The honest replacement, which is what AC10 and
+V8/V8b assert:
+
+> Every file still listed above contains assertions that must pass
+> **unmodified** — and in the two files promoted to Deliverables, **no assertion
+> changes at all: the only edits are the seven oracle-expression swaps Table H
+> enumerates.** The proof narrows from *"nothing else moved"* to
+> **"nothing moved beyond the enumerated oracle swaps"**, and that narrower claim
+> is now **mechanically checkable** (V8b: every `+`/`-` line in those two files
+> either contains a `nodePath` token or is an added comment) rather than resting
+> on the files' absence from this table.
+
+See "Out of scope" for why each remaining file is untouched.
 
 ### Exact contracts
 
@@ -614,10 +640,11 @@ surface and one of two now-distinct node-path roles is re-pointed at it;
 decide whether the alias or `execPath` wins, and the fail-safe direction must be
 identical in all **five** failure conditions; (vii) the same rule is restated
 across Deliverables cells, acceptance criteria, verification greps, Current-state
-and the operative prose. **Six canonical tables** below (A: the return rule; B:
+and the operative prose. **Seven canonical tables** below (A: the return rule; B:
 the role split; C: post-`sync` convergence; D: what `sync` reports; F: the fixture
-arithmetic; **G (added 2026-08-02): the macOS readback-echo premise**); every
-mirror is registered under them.
+arithmetic; **G (added 2026-08-02): the macOS readback-echo premise**; **H (added
+2026-08-02): the authorized test-oracle sites**); every mirror is registered under
+them.
 
 Round 1 shipped only A and B, and the review found the consequences in exactly the
 places the missing tables would have covered: the convergence limitation lived in
@@ -773,7 +800,7 @@ shipped two that were not, and AC9 copies this table into the merge artifact).
 The **OS calls** column below is scoped to the **per-job helper**
 (`ensureDarwinEntryRegistered`, one invocation), **not** to a whole `sync` run.
 That is deliberate, and it follows the landed sibling's own canonical rule
-(`docs/specs/done/WP-scheduler-register-replaces-loaded-record.md:1881-1883`),
+(`docs/specs/done/WP-scheduler-register-replaces-loaded-record.md:1880-1883`),
 quoted verbatim:
 
 > *"A full darwin `registerPlatform` on an unchanged healthy install therefore
@@ -876,9 +903,96 @@ falsified it. A fake cannot test an assumption about the real system it stands i
 for. **P is now known true from the real system, not from the fake** — cite
 Current state §9 in the PR, never the suite.
 
+### Table H — the authorized test-oracle sites (canonical; NEW 2026-08-02)
+
+**Why this table exists.** `tests/unit/scheduler-schedule.test.js` and
+`tests/unit/sync-repoint.test.js` were on this spec's **not-deliverables** list,
+whose stated role was *"assertions that must pass unmodified — the proof nothing
+else moved"*. With D1/D2 implemented, **15 of their tests fail on a Homebrew macOS
+host and pass on a CI runner**, because seven expressions in them use
+`gen.nodePath()` as the oracle for *what a freshly-written entry embeds* — and that
+is now `gen.entryNodePath()`. The boundary did not anticipate it; the amendment is
+recorded in Implementation notes → **D3/D4**. This table is the **bounded
+enumeration** that replaces the withdrawn blanket claim.
+
+**How to read it.** Every authorized site is a row. **Every row is one expression
+swap — `gen.nodePath()` → `gen.entryNodePath()` — plus at most one added `//`
+comment line above it.** Nothing else in either file changes: no assertion text, no
+expected value, no test name, no helper signature, no fixture, no
+`fakeLaunchd` / `buildPrintStdout` / `printStdoutFromPlistXml` change, and none of
+the **seven `process.execPath` occurrences** in `scheduler-schedule.test.js`
+(`:398`, `:422`, `:460`, `:633`, `:769`, `:808`, `:1148` — RUNTIME-role argv for a
+spawned test child, Table B row 2). **A site not in this table is out of the
+permission boundary**, exactly as with Table E. V8 and V8b make both halves
+mechanical.
+
+`main` line numbers are `origin/main` @ `179173b`; `branch` line numbers are this
+branch after the swap (they shift by the added comment lines, and are given so a
+reader can find the site — they are not the contract; the expression and its role
+are).
+
+| # | File | `main` | branch | The expression | Its role — what the test uses it for | Class | Red on the authoring host? |
+|---|------|--------|--------|----------------|--------------------------------------|-------|----------------------------|
+| 1 | `tests/unit/scheduler-schedule.test.js` | `:1254` | `:1255` | `const stableNode = gen.nodePath();` | In `scheduler-schedule: repointSchedules rewrites a stale embedded node path (changed:1)` — the string **split out of the freshly-registered plist** to seed a stale entry, then asserted back in after repoint (`entry now targets the current node`) | **(a)** | **YES** — 1 test |
+| 2 | `tests/unit/scheduler-schedule.test.js` | `:1547` | `:1550` | `darwinJobExpect`'s `const node = gen.nodePath();` | Builds `expect.argv[0]` for the per-job darwin readback. Its JSDoc contract is *"Compute the SAME `expect`-shape values `registerPlatformEntries`'s darwin arm derives"* — and that arm now derives the durable alias | **(a)** | **YES** — feeds all 45 `verified-register:` tests |
+| 3 | `tests/unit/scheduler-schedule.test.js` | `:1569` | `:1573` | `darwinCatchupExpect`'s `const node = gen.nodePath();` | The catch-up analogue of row 2 (`ensureCatchup`'s `expect.argv[0]`) | **(a)** | **YES** |
+| 4 | `tests/unit/scheduler-schedule.test.js` | `:1592` | `:1597` | `canonicalJobPlistContent`'s `const node = gen.nodePath();` | Renders *"the exact plist bytes `registerPlatformEntries`'s darwin arm renders"*, so a test can pre-plant a `changed:false` fixture. On the pinned path those bytes are no longer canonical, `ensureEntry` reports `changed:true`, and the fixture stops being the thing under test | **(a)** | **YES** |
+| 5 | `tests/unit/scheduler-schedule.test.js` | `:2070` | `:2075` | T3 case (xi)'s inline `node: gen.nodePath(),` inside `gen.catchupPlist({…})` | Row 4's job for the catch-up entry, written inline rather than through the helper | **(a)** | **YES** |
+| 6 | `tests/unit/scheduler-schedule.test.js` | `:2090` | `:2095` | T3 case (xii)'s inline `node: gen.nodePath(),` inside `gen.catchupPlist({…})` | Same as row 5, for the `Hour => 0` sibling case | **(a)** | **NO — green, and repaired anyway.** Its expectation is `attempt`, so a stale node merely supplies a *second* reason to attempt: the test stays green **for the wrong reason** and no longer isolates the `Hour`-key rule its name claims to pin. A silently-weakened test is the same defect class as a red one, and leaving row 6 out would make the "every `gen.nodePath()` in these two files" boundary a rule with one unexplained exception |
+| 7 | `tests/unit/sync-repoint.test.js` | `:150` | `:151` | `const stableNode = gen.nodePath();` | In `sync-repoint: rewrites a stale scheduler entry to the vendored bin, then is idempotent` — asserted **present** in the post-`sync` entry (`entry now targets the current node`) after a REAL `sync.run` | **(a)** | **YES** — 1 test |
+
+**Rows 1-6 account for 14 of the failures, row 7 for the 15th.** Rows 2-4 are the
+multiplier: 13 of the 45 `verified-register:` tests are the ones where the node
+divergence flips a verdict (`'match'` → `'mismatch-fatal'`, or `changed:false` →
+`changed:true`). The other 32 already asserted an `attempt`/mismatch outcome that
+the extra divergence does not change — which is why the collision presents as 13
+reds rather than 45.
+
+**Oracle classes considered, and why every site is (a).**
+
+| Class | What it would mean | Verdict |
+|-------|--------------------|---------|
+| **(a) `gen.entryNodePath()`** — the value the renderer now embeds | The oracle names the **contract** (Table B row 1: the ENTRY role's value) rather than reading the implementation's output | **CHOSEN for all seven.** It sits at exactly the same distance from the assertion that `gen.nodePath()` sat at **before** this WP: a pure generator function, called by the test, compared against what `schedule.js` and the register machinery produced. No detection power is lost |
+| **(b)** a value **derived from the rendered output itself** — parse the plist the test just wrote and take `ProgramArguments[0]` | The oracle is read out of the artifact under test | **REJECTED — it destroys the assertion.** For rows 2-4 the entire point of `expect` is to be computed **independently** of the bytes `registerPlatform` writes; deriving it from those bytes makes the FATAL-tier argv comparison self-satisfying and silently deletes T3's whole mismatch matrix. For rows 1 and 7 the assertion *is* "the file now contains the right node path", so an oracle read from that same file is vacuously true |
+| **(c)** something else — a literal, a host probe, a platform branch | e.g. hardcode `/opt/homebrew/opt/node/bin/node`, or branch on `fs.existsSync('/opt/homebrew')` | **REJECTED.** A literal is wrong on every non-Homebrew host and on any other `brew` prefix; a host probe re-introduces precisely the host-shape dependence this amendment exists to remove, and would itself need tests |
+
+**Why (a) is not tautological — stated precisely, because it is the obvious
+objection.** The code under test at these seven sites is `src/cli/schedule.js`'s
+**call site** plus the register machinery around it — **not** `entryNodePath`
+itself, which has its own seam-free detector (T5, Table E row 7) and its own
+twelve-fixture negative sweep (T2). After the swap these tests still go red if
+`schedule.js` stops calling `entryNodePath` at an entry site, if a renderer stops
+interpolating `o.node`, if `expect` and the renderer are built from **different**
+values (Implementation notes §D2's "do not helpfully split them"), or if
+`darwinLoadedVerdict` mis-tiers `program` / `argv[0]`. **Detection power strictly
+increases:** on a Homebrew host, Table E row 8's mutation (revert
+`schedule.js:611` to `gen.nodePath()`) now turns rows 2-4's dependents red **as
+well as** flipping V3's counts, where before the amendment it was judged by reading
+V3's counts alone.
+
+**Consistency with the sibling's `fakeLaunchd` readback — checked, not assumed.**
+`fakeLaunchd` stores the plist bytes at `bootstrap` and answers `print` through
+`printStdoutFromPlistXml`, which renders `program: argv[0] || ''` from those very
+bytes (`tests/unit/scheduler-schedule.test.js:241` — unchanged by this amendment).
+It therefore echoes **whatever the renderer wrote**, so every `fakeLaunchd`-driven
+test is host-shape-independent by construction and needs no site here. The tests
+that needed one are exactly those using `scriptedDarwinLoader` with an `expect`
+built by rows 2-4, where `matchingStdout(expect)` sets
+`program: expect.argv[0]` — so the readback follows row 2/3's value automatically
+and stays consistent with the chosen oracle. **No loader, no double and no stdout
+builder is edited.**
+
+**On a host where `entryNodePath() === nodePath()` the swap is a literal no-op.**
+That is the property that makes it correct rather than merely convenient: on the CI
+runners (`setup-node`; no Homebrew alias resolving to `execPath`) these seven
+expressions evaluate to the same string before and after, so this amendment cannot
+change CI's verdict in either direction. What it removes is the **asymmetry** — a
+proof mechanism that was green on the runners and red on the exact machine class
+this WP was written to protect.
+
 ### Mirrored Surface Checklist
 
-Tables A, B, C, D, F **and G** are the single place these facts are decided. Every
+Tables A, B, C, D, F, G **and H** are the single place these facts are decided. Every
 surface in this spec that restates them is registered below, so one review finding
 updates the table **and** all its mirrors in one pass, and any new mirror found in
 review is added here on the spot. **The five entries marked (+r2) were
@@ -892,12 +1006,26 @@ sibling's landing cannot leave a stale mirror behind. **`(+r5)` entries carrying
 line number are mirrors of Current state's re-anchoring, not of a rule** — they
 move whenever `schedule.js` moves, which is why they are registered.
 
+**(+r7, 2026-08-02) — the mirrors the D3/D4 boundary amendment created or
+invalidated.** Promoting `tests/unit/scheduler-schedule.test.js` and
+`tests/unit/sync-repoint.test.js` from not-deliverables to Deliverables added
+**Table H** and **falsified one existing mirror outright** — the not-deliverables
+paragraph's *"proof nothing else moved"* role. Every surface that restates the
+seven-site enumeration, the two new Deliverables cells, or the narrowed proof
+statement is registered below with a `(+r7)` marker, in the same pass, so the
+amendment cannot leave a stale mirror behind. **The remedial-extraction rule was
+applied, not skipped:** the contract that had leaked into the not-deliverables
+prose is now decided in exactly one place (Table H), and every mirror below defers
+to it.
+
 In this spec:
 
 - [ ] Deliverables cell for `src/scheduler/generators.js` (D1 — "per Table A", `nodePath()` byte-for-byte)
 - [ ] Deliverables cell for `src/cli/schedule.js` (D2 — the six site list, Table B row 1)
 - [ ] **(+r3)** Deliverables cell for `tests/unit/scheduler-generators.test.js` — it mirrors the **Test index** row set (T1/T2/T4/T5) and the "no T3" fact. **This is the mirror whose absence caused a round-2 defect**: the T3→T5 renumbering updated five registered surfaces and missed this unregistered one, leaving the permission-boundary table telling the implementer to build the round-1-failing test set. Registered so the Test index and this cell can never diverge again.
-- [ ] **(+r2)** Deliverables → the **Sizing** paragraph (it restates Table B row 1's "six call sites" count)
+- [ ] **(+r7)** Deliverables cells for `tests/unit/scheduler-schedule.test.js` (**D3 / T6**) and `tests/unit/sync-repoint.test.js` (**D4 / T7**) — both mirror **Table H**'s row set and its "one expression swap plus at most one comment line" rule. **Neither cell carries a site list of its own**, deliberately: the sibling's D6 amendment showed that a Deliverables cell restating an enumeration is exactly the mirror that goes stale (`done/WP-scheduler-register-replaces-loaded-record.md:368` says the same of its Table E). Table H is the authority
+- [ ] **(+r7)** Deliverables → the **not-deliverables paragraph's proof-role statement**. This is the mirror the amendment **falsified**: it claimed the two files' unmodified assertions were *"this WP's proof that nothing else moved"*, which stopped being true the moment D1/D2 landed on a Homebrew host. The withdrawn sentence is quoted in place and replaced by the narrowed claim — *no assertion changes beyond the enumerated oracle swaps* — which **AC10** asserts and **V8/V8b** make mechanical. **The three must never disagree about the scope of the claim**
+- [ ] **(+r2, +r7)** Deliverables → the **Sizing** paragraph (it restates Table B row 1's "six call sites" count, **and now Table H's seven-site count**)
 - [ ] "Exact contracts" JSDoc block, its default-parameter note (Table A row 1) and its input → output pairs (Table F)
 - [ ] "Exact contracts" literal `.plist` fragment (the `--expect-digest`-unchanged claim, Table A row 6)
 - [ ] Current state §2 (the ENTRY/RUNTIME site classification — Table B) — **(+r5)** and its NEW hoisted-`const node` sub-table, which is the mirror of Implementation notes §D2's dual-consumer rule
@@ -905,19 +1033,25 @@ In this spec:
 - [ ] **(+r5)** Current state §8 — **REWRITTEN against `ensureDarwinEntryRegistered`**; it is the mechanism behind Tables C and D and must be re-read whenever either moves. Its `5f0ffc0` text is retained in a quote block, not deleted
 - [ ] **(+r5)** Current state §9 — **the executed record of the scratch-label experiment that settled Table G's premise (P is TRUE, 2026-08-02)**. Table G decides; §9 records what was run, by whom, and the teardown. **Registered because Table G's Status row and §9 must move together**: if the premise is ever re-opened (a launchd behavior change), both flip, plus every mirror below
 - [ ] **(+r5, updated 2026-08-02)** **AC6**'s non-claim bullet — it cited Table G's premise as unverified and now must not; and the **Convergence** section heading paragraph, which states the premise's settled status
-- [ ] **(+r6, 2026-08-02, from the light gate)** **Table D's OS-call lists** — D-a's call-count scoping paragraph, D-a's steady-state cell, D-c's `plutil` cell, Table D's RECONCILED preamble bullet ("a later `sync` makes two read-only `print`s"), **Table G's "If P is TRUE" row**, and **AC9's reproduction requirement**. All six state the same two facts — *the `plutil` preflight (`:201-203`) runs before the teardown guard (`:208`)*, and *a full darwin `sync` issues **two** read-only `print`s, one per helper*. Registered because the gate found **two** of them wrong while the others were right: a call list is a contract here, since AC9 makes the implementer copy it into the merge artifact verbatim. The full-path count is the **landed sibling's** canonical property (`done/WP-scheduler-register-replaces-loaded-record.md:1881-1883`) — derive from it, never restate it independently
+- [ ] **(+r6, 2026-08-02, from the light gate)** **Table D's OS-call lists** — D-a's call-count scoping paragraph, D-a's steady-state cell, D-c's `plutil` cell, Table D's RECONCILED preamble bullet ("a later `sync` makes two read-only `print`s"), **Table G's "If P is TRUE" row**, and **AC9's reproduction requirement**. All six state the same two facts — *the `plutil` preflight (`:201-203`) runs before the teardown guard (`:208`)*, and *a full darwin `sync` issues **two** read-only `print`s, one per helper*. Registered because the gate found **two** of them wrong while the others were right: a call list is a contract here, since AC9 makes the implementer copy it into the merge artifact verbatim. The full-path count is the **landed sibling's** canonical property (`done/WP-scheduler-register-replaces-loaded-record.md:1880-1883`) — derive from it, never restate it independently
 - [ ] **(+r5)** Table C's reconciliation preamble (the row-4 / row-5 verdict-change table) and Table D's reconciliation preamble — these are the dated records of the two settled rows that changed outcome; neither may be silently folded into the tables they precede
 - [ ] Implementation notes §D1 (the derivation, the `parts.length < 6` spelling of row 2, the anti-`indexOf` rule from Table E row 4), §"Why the descriptor field stays" (row 6), §"Windows" (row 1), §"Convergence — governed by Table C" (which now cites C and D instead of restating them)
 - [ ] Design space → option (a) (the alias mechanism is rows 5–6)
 - [ ] Security checklist bullets 1 and 2 (rows 3, 4 and 5 — which of them is the security boundary)
 - [ ] Acceptance criteria AC1 (rows 5–6), AC2 (rows 1–4 via Table F), AC3 (Table B row 1), AC4 (Table B row 2 **and**, as the spec's only seam-free assertion of them, Table A rows 5-6), AC5 (Table A row 6), AC6 (idempotence, and its explicit non-claim about Tables C/D), AC9 (Tables C and D reproduced in the PR) — **(+r5)** AC9 now also mirrors Table C row 5's flipped verdict, Table D's discharged false-success finding and **Table G**'s premise — **which is SETTLED TRUE as of 2026-08-02, so AC9 sub-item (iv) reports it as executed, never as unverified**
-- [ ] Verification commands V3 (Table B row 1 count), V4 (Table B row 2 preservation), V5 + V5b (Table A row 6 preservation and AC5's zero-coupling argument)
+- [ ] **(+r7)** **AC10** (Table H's seven sites, the narrowed proof statement) and **Table H itself** — AC10 is the criterion, Table H the enumeration. AC10 states no site list; it points at the table
+- [ ] Verification commands V3 (Table B row 1 count), V4 (Table B row 2 preservation), V5 + V5b (Table A row 6 preservation and AC5's zero-coupling argument) — **(+r7)** and **V5's expected file list**, which is a mirror of the Deliverables row count and moved from **three files** to **five** when D3/D4 landed
+- [ ] **(+r7)** Verification commands **V8** (Table H's four `main`-vs-branch counts, plus the `process.execPath` preservation pair) and **V8b** (the "everything else stays unchanged" half). Together they are the mechanical form of Table H, and of the narrowed proof statement in the not-deliverables paragraph. **V7's `boundary-check.js` argument list is also a mirror** — it must name all five Deliverables files, or the gate silently checks a subset
+- [ ] **(+r7)** Test index rows **T6** and **T7**, and the naming-rule exemption immediately under the table: T6/T7 add no `node-path-durability:`-prefixed subtest, so **V2's `>= 4` threshold is unaffected by them** and must not be raised on their account
 - [ ] **(+r2)** Verification command V2 (its `>= 4` threshold mirrors the Test index row count — note T5 is **skipped** on win32, so a win32 run legitimately reports one fewer)
 - [ ] **(+r4)** T5's POSIX-only platform gate — stated in **AC4**, the **Test index** T5 cell, and **Table E row 7**'s scope column; all three must move together
-- [ ] Table E mutation rows 1–8; the Table F fixture references belong to **rows 4-6 only** (rows 1, 2, 3, 7 and 8 are driven by T1/T5/V3 and cite no Table F fixture)
+- [ ] Table E mutation rows 1–8; the Table F fixture references belong to **rows 4-6 only** (rows 1, 2, 3, 7 and 8 are driven by T1/T5/V3 and cite no Table F fixture) — **(+r7)** and row **8**'s redness claim, which Table H's "detection power strictly increases" paragraph extends: on a Homebrew host that mutation now also reddens Table H rows 2-4's dependents. **Table E row 8 stays judged by reading V3's counts**; the extra redness is a bonus, never a substitute, and the two statements must move together
+- [ ] **(+r7)** Implementation notes **§D3/D4** — the dated amendment record (the collision, the decision, the two rejected alternatives, the escalation rule). It is the narrative behind **Table H**; Table H decides, §D3/D4 records what happened and why. Neither may be folded into the other, and a change to Table H's row set requires a dated note here
+- [ ] **(+r7)** Implementation notes §D2's dual-consumer rule — Table H rows 2-4 are its **test-side** mirror: `darwinJobExpect` and `canonicalJobPlistContent` reproduce, on the test side, the same "renderer and `expect` are built from the SAME value" invariant the hoisted `const node` gives on the production side. If §D2's rule ever changes, these three helpers change with it
 - [ ] **(+r2)** Test index — T1's and T2's cells are the only place Table F rows 13–15 (the alias positives) and rows 1–12 (the negatives) carry a *requirement* rather than an arithmetic fact
 - [ ] **(+r2)** The whole **Out of scope** section — every bullet applies Table A row 6 (descriptor), row 2 (nvm et al.) or row 1 (Windows), and the first bullet applies Tables C/D
-- [ ] **(+r2)** Definition of done items 0 (the Tables C/D blocker **and** the `depends_on` obligation), 1 (V2/V3 thresholds), 6 (the Windows owner check, Table A row 1), 7 (AC9's no-overclaim rule) and 8 (the ADR-0028 sequencing gate) — **(+r5)** and item **9**, which mirrors Table G's Status row: it began as a **premise gate** and is now a **live smoke test**, the premise having been discharged pre-implementation on 2026-08-02. **Item 9 and Table G's Status row may never disagree about whether the premise is open**
+- [ ] **(+r2)** Definition of done items 0 (the Tables C/D blocker **and** the `depends_on` obligation), 1 (V2/V3 thresholds), 6 (the Windows owner check, Table A row 1), 7 (AC9's no-overclaim rule) and 8 (the ADR-0028 sequencing gate) — **(+r5)** and item **9**, which mirrors Table G's Status row: it began as a **premise gate** and is now a **live smoke test**, the premise having been discharged pre-implementation on 2026-08-02. **Item 9 and Table G's Status row may never disagree about whether the premise is open**; **(+r7)** and item **10**, which mirrors **Table H** and the narrowed proof statement
+- [ ] **(+r7)** Out of scope → the new **"the two amended test files"** bullet, which records what stays out of bounds *inside* two files that are now Deliverables. It mirrors Table H's "a site not in this table is out of the permission boundary" rule from the opposite direction and must move with it
 - [ ] **(+r5)** Definition of done item 1's **V2 pass-count threshold**, which mirrors the V1 baseline measured at a specific SHA. It was `79` at `5f0ffc0` and is **`120` at `1093e51`**; it moves whenever the suite grows, so it is registered rather than left as a literal in two places
 - [ ] **(+r5)** Implementation notes §D2's "do not touch" list — it names the register machinery by function, and PR #140 replaced those functions
 - [ ] **(+r5)** Out of scope, the registration-path bullet — it described the defect as *routed and unfixed*; it now records it as *fixed by PR #140*
@@ -1118,6 +1252,116 @@ or any probe, notice or heal. *(At `5f0ffc0` this paragraph said "do not touch t
 bare `launchctl bootstrap` calls at `:315` and `:431`". **Those calls no longer
 exist** — PR #140 deleted them. The instruction is unchanged in spirit: the
 register machinery is not this WP's to edit.)*
+
+### D3/D4 — the host-shape oracle collision (architect boundary amendment, 2026-08-02)
+
+**This section was added after the implementer finished D1/D2.** It is a spec bug
+being paid for, not a scope change the implementer chose. The collision was
+invisible at spec time and surfaced only at `npm test` time, in two files this
+spec's Deliverables table did not list — and it surfaced **only on the authoring
+host**. Recorded here in full so the next reader does not have to reconstruct it
+from a PR body. **Table H is canonical for the sites; this section is canonical
+for the decision.**
+
+**The collision, verified firsthand.** With D1 and D2 implemented and nothing else
+touched, `npm test` on the **authoring host** — a real Homebrew macOS install
+(macOS 26, Apple Silicon, prefix `/opt/homebrew`, `process.execPath` =
+`/opt/homebrew/Cellar/node/25.9.0_2/bin/node`, alias
+`/opt/homebrew/opt/node -> ../Cellar/node/25.9.0_2`) — reports **15 failures**:
+
+```
+ℹ tests 93 / ℹ pass 71 / ℹ fail 15 / ℹ skipped 7
+  14 in tests/unit/scheduler-schedule.test.js
+   1 in tests/unit/sync-repoint.test.js
+```
+
+Both files were on the **not-deliverables** list. The implementer touched neither
+and reported it rather than adapting a test outside their boundary, which is the
+correct move and is why this amendment exists instead of a silent widening.
+
+**Root cause — the WP working exactly as designed.** Seven expressions in those two
+files call `gen.nodePath()` as their **oracle for what a freshly-written entry
+embeds**. On this host `entryNodePath()` now legitimately returns
+`/opt/homebrew/opt/node/bin/node` (Table A row 6; Table G's premise P is TRUE), so
+the oracle and the rendered bytes diverge by exactly one string. Everything
+downstream follows mechanically: `expect.argv[0]` stops matching the readback, so
+the FATAL-tier comparison at `schedule.js:134-139` grades `'mismatch-fatal'` where
+the test expects `'match'`; and `canonicalJobPlistContent`'s bytes stop being
+canonical, so `ensureEntry` reports `changed:true` where the fixture needs
+`changed:false`. **No production behavior is wrong. Fifteen oracles are stale.**
+
+**The finding this makes unavoidable, and it is about the spec, not the code.**
+This spec's own proof mechanism was **host-shape-dependent**. The not-deliverables
+paragraph rested on those two files' assertions passing unmodified, and that
+property held on the CI runners (`setup-node`; no Homebrew alias resolving to
+`execPath`, so `entryNodePath() === nodePath()` and the swap is a no-op) while
+failing on the **exact machine class this WP was written to protect**. A boundary
+whose proof is green precisely where the change is inert, and red precisely where
+the change does something, is not a proof. That asymmetry is the defect; the
+15 reds are its symptom.
+
+**Same defect class as the sibling's D6, and the same remedy.**
+`WP-scheduler-register-replaces-loaded-record` hit an identical shape — an
+unavoidable consequence in a non-deliverable file the boundary did not anticipate
+(`docs/specs/done/WP-scheduler-register-replaces-loaded-record.md:1289-1382`, §D6,
+the `WIENERDOG_LOADER_NOOP` collision) — and answered it with a dated amendment
+that promoted the file into Deliverables under a bounded enumeration rather than
+either widening the boundary implicitly or bending the production code. That is the
+precedent this section follows.
+
+**THE DECISION.** Promote both files into the Deliverables table (**D3** and
+**D4**), authorize **exactly** the seven oracle expressions **Table H** enumerates
+— `gen.nodePath()` → `gen.entryNodePath()`, plus at most one added `//` comment
+line per site — and **narrow the not-deliverables paragraph's proof claim** from
+*"nothing else moved"* to *"no assertion changes beyond the enumerated oracle
+swaps"*, which **AC10** asserts and **V8/V8b** check mechanically. **Not one
+assertion, expected value, test name, helper signature, fixture, loader or stdout
+builder changes.** Table H's rejected-oracle table records why class (a) was chosen
+over deriving the oracle from the rendered output (b) or from the host (c), and why
+(a) is not tautological.
+
+**REJECTED ALTERNATIVE 1 — leave the two files out of Deliverables and let the
+15 stay red, on the ground that CI is green.** Rejected, and rejected in this WP's
+own terms.
+
+1. **It ships a WP whose own suite fails on the owner's production machine.**
+   Definition of done item 1 requires the verification steps to pass *locally*, and
+   V1's `ℹ fail 0` is an explicit **preservation** result. "Green on the runner"
+   was never the contract.
+2. **It institutionalises the asymmetry.** The next change to the entry node path
+   would meet the same 15 reds with no record of why, and the obvious local repair
+   — teaching a test to branch on the host — would bake the dependence in.
+3. **It is the failing-outside-our-own-observability signature one layer up.** This
+   spec's Context names that signature as the thing the WP exists to kill. A proof
+   mechanism that only reports where the change is inert has the same shape.
+
+**REJECTED ALTERNATIVE 2 — make `entryNodePath()` return `execPath` under a test
+env var (`WIENERDOG_TEST_NO_DURABLE_NODE=1`, or keyed off
+`WIENERDOG_TEST_NO_REAL_SCHEDULER`), so the two files need no edit at all.**
+Rejected, hard, and for the same reason the sibling rejected teaching
+`WIENERDOG_LOADER_NOOP` to fabricate a readback (§D6, rejected alternative).
+
+1. **It disables the feature in the only suite that could detect it.** Every test
+   would then exercise the pinned path, so no test could ever again observe the
+   durable path being chosen — including T5, whose entire job is the role split.
+   The WP would ship with its central behavior untested by construction.
+2. **It puts a test seam in the production return value**, on the registration
+   path, contradicting the "Exact contracts" JSDoc (`opts.realpath` is the **only**
+   seam) and the Security checklist's statement that the only filesystem touch is
+   two `realpath` calls.
+3. **It is a wider diff than the honest one.** Seven expression swaps in test files
+   versus a new env-var branch in `generators.js` plus its own tests plus a
+   documented seam. The cheaper change is also the correct one here, which is not
+   always true and is worth recording when it is.
+
+**The escalation rule this amendment follows, stated so it is reusable.** When an
+implementer reports a failure in a **non-deliverable** file: first ask whether it
+is a **behavioral regression** or a **stale oracle**. A regression stops the WP —
+that is the boundary doing its job. A stale oracle is a spec bug, and the spec
+owner pays for it with a **dated amendment plus a bounded enumeration**, never with
+a verbal go-ahead and never by the implementer editing outside their table. Each of
+the 15 failures here was read individually and classified before a single character
+of test source changed; all fifteen were stale oracles, none was a regression.
 
 ### Why the descriptor field stays `process.execPath` — the decisive reason
 
@@ -1386,7 +1630,7 @@ fixture without adding its row there.
       of those tables, not commentary on them. Reproducing the call lists **without**
       the scoping paragraph restates the *"'exactly one' through the full path"*
       claim the landed sibling explicitly forbids
-      (`docs/specs/done/WP-scheduler-register-replaces-loaded-record.md:1881-1883`),
+      (`docs/specs/done/WP-scheduler-register-replaces-loaded-record.md:1880-1883`),
       so dropping it turns a correct table into an incorrect one. The PR states
       **all four** of:
       (i) Table C rows **4** (linux, degraded reload) and **7** (macOS,
@@ -1410,6 +1654,27 @@ fixture without adding its row there.
       converge and that Table D's final row in each sub-table reports that as
       success". Row 5 converges as of PR #140; repeating the old sentence would now
       be an UNDERclaim, and an inaccurate one.)*
+
+- [ ] **AC10 (Table H — the oracle swap is bounded, and the narrowed proof holds).
+      NEW 2026-08-02, with the D3/D4 boundary amendment.** Four things, all
+      mechanical:
+      (i) `tests/unit/scheduler-schedule.test.js` and
+      `tests/unit/sync-repoint.test.js` contain **zero** occurrences of
+      `gen.nodePath()` and exactly **six** and **one** of `gen.entryNodePath()`
+      respectively — V8, whose `origin/main` output is the inverse (6/0 and 1/0);
+      (ii) their `process.execPath` counts are **unchanged** at **7** and **0** —
+      the RUNTIME role did not move inside a file that is now a Deliverable
+      (V8, second half);
+      (iii) **every** `+`/`-` line in those two files' diff against `origin/main`
+      either contains a `nodePath` token or is an added `//` comment line — V8b,
+      **exit status is the verdict**. This is the executable form of the narrowed
+      proof statement: *no assertion changes beyond the enumerated oracle swaps*;
+      (iv) all 15 previously-failing tests are green **on a Homebrew macOS host**,
+      and V1 still reports `ℹ fail 0`.
+      **AC10 states no site list of its own — Table H is the enumeration.** A swap
+      at a site Table H does not list fails the boundary gate (V7) in spirit even
+      when `boundary-check.js` passes it, because `boundary-check.js` checks files
+      and Table H checks sites; V8b is what closes that gap.
 
 ### Table F — fixture arithmetic (canonical; every AC2/Table E fixture)
 
@@ -1491,13 +1756,18 @@ inventing a contrived row for a preservation criterion.
 | T4 | tests/unit/scheduler-generators.test.js | double-render byte-identity and repeat-call stability (AC6) |
 | T5 | tests/unit/scheduler-generators.test.js | the fabricated-Homebrew-layout role-split detector: `nodePath()` vs `entryNodePath()` under a controlled `process.execPath`, real `fs.realpathSync`, no seam (AC4, Table E row 7). **POSIX-only — must be declared with `{ skip: process.platform === 'win32' }`** (the `posixOnly` idiom at `tests/unit/exec-identity.test.js:26`); see AC4 for why an ungated T5 fails against a correct implementation on win32 |
 
+| T6 | tests/unit/scheduler-schedule.test.js | **(+2026-08-02, D3)** the six oracle sites of **Table H** rows 1-6 (AC10). **Not new tests and not `node-path-durability:` subtests** — six existing expressions in existing tests, so the naming rule below does not apply to them and V2's `>= 4` threshold is unaffected |
+| T7 | tests/unit/sync-repoint.test.js | **(+2026-08-02, D4)** the one oracle site of **Table H** row 7 (AC10). Same exemption as T6 |
+
 There is no T3. Round 1's T3 (descriptor-digest invariance) was vacuous by
 construction and its criterion (AC5) is now static — see AC5.
 
 Name every subtest with the prefix `node-path-durability:` **followed by one
 space** so the verification commands can count them with one anchored grep,
 exactly as `tests/unit/scheduler-entry-identity.test.js` does with its
-`entry-identity:` prefix.
+`entry-identity:` prefix. **T6 and T7 are exempt — see their rows.** They add no
+subtest at all, so they neither satisfy nor inflate V2's `>= 4` count; V2 remains a
+statement about T1/T2/T4/T5 only.
 
 T1 and T2 must be **table-driven** over arrays of `[input, expected, why]` — the
 arrays are the executable form of Table F, and adding a fixture is then one line
@@ -1536,17 +1806,21 @@ they moved.
 **Three rules, and they are not the same rule.**
 
 1. **Change checks** must print something different after the fix than on `main`.
-   **V2, V3 and V6 are change checks.** V2's `main` count of **`ℹ pass 120`** is a
-   **FAILURE** after implementation — T1, T2, T4 and T5 add tests, so a run still
-   reporting 120 means no new direct evidence was written.
+   **V2, V3, V6 and V8's first four counts are change checks.** V2's `main` count
+   of **`ℹ pass 120`** is a **FAILURE** after implementation — T1, T2, T4 and T5
+   add tests, so a run still reporting 120 means no new direct evidence was
+   written. (T6/T7 add **no** subtests, so they neither raise nor excuse this
+   threshold — Test index.)
 2. **Preservation checks** assert something did *not* move and are supposed to
-   print the same thing before and after. The carve-out covers **exactly four
-   results: V1's `ℹ fail 0` line, V4, V5 and V5b** — nothing else. V1's `ℹ pass`
-   count is emphatically not covered; it is V2's input.
-3. **Exit status is the verdict for V1 and V5b only** (V5b is a negative grep, so
-   its exit status *is* its answer). V3, V4, V5 and V6 are judged by **reading the
-   printed output** — `grep` exits 0 whether it prints six lines or one. Never
-   report an exit 0 from those as a pass.
+   print the same thing before and after. The carve-out covers **exactly six
+   results: V1's `ℹ fail 0` line, V4, V5, V5b, V8's two `execPath` counts, and
+   V8b** — nothing else (**UPDATED 2026-08-02**: it was four before V8/V8b joined
+   with the D3/D4 boundary amendment). V1's `ℹ pass` count is emphatically not
+   covered; it is V2's input.
+3. **Exit status is the verdict for V1, V5b and V8b only** (V5b and V8b are
+   negative greps, so their exit status *is* their answer). V3, V4, V5, V6 and V8
+   are judged by **reading the printed output** — `grep` exits 0 whether it prints
+   six lines or one. Never report an exit 0 from those as a pass.
 
 Two commands need a `main` ref that exists in the implementer's worktree. Fetch it
 once up front rather than assuming a local branch: `git fetch origin main --quiet`,
@@ -1597,8 +1871,10 @@ grep -n "node: process.execPath" src/scheduler/descriptor.js
 git diff --name-only origin/main...HEAD
 # on main (RE-EXECUTED at 1093e51): src/scheduler/descriptor.js:215:    node: process.execPath,
 # REQUIRED after: the same single line, AND descriptor.js absent from the
-# name-only diff, which must list exactly the three Deliverables files plus this
-# spec.
+# name-only diff, which must list exactly the FIVE Deliverables files plus this
+# spec (UPDATED 2026-08-02: it was three before the D3/D4 boundary amendment
+# added tests/unit/scheduler-schedule.test.js and tests/unit/sync-repoint.test.js
+# — see Table H).
 
 # V5b (PRESERVATION — AC5's zero-coupling argument, made executable. This is the
 #      command that replaces round 1's vacuous descriptor-digest test: it shows
@@ -1617,10 +1893,45 @@ git diff origin/main...HEAD -- src/scheduler/generators.js src/cli/schedule.js \
   echo "OK: no new require/spawn/timer in the production diff"
 # on main: n/a (empty diff). REQUIRED after: the OK line, with no matches above it.
 
-# V7 — the boundary gate and the lint pipeline.
+# V8 (CHANGE + PRESERVATION — Table H / AC10 (i) and (ii); judged by reading the
+#     counts). The oracle swap is BOUNDED: in the two amended test files every
+#     `gen.nodePath()` becomes `gen.entryNodePath()`, and the RUNTIME-role
+#     `process.execPath` occurrences (Table B row 2) do not move.
+#     ADDED 2026-08-02 with the D3/D4 boundary amendment.
+for f in tests/unit/scheduler-schedule.test.js tests/unit/sync-repoint.test.js; do
+  echo "$f  main: nodePath=$(git show origin/main:$f | grep -c 'gen\.nodePath()') \
+entryNodePath=$(git show origin/main:$f | grep -c 'gen\.entryNodePath()') \
+execPath=$(git show origin/main:$f | grep -c 'process\.execPath')"
+  echo "$f  HEAD: nodePath=$(grep -c 'gen\.nodePath()' "$f") \
+entryNodePath=$(grep -c 'gen\.entryNodePath()' "$f") \
+execPath=$(grep -c 'process\.execPath' "$f")"
+done
+# on main:  scheduler-schedule  nodePath=6  entryNodePath=0  execPath=7
+#           sync-repoint        nodePath=1  entryNodePath=0  execPath=0
+# REQUIRED after: scheduler-schedule  nodePath=0  entryNodePath=6  execPath=7
+#                 sync-repoint        nodePath=0  entryNodePath=1  execPath=0
+# The two execPath counts are the PRESERVATION half and must be IDENTICAL.
+
+# V8b (PRESERVATION — Table H / AC10 (iii): the "everything else stays unchanged"
+#      half, and the executable form of the NARROWED proof statement in the
+#      not-deliverables paragraph. EXIT STATUS IS THE VERDICT — the inner grep
+#      must find nothing, so the OK branch must be the one that prints.
+git diff origin/main...HEAD -- tests/unit/scheduler-schedule.test.js \
+                               tests/unit/sync-repoint.test.js \
+  | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
+  | grep -vE 'gen\.(entry)?[Nn]odePath\(\)' | grep -vE '^\+[[:space:]]*//' \
+  && echo "FAIL: a line outside Table H's enumeration moved in the amended test files" \
+  || echo "OK: every changed line is an enumerated oracle swap or its added comment"
+# on main: n/a (empty diff). REQUIRED after: the OK line, with nothing above it.
+
+# V7 — the boundary gate and the lint pipeline. The argument list must name ALL
+#      FIVE Deliverables files (UPDATED 2026-08-02: the last two were added by the
+#      D3/D4 boundary amendment; a V7 that still lists three checks a subset and
+#      passes vacuously).
 node scripts/boundary-check.js docs/specs/WP-scheduler-node-path-durability.md \
   src/scheduler/generators.js src/cli/schedule.js \
-  tests/unit/scheduler-generators.test.js
+  tests/unit/scheduler-generators.test.js \
+  tests/unit/scheduler-schedule.test.js tests/unit/sync-repoint.test.js
 npm run lint
 npm test
 ```
@@ -1679,6 +1990,21 @@ npm test
 - **Any change to `status.js`, `launcher.js`, `run-job.js` or the renderers.**
 - **Windows-specific handling.** Table A row 1 makes the change a no-op there by
   construction; that is the whole Windows story for this WP.
+- **Everything in the two amended test files that Table H does not list.** NEW
+  2026-08-02 with the D3/D4 boundary amendment. `tests/unit/scheduler-schedule.test.js`
+  and `tests/unit/sync-repoint.test.js` are now Deliverables, and that is **not** a
+  licence to touch them generally. Out of bounds inside them: every assertion text
+  and expected value, every test name, `fakeLaunchd`, `printStdoutFromPlistXml`,
+  `buildPrintStdout`, `matchingStdout`, `scriptedDarwinLoader`,
+  `unchangedJobFixture`'s structure, `primaryEntry`/`runSync`, every fixture, and
+  **all seven `process.execPath` occurrences** (RUNTIME role — Table B row 2).
+  **A site not in Table H is out of the permission boundary**, and V8b is the check
+  that says so mechanically rather than on trust.
+- **Teaching `entryNodePath` a test-only escape hatch** (an env var that makes it
+  return `execPath` under the suite) so the two files would have needed no edit.
+  Rejected in Implementation notes → **D3/D4, rejected alternative 2**: it would
+  disable the WP's central behavior in the only suite that could detect it, and put
+  a second seam in a production return value. Do not reopen it.
 
 ## Definition of done
 
@@ -1742,8 +2068,13 @@ npm test
    C, D and G, not a memory of their pre-#140 shape.
 1. All verification steps pass locally; output pasted into the PR body, with V2's
    pass count **strictly above 120** (RE-BASELINED 2026-08-02 at `1093e51`; it was
-   79 at `5f0ffc0` — do **not** use the old number), V2's subtest count `>= 4`, and
-   V3's two counts flipped to 0 / 6.
+   79 at `5f0ffc0` — do **not** use the old number), V2's subtest count `>= 4`,
+   V3's two counts flipped to 0 / 6, and **V8's four counts flipped to 0/6 and 0/1
+   with both `execPath` counts unmoved** (added 2026-08-02 with D3/D4).
+   **"Locally" means a real Homebrew macOS host wherever one is available** — that
+   is where this WP's change is not inert, and it is the host on which the D3/D4
+   collision was found. A green run on a CI runner alone does not discharge this
+   item; say which host class was used.
 2. Every Table E row (1–8) demonstrated red (with the "selected exactly one named
    subtest" assertion) and the file restored byte-for-byte afterwards.
 3. Conventional commits; PR titled
@@ -1848,3 +2179,18 @@ npm test
    superseded text. None of that ADR's five prior amendments annotated the text
    it refined, and the amendment spec forbids it explicitly. The dated amendment
    plus its owner signature is the **only** way this item is satisfied.
+10. **D3/D4 — the boundary amendment is discharged, and its proof is the narrowed
+    one. NEW 2026-08-02.**
+    - **AC10** passes in all four parts: V8's counts flipped (0/6 and 0/1) with
+      both `process.execPath` counts unmoved (7 and 0); **V8b prints the OK line
+      with nothing above it**; and the 15 previously-failing tests are green on a
+      Homebrew macOS host with V1 still reporting `ℹ fail 0`.
+    - **V7's `boundary-check.js` invocation names all FIVE Deliverables files** and
+      exits 0. A V7 still listing three files is a vacuous pass, not a pass.
+    - The PR body states, in one sentence, that this WP's proof of non-interference
+      is the **narrowed** one — *no assertion changes beyond the enumerated oracle
+      swaps* — and **not** the withdrawn *"nothing else moved"*. Overstating it
+      would re-assert exactly the claim the amendment retired.
+    - **No owner marker is written for this item.** It is discharged by the
+      architect's dated amendment plus the mechanical checks above; there is no
+      signature to produce and none may be invented.

--- a/docs/specs/WP-scheduler-node-path-durability.md
+++ b/docs/specs/WP-scheduler-node-path-durability.md
@@ -526,7 +526,7 @@ adds the D2 consistency rule rather than a new deliverable.
 | modify | src/scheduler/generators.js | **D1** — add `entryNodePath(execPath?, opts?)` per Table A and export it. `nodePath()` keeps its body **byte-for-byte** (Table A row 6, Table B row 2). No renderer, no other function. |
 | modify | src/cli/schedule.js | **D2** — replace `gen.nodePath()` with `gen.entryNodePath()` at exactly the six ENTRY sites, **re-anchored to `1093e51`: `:477`, `:536`, `:611`, `:856`, `:885`, `:970`** (Current state §2; `5f0ffc0`'s `:303 :342 :417 :638 :667 :752` are dead line numbers — do not use them). Nothing else in this file changes: **no change to `ensureDarwinEntryRegistered`, `darwinLoadedVerdict`, `darwinReplaceEntry`, the `plutil` preflight, the linux `reloadOk`/`enableOk` gate**, no probe change, no notice change. |
 | modify | tests/unit/scheduler-generators.test.js | **T1, T2, T4 and T5** — the exact set in the Test index. **There is no T3** (round 1's descriptor-digest test was vacuous and is deleted — see AC5), and **T5 is not optional**: it is the ONLY detector for Table E row 7, the role split. Building T1/T2/T4 without T5 reproduces the round-1 test set that shipped an undetectable mutation. The existing test at `:421` (`nodePath/wienerdogBin are absolute`) must pass **unmodified** — and note it does **not** protect the role split, which is exactly why T5 exists. |
-| modify | tests/unit/scheduler-schedule.test.js | **D3 / T6 — architect boundary amendment, 2026-08-02.** Exactly the **six** oracle sites **Table H** rows 1-6 enumerate, and nothing else: `gen.nodePath()` → `gen.entryNodePath()` at each, plus the one added `//` comment line per site. **Table H is the authority — this cell carries no site list of its own.** No new test, no deleted test, no renamed subtest, no helper signature change, no `fakeLaunchd`/`buildPrintStdout`/`printStdoutFromPlistXml` change, and **no change to any of the seven `process.execPath` occurrences** (RUNTIME role — Table B row 2). The collision was discovered at `npm test` time on the authoring host, not at spec time; the full record, the decision and the rejected alternatives are in Implementation notes → **D3/D4**. |
+| modify | tests/unit/scheduler-schedule.test.js | **D3 / T6 — architect boundary amendment, 2026-08-02.** Exactly the **six** oracle sites **Table H** rows 1-6 enumerate, and nothing else: `gen.nodePath()` → `gen.entryNodePath()` at each, plus the added `//` comment line(s) **Table H**'s comment-budget rule authorizes (at most one per site, two at row 2 — amended 2026-08-02, round-2 finding 12; this cell previously said "the one added comment line per site" and was one of the mirrors the amendment corrected). **Table H is the authority — this cell carries neither a site list nor a comment budget of its own.** No new test, no deleted test, no renamed subtest, no helper signature change, no `fakeLaunchd`/`buildPrintStdout`/`printStdoutFromPlistXml` change, and **no change to any of the seven `process.execPath` occurrences** (RUNTIME role — Table B row 2). The collision was discovered at `npm test` time on the authoring host, not at spec time; the full record, the decision and the rejected alternatives are in Implementation notes → **D3/D4**. |
 | modify | tests/unit/sync-repoint.test.js | **D4 / T7 — architect boundary amendment, 2026-08-02.** Exactly the **one** oracle site **Table H** row 7 enumerates, plus its added `//` comment line. Nothing else in this file: no other test, no `primaryEntry`/`runSync` helper change, no fixture change, no `oldNode` change. Same record as D3. |
 
 Not deliverables, deliberately: `src/scheduler/descriptor.js`,
@@ -697,11 +697,23 @@ registered has to be re-minted for this WP.
 
 ### Table B — role split (canonical)
 
+> **RE-ANCHORED 2026-08-02 to `1093e51` (round-2 finding 13).** Rows 1 and 2 still
+> carried `5f0ffc0`'s line numbers after PR #140 moved every one of them. Current
+> state §2 and Deliverables **D2** had already been re-anchored — this table, the
+> one the Mirrored Surface Checklist points those mirrors *at*, was the surface
+> left behind, which inverted the direction the checklist exists to enforce. The
+> numbers below are re-executed from `grep -rn "gen\.nodePath()" src/` at
+> `1093e51` (the listing is reproduced in Current state §2), not carried forward.
+> **The counts did not change — six ENTRY, three RUNTIME — and neither did the
+> enclosing function of any site; only the line numbers moved.** `5f0ffc0`'s
+> numbers are retained in the cells for provenance and are **dead — never
+> navigate by them**.
+
 | Role | Function | Call sites | Value | Rule |
 |------|----------|-----------|-------|------|
-| Entry (written into a file the OS keeps) | `entryNodePath()` | `schedule.js` `:303 :342 :417 :638 :667 :752` | Table A | must survive a package upgrade |
-| Runtime (spawn a child of this process) | `nodePath()` | `run-job.js:408`, `run-job.js:529`, `routine-runtime.js:92` | `process.execPath` | must be the exact running interpreter (WP-154) |
-| Authorization record (digest-covered) | *(inline)* `process.execPath` | `descriptor.js:215` | `process.execPath` | **unchanged** — see Table A row 6 |
+| Entry (written into a file the OS keeps) | `entryNodePath()` | `schedule.js` `:477 :536 :611 :856 :885 :970` *(at `1093e51`; `5f0ffc0`'s dead `:303 :342 :417 :638 :667 :752`, retained for provenance)* | Table A | must survive a package upgrade |
+| Runtime (spawn a child of this process) | `nodePath()` | `run-job.js:439`, `run-job.js:579`, `routine-runtime.js:92` *(at `1093e51`; `run-job.js`'s dead `:408` / `:529`, retained for provenance — `routine-runtime.js:92` never moved)* | `process.execPath` | must be the exact running interpreter (WP-154) |
+| Authorization record (digest-covered) | *(inline)* `process.execPath` | `descriptor.js:215` *(re-confirmed at `1093e51` — unmoved)* | `process.execPath` | **unchanged** — see Table A row 6 |
 
 ### Table C — post-`sync` convergence, by platform and starting state (canonical)
 
@@ -916,8 +928,9 @@ recorded in Implementation notes → **D3/D4**. This table is the **bounded
 enumeration** that replaces the withdrawn blanket claim.
 
 **How to read it.** Every authorized site is a row. **Every row is one expression
-swap — `gen.nodePath()` → `gen.entryNodePath()` — plus at most one added `//`
-comment line above it.** Nothing else in either file changes: no assertion text, no
+swap — `gen.nodePath()` → `gen.entryNodePath()` — plus, above it, at most one
+added `//` comment line, or a two-line `//` comment where the citation does not
+fit on one line.** Nothing else in either file changes: no assertion text, no
 expected value, no test name, no helper signature, no fixture, no
 `fakeLaunchd` / `buildPrintStdout` / `printStdoutFromPlistXml` change, and none of
 the **seven `process.execPath` occurrences** in `scheduler-schedule.test.js`
@@ -926,9 +939,25 @@ spawned test child, Table B row 2). **A site not in this table is out of the
 permission boundary**, exactly as with Table E. V8 and V8b make both halves
 mechanical.
 
+> **AMENDED 2026-08-02 (round-2 finding 12) — the comment budget is "at most one,
+> or two where the citation needs it", and the amendment moved the PROSE, not the
+> code.** The rule above read *"at most one added `//` comment line"* while
+> **row 2** carries **two** — its citation names both Table B row 1 and this
+> table, and does not fit on one line. The `branch` column below **already
+> encoded the two-line shape**: the **+3** cumulative shift at row 2 and the
+> **+4 / +5** shifts at rows 3-6 are arithmetically consistent *only* with two
+> comment lines at row 2. So the prose was the stale mirror and the numbers were
+> right; the prose is what moved. Trimming the test comment instead would have
+> invalidated four downstream `branch` line numbers to save one line of comment.
+> **Row 2 is the only two-line site**: rows 1, 3, 4 and 7 carry exactly one line
+> each, rows 5 and 6 carry none. **V8b is indifferent either way** — it filters
+> `^\+[[:space:]]*//` per line, so it accepts any number of added comment lines
+> and its verdict does not change under this amendment.
+
 `main` line numbers are `origin/main` @ `179173b`; `branch` line numbers are this
-branch after the swap (they shift by the added comment lines, and are given so a
-reader can find the site — they are not the contract; the expression and its role
+branch after the swap (they shift by the added comment lines — see the amendment
+note above for the per-row budget those shifts encode — and are given so a
+reader can find the site; they are not the contract, the expression and its role
 are).
 
 | # | File | `main` | branch | The expression | Its role — what the test uses it for | Class | Red on the authoring host? |
@@ -1018,24 +1047,37 @@ applied, not skipped:** the contract that had leaked into the not-deliverables
 prose is now decided in exactly one place (Table H), and every mirror below defers
 to it.
 
+**(+r8, 2026-08-02) — round-2 findings 12 and 13, and the one lesson they share.**
+Both were **canonical tables outvoted by their own mirrors**. Finding 12: Table H's
+comment-budget prose said "at most one" while Table H's own `branch` column
+encoded two at row 2 — a table disagreeing with itself. Finding 13: Table B row 1
+and row 2 still carried `5f0ffc0`'s line numbers *after* two registered mirrors of
+Table B — Current state §2 and Deliverables **D2** — had been re-anchored to
+`1093e51`. **A re-anchoring pass that updates the mirrors and not the table it
+mirrors is the checklist run backwards**, and it is the failure this block exists
+to make un-repeatable: **when a `(+r5)`-class line-number entry moves, Table B
+moves first and the mirrors follow it.** Table B is now marked with its own dated
+re-anchoring preamble so a future reader can tell at a glance which commit its
+numbers belong to.
+
 In this spec:
 
 - [ ] Deliverables cell for `src/scheduler/generators.js` (D1 — "per Table A", `nodePath()` byte-for-byte)
 - [ ] Deliverables cell for `src/cli/schedule.js` (D2 — the six site list, Table B row 1)
 - [ ] **(+r3)** Deliverables cell for `tests/unit/scheduler-generators.test.js` — it mirrors the **Test index** row set (T1/T2/T4/T5) and the "no T3" fact. **This is the mirror whose absence caused a round-2 defect**: the T3→T5 renumbering updated five registered surfaces and missed this unregistered one, leaving the permission-boundary table telling the implementer to build the round-1-failing test set. Registered so the Test index and this cell can never diverge again.
-- [ ] **(+r7)** Deliverables cells for `tests/unit/scheduler-schedule.test.js` (**D3 / T6**) and `tests/unit/sync-repoint.test.js` (**D4 / T7**) — both mirror **Table H**'s row set and its "one expression swap plus at most one comment line" rule. **Neither cell carries a site list of its own**, deliberately: the sibling's D6 amendment showed that a Deliverables cell restating an enumeration is exactly the mirror that goes stale (`done/WP-scheduler-register-replaces-loaded-record.md:368` says the same of its Table E). Table H is the authority
+- [ ] **(+r7)** Deliverables cells for `tests/unit/scheduler-schedule.test.js` (**D3 / T6**) and `tests/unit/sync-repoint.test.js` (**D4 / T7**) — both mirror **Table H**'s row set and its comment-budget rule — **(+r8)** now *"one expression swap plus at most one added `//` comment line, or two where the citation needs it (row 2 only)"*, amended 2026-08-02 for round-2 finding 12, which found the D3 cell restating the superseded one-line budget. **Neither cell carries a site list or a comment budget of its own**, deliberately: the sibling's D6 amendment showed that a Deliverables cell restating an enumeration is exactly the mirror that goes stale (`done/WP-scheduler-register-replaces-loaded-record.md:368` says the same of its Table E). Table H is the authority
 - [ ] **(+r7)** Deliverables → the **not-deliverables paragraph's proof-role statement**. This is the mirror the amendment **falsified**: it claimed the two files' unmodified assertions were *"this WP's proof that nothing else moved"*, which stopped being true the moment D1/D2 landed on a Homebrew host. The withdrawn sentence is quoted in place and replaced by the narrowed claim — *no assertion changes beyond the enumerated oracle swaps* — which **AC10** asserts and **V8/V8b** make mechanical. **The three must never disagree about the scope of the claim**
 - [ ] **(+r2, +r7)** Deliverables → the **Sizing** paragraph (it restates Table B row 1's "six call sites" count, **and now Table H's seven-site count**)
 - [ ] "Exact contracts" JSDoc block, its default-parameter note (Table A row 1) and its input → output pairs (Table F)
 - [ ] "Exact contracts" literal `.plist` fragment (the `--expect-digest`-unchanged claim, Table A row 6)
-- [ ] Current state §2 (the ENTRY/RUNTIME site classification — Table B) — **(+r5)** and its NEW hoisted-`const node` sub-table, which is the mirror of Implementation notes §D2's dual-consumer rule
+- [ ] Current state §2 (the ENTRY/RUNTIME site classification — Table B) — **(+r5)** and its NEW hoisted-`const node` sub-table, which is the mirror of Implementation notes §D2's dual-consumer rule. **(+r8)** §2's nine line numbers and **Deliverables D2**'s six are mirrors of **Table B rows 1-2**, which is where they are decided; round-2 finding 13 found both mirrors re-anchored to `1093e51` while Table B itself was not. Re-anchor Table B first, then these
 - [ ] Current state §7 (the descriptor field — Table A row 6)
 - [ ] **(+r5)** Current state §8 — **REWRITTEN against `ensureDarwinEntryRegistered`**; it is the mechanism behind Tables C and D and must be re-read whenever either moves. Its `5f0ffc0` text is retained in a quote block, not deleted
 - [ ] **(+r5)** Current state §9 — **the executed record of the scratch-label experiment that settled Table G's premise (P is TRUE, 2026-08-02)**. Table G decides; §9 records what was run, by whom, and the teardown. **Registered because Table G's Status row and §9 must move together**: if the premise is ever re-opened (a launchd behavior change), both flip, plus every mirror below
 - [ ] **(+r5, updated 2026-08-02)** **AC6**'s non-claim bullet — it cited Table G's premise as unverified and now must not; and the **Convergence** section heading paragraph, which states the premise's settled status
 - [ ] **(+r6, 2026-08-02, from the light gate)** **Table D's OS-call lists** — D-a's call-count scoping paragraph, D-a's steady-state cell, D-c's `plutil` cell, Table D's RECONCILED preamble bullet ("a later `sync` makes two read-only `print`s"), **Table G's "If P is TRUE" row**, and **AC9's reproduction requirement**. All six state the same two facts — *the `plutil` preflight (`:201-203`) runs before the teardown guard (`:208`)*, and *a full darwin `sync` issues **two** read-only `print`s, one per helper*. Registered because the gate found **two** of them wrong while the others were right: a call list is a contract here, since AC9 makes the implementer copy it into the merge artifact verbatim. The full-path count is the **landed sibling's** canonical property (`done/WP-scheduler-register-replaces-loaded-record.md:1880-1883`) — derive from it, never restate it independently
 - [ ] **(+r5)** Table C's reconciliation preamble (the row-4 / row-5 verdict-change table) and Table D's reconciliation preamble — these are the dated records of the two settled rows that changed outcome; neither may be silently folded into the tables they precede
-- [ ] Implementation notes §D1 (the derivation, the `parts.length < 6` spelling of row 2, the anti-`indexOf` rule from Table E row 4), §"Why the descriptor field stays" (row 6), §"Windows" (row 1), §"Convergence — governed by Table C" (which now cites C and D instead of restating them)
+- [ ] Implementation notes §D1 (the derivation, the `parts.length < 6` spelling of row 2, the anti-`indexOf` rule from Table E row 4), §"Why the descriptor field stays" (row 6), §"Windows" (row 1 — **(+r8)** and, newly registered, **Table B row 1**: §"Windows" names the Windows-reachable call sites, so it moves with every re-anchoring. Round-2 finding 13's sweep found it still on `5f0ffc0`'s `:342`/`:667`, and found it naming **two** sites where Current state §2's sub-table has **three** — `:611`'s hoisted `const node` also feeds the win32 `argline` at `:716`. Both corrected in the finding-13 pass), §"Convergence — governed by Table C" (which now cites C and D instead of restating them)
 - [ ] Design space → option (a) (the alias mechanism is rows 5–6)
 - [ ] Security checklist bullets 1 and 2 (rows 3, 4 and 5 — which of them is the security boundary)
 - [ ] Acceptance criteria AC1 (rows 5–6), AC2 (rows 1–4 via Table F), AC3 (Table B row 1), AC4 (Table B row 2 **and**, as the spec's only seam-free assertion of them, Table A rows 5-6), AC5 (Table A row 6), AC6 (idempotence, and its explicit non-claim about Tables C/D), AC9 (Tables C and D reproduced in the PR) — **(+r5)** AC9 now also mirrors Table C row 5's flipped verdict, Table D's discharged false-success finding and **Table G**'s premise — **which is SETTLED TRUE as of 2026-08-02, so AC9 sub-item (iv) reports it as executed, never as unverified**
@@ -1311,8 +1353,9 @@ precedent this section follows.
 
 **THE DECISION.** Promote both files into the Deliverables table (**D3** and
 **D4**), authorize **exactly** the seven oracle expressions **Table H** enumerates
-— `gen.nodePath()` → `gen.entryNodePath()`, plus at most one added `//` comment
-line per site — and **narrow the not-deliverables paragraph's proof claim** from
+— `gen.nodePath()` → `gen.entryNodePath()`, plus the added `//` comment line(s)
+**Table H**'s comment-budget rule authorizes (at most one per site, two at row 2)
+— and **narrow the not-deliverables paragraph's proof claim** from
 *"nothing else moved"* to *"no assertion changes beyond the enumerated oracle
 swaps"*, which **AC10** asserts and **V8/V8b** check mechanically. **Not one
 assertion, expected value, test name, helper signature, fixture, loader or stdout
@@ -1440,9 +1483,12 @@ must both honor — **all three were re-derived on 2026-08-02 against `1093e51`*
 
 ### Windows — scoped OUT, with the reason recorded
 
-The same `nodePath()` value flows into `windowsCmdArguments` (Current state §2,
-sites `:342` and `:667`), so the Windows generator **does** carry the identical
-pin, and `entryNodePath` is wired into both Windows sites — but Table A row 1
+The same `nodePath()` value flows into `windowsCmdArguments` from **Table B row 1**
+sites **`:536`** (`ensureWindowsCatchup`) and **`:885`** (`repairCatchup`'s win32
+leg), and — via the hoisted `const node` — from **`:611`** (`registerPlatformEntries`,
+whose win32 `argline` is at `:716`; Current state §2's sub-table). So the Windows
+generator **does** carry the identical pin, and `entryNodePath` is wired into every
+Windows-reachable site by D2's six-site swap — but Table A row 1
 makes it a **no-op** there, because a Windows `process.execPath` never starts with
 `/`. That is deliberate, and the exclusion rests on the Windows node layouts
 being stable already: the official MSI and Chocolatey install to
@@ -1887,10 +1933,29 @@ grep -nE "generators|nodePath|entryNodePath" src/scheduler/descriptor.js \
 # REQUIRED after: IDENTICAL.
 
 # V6 (CHANGE — AC8; judged by reading). The new function must add no process,
-#     no timer and no require.
+#     no timer and no require. COMMENT-TOLERANT and CALL-ANCHORED, and both are
+#     required, not conveniences (amended 2026-08-02, round-2 finding 11 — the
+#     same caused-by-conformance class as the sibling's V5/V6b, fixed at 56ee4d0):
+#     the JSDoc this spec MANDATES for `entryNodePath` contains the literal
+#     "NOT for spawning a child of the current process" (see "Exact contracts"),
+#     the bare `spawn` alternative matched that one prose line, and the OK branch
+#     therefore could NEVER print on a branch that followed the spec exactly. Two
+#     narrowings, both applied: drop comment-leading ADDED lines, and anchor the
+#     process alternatives on a CALL (`spawn(`, `spawnSync(`, `exec(`, `execFile(`)
+#     rather than on the bare word. The contract JSDoc must NOT be reworded to
+#     dodge a grep.
 git diff origin/main...HEAD -- src/scheduler/generators.js src/cli/schedule.js \
-  | grep -E "^\+" | grep -nE "require\(|spawn|setInterval|setTimeout|exec\(" || \
-  echo "OK: no new require/spawn/timer in the production diff"
+  | grep -E "^\+" \
+  | grep -vE "^\+[[:space:]]*(\*|//|/\*)" \
+  | grep -nE "require\(|spawn(Sync)?\(|exec(Sync|File|FileSync)?\(|setInterval|setTimeout" \
+  || echo "OK: no new require/spawn/timer in the production diff"
+# The middle filter drops added lines whose first non-blank character starts a
+# comment (` * `, `//`, `/*`) — i.e. prose, the mandated JSDoc included. It does
+# NOT weaken the gate: every real violation is a code line, and
+# `require('child_process')`, `spawn(`, `spawnSync(`, `exec(`, `execFile(`,
+# `setInterval` and `setTimeout` all still trip it. Executed on this branch as a
+# two-sided check — green on the real diff, and matching (no OK line) on a
+# synthetic diff carrying those five code lines.
 # on main: n/a (empty diff). REQUIRED after: the OK line, with no matches above it.
 
 # V8 (CHANGE + PRESERVATION — Table H / AC10 (i) and (ii); judged by reading the

--- a/docs/specs/WP-scheduler-node-path-durability.md
+++ b/docs/specs/WP-scheduler-node-path-durability.md
@@ -1,7 +1,7 @@
 ---
 id: WP-scheduler-node-path-durability
 title: Register scheduler entries against an upgrade-durable node path, not a version-pinned Cellar path
-status: Ready
+status: In-Review
 model: sonnet
 size: M
 depends_on: [WP-scheduler-register-replaces-loaded-record]

--- a/src/cli/schedule.js
+++ b/src/cli/schedule.js
@@ -474,7 +474,7 @@ function ensureCatchup(paths, manifest, loader, uid, jobDigests) {
   // Hoisted so the renderer and `expect` are provably built from the SAME
   // values — two independent calls could otherwise diverge (D3 implementation
   // note), and the skip would then compare against something we never wrote.
-  const node = gen.nodePath();
+  const node = gen.entryNodePath();
   const launcher = launcherPathFor(paths);
   const expectDigest = catchupExpectDigest(paths);
   const content = gen.catchupPlist({
@@ -533,7 +533,7 @@ function ensureWindowsCatchup(paths, manifest, loader, jobDigests) {
   const launchArgs = ['--catch-up', '--expect-digest', catchupExpectDigest(paths)];
   if (typeof jobDigests === 'string' && jobDigests !== '') launchArgs.push('--job-digests', jobDigests);
   const argline = gen.windowsCmdArguments({
-    node: gen.nodePath(),
+    node: gen.entryNodePath(),
     launcher: launcherPathFor(paths),
     home: paths.home,
     core: paths.core,
@@ -608,7 +608,7 @@ function registerPlatform(paths, manifest, o, loader, platform = process.platfor
  *  (same params/returns) — split out so the descriptor capture wraps every
  *  platform branch uniformly (WP-156). */
 function registerPlatformEntries(paths, manifest, o, loader, platform = process.platform) {
-  const node = gen.nodePath();
+  const node = gen.entryNodePath();
   // WP-157: the OS entry invokes the out-of-tree launcher with the descriptor
   // path + expect-digest, not the app bin directly.
   const b = jobLaunchBinding(paths, o.name, platform);
@@ -853,7 +853,7 @@ function repairCatchup(paths, manifest, opts = {}) {
     const observed = probeArgv ? probe(probeArgv, expect, { run: opts.run }) : null;
     if (!probeArgv || !HEAL_SET.has(observed)) return {};
     const content = gen.catchupPlist({
-      node: gen.nodePath(),
+      node: gen.entryNodePath(),
       launcher: launcherPathFor(paths),
       expectDigest: catchupExpectDigest(paths),
       jobDigests,
@@ -882,7 +882,7 @@ function repairCatchup(paths, manifest, opts = {}) {
   const launchArgs = ['--catch-up', '--expect-digest', catchupExpectDigest(paths)];
   if (jobDigests) launchArgs.push('--job-digests', jobDigests);
   const argline = gen.windowsCmdArguments({
-    node: gen.nodePath(),
+    node: gen.entryNodePath(),
     launcher: launcherPathFor(paths),
     home: paths.home,
     core: paths.core,
@@ -967,7 +967,7 @@ function writeCanonicalSchedule(filePath, content) {
 function reloadJob(paths, job, loader, platform) {
   if (!/^[a-z0-9][a-z0-9-]*$/.test(job.name)) return false;
   const { hour, minute } = gen.parseAt(job.at); // throws on a bad time → caller treats as failed
-  const node = gen.nodePath();
+  const node = gen.entryNodePath();
   const b = jobLaunchBinding(paths, job.name, platform);
   const roots = schedulerRootsFor(paths);
 

--- a/src/scheduler/generators.js
+++ b/src/scheduler/generators.js
@@ -22,6 +22,45 @@ function nodePath() {
 }
 
 /**
+ * The absolute node path written into an OS scheduler ENTRY (plist / systemd
+ * unit / Task Scheduler XML) — a string the OS keeps and re-reads days later.
+ * Prefers an upgrade-DURABLE alias over the version-pinned `process.execPath`,
+ * but ONLY when that alias provably resolves to the very interpreter that is
+ * running right now. Every other input, and every failure, returns `execPath`
+ * unchanged (Table A). PURE apart from one `realpath` stat; NEVER throws.
+ *
+ * NOT for spawning a child of the current process — use `nodePath()` there.
+ *
+ * @param {string} [execPath=process.execPath]  absolute path of the running node
+ * @param {{realpath?: (p:string) => string}} [opts]  test seam; default fs.realpathSync
+ * @returns {*} the durable alias (always a string), OR `execPath` returned
+ *   **verbatim** — including when `execPath` is not a string at all, which is a
+ *   caller bug this function passes through rather than masks (Table A row 1).
+ *   The type is deliberately `*` and not `string`: an earlier draft wrote
+ *   `{string}`, which contradicted row 1.
+ */
+function entryNodePath(execPath = process.execPath, opts = {}) {
+  try {
+    if (typeof execPath !== 'string' || execPath[0] !== '/') return execPath;
+    const parts = execPath.split('/');
+    if (parts.length < 6) return execPath;
+    const i = parts.length - 5;
+    if (parts[i] !== 'Cellar') return execPath;
+    const formula = parts[i + 1];
+    if (!/^node(@[0-9]+(\.[0-9]+)*)?$/.test(formula)) return execPath;
+    const version = parts[i + 2];
+    if (!/^[0-9][0-9A-Za-z._+-]*$/.test(version)) return execPath;
+    const prefix = parts.slice(0, i).join('/');
+    const ALIAS = prefix + '/opt/' + formula + '/bin/node';
+    const realpath = typeof opts.realpath === 'function' ? opts.realpath : fs.realpathSync;
+    if (realpath(ALIAS) !== realpath(execPath)) return execPath;
+    return ALIAS;
+  } catch {
+    return execPath;
+  }
+}
+
+/**
  * Absolute path to the STABLE vendored bin (ADR-0013). Survives version bumps:
  * only the `current` symlink's target changes, so scheduler entries are
  * version-independent. @param {import('../core/paths').WienerdogPaths} paths
@@ -1123,6 +1162,7 @@ function teardownCatchup(paths, manifest, opts = {}) {
 
 module.exports = {
   nodePath,
+  entryNodePath,
   wienerdogBin,
   launcherPath,
   launchAgentsDir,

--- a/tests/unit/scheduler-generators.test.js
+++ b/tests/unit/scheduler-generators.test.js
@@ -631,3 +631,196 @@ test('scheduler-generators: windowsCmdArguments clears NODE_OPTIONS/NODE_PATH + 
   // cmd.exe /c wrapper with AutoRun disabled and delayed expansion off.
   assert.match(argline, /^\/d \/s \/v:off \/c "/);
 });
+
+// WP-scheduler-node-path-durability: `entryNodePath` (Table A) is the ENTRY-only
+// role — the durable Homebrew alias, taken ONLY when proven to be the same
+// interpreter that is running. `nodePath()` stays the RUNTIME role (Table B)
+// and is untouched (T4 covers its own preservation implicitly via T5's split).
+
+// T1 — Table A rows 5-6, injected realpath: the three alias positives (Table F
+// rows 13-15), the different-inode negative, and the throwing negative (AC1).
+const T1_POSITIVES = [
+  [
+    '/opt/homebrew/Cellar/node/25.9.0_2/bin/node',
+    '/opt/homebrew/opt/node/bin/node',
+    'Table F row 13 — plain homebrew formula',
+  ],
+  [
+    '/usr/local/Cellar/node@22/22.14.0/bin/node',
+    '/usr/local/opt/node@22/bin/node',
+    'Table F row 14 — versioned formula (node@22)',
+  ],
+  [
+    '/home/linuxbrew/.linuxbrew/Cellar/node/24.0.1/bin/node',
+    '/home/linuxbrew/.linuxbrew/opt/node/bin/node',
+    'Table F row 15 — linuxbrew prefix derivation',
+  ],
+];
+
+test('node-path-durability: entryNodePath takes the alias only when realpath proves it is the same binary (AC1)', () => {
+  const sameRealpath = () => 'SAME-INODE';
+  for (const [input, expected, why] of T1_POSITIVES) {
+    assert.equal(gen.entryNodePath(input, { realpath: sameRealpath }), expected, why);
+  }
+
+  // Different-inode negative: ALIAS and exec resolve to DIFFERENT strings —
+  // the alias currently names a different binary — fail-safe direction wins.
+  const CELLAR = '/opt/homebrew/Cellar/node/25.9.0_2/bin/node';
+  const identityRealpath = (p) => p;
+  assert.equal(
+    gen.entryNodePath(CELLAR, { realpath: identityRealpath }),
+    CELLAR,
+    'different-inode negative must return execPath verbatim'
+  );
+
+  // Throwing negative: realpath throws (ENOENT-shaped) — fail-safe direction wins.
+  const throwingRealpath = () => {
+    throw new Error('ENOENT: no such file or directory');
+  };
+  assert.equal(
+    gen.entryNodePath(CELLAR, { realpath: throwingRealpath }),
+    CELLAR,
+    'a throwing realpath must return execPath verbatim, never throw'
+  );
+});
+
+// T2 — Table A rows 1-4, table-driven over Table F rows 1-12: every fixture
+// returns its input verbatim, and — via the `reached` flag, checked AFTER the
+// call so a swallowed exception cannot mask it — realpath is never invoked
+// (AC2; this is what makes Table E rows 4-6 red).
+const T2_FIXTURES = [
+  [null, null, 'Table F row 1 — not a string (null)'],
+  [42, 42, 'Table F row 2 — not a string (number)'],
+  ['', '', 'Table F row 3 — empty string, no leading /'],
+  [
+    'C:\\Program Files\\nodejs\\node.exe',
+    'C:\\Program Files\\nodejs\\node.exe',
+    'Table F row 4 — Windows path, no leading /',
+  ],
+  ['/usr/bin/node', '/usr/bin/node', 'Table F row 5 — len < 6'],
+  [
+    '/opt/homebrew/Cellar/node/bin/node',
+    '/opt/homebrew/Cellar/node/bin/node',
+    'Table F row 6 — len < 6',
+  ],
+  [
+    '/home/u/.nvm/versions/node/v22.1.0/bin/node',
+    '/home/u/.nvm/versions/node/v22.1.0/bin/node',
+    "Table F row 7 — parts[i] === 'versions', not Cellar",
+  ],
+  [
+    '/opt/homebrew/Cellar/node/25.9.0_2/bin/x/node',
+    '/opt/homebrew/Cellar/node/25.9.0_2/bin/x/node',
+    'Table F row 8 — Cellar at the wrong depth',
+  ],
+  [
+    '/opt/homebrew/Cellar/pnpm/9.0.0/bin/node',
+    '/opt/homebrew/Cellar/pnpm/9.0.0/bin/node',
+    "Table F row 9 — formula 'pnpm' is not a node keg",
+  ],
+  [
+    '/opt/homebrew/Cellar/../1.0.0/bin/node',
+    '/opt/homebrew/Cellar/../1.0.0/bin/node',
+    'Table F row 10 — traversal in the formula position',
+  ],
+  [
+    '/opt/homebrew/Cellar/node/../bin/node',
+    '/opt/homebrew/Cellar/node/../bin/node',
+    'Table F row 11 — traversal in the version position',
+  ],
+  [
+    '/opt/homebrew/Cellar/node/beta/bin/node',
+    '/opt/homebrew/Cellar/node/beta/bin/node',
+    "Table F row 12 — version 'beta' does not start with a digit",
+  ],
+];
+
+test('node-path-durability: entryNodePath returns every non-alias input verbatim, WITHOUT touching the filesystem (AC2)', () => {
+  for (const [input, expected, why] of T2_FIXTURES) {
+    const reached = { realpath: false };
+    const realpath = () => {
+      reached.realpath = true;
+      assert.fail(`AC2: realpath must not be called — ${why}`);
+    };
+    const got = gen.entryNodePath(input, { realpath });
+    assert.equal(got, expected, why);
+    assert.equal(reached.realpath, false, `realpath was reached for: ${why}`);
+  }
+});
+
+// T4 — idempotence (AC6): entryNodePath is deterministic for a fixed
+// filesystem, and rendering the same job twice through a real renderer with
+// entryNodePath's result produces byte-identical strings. AC6 asserts
+// rendered-bytes idempotence ONLY — it says nothing about OS convergence
+// (Table C rows 4 and 7 are the residual on that front, not this test's job).
+test('node-path-durability: entryNodePath is deterministic, and double-rendering a plist with it is byte-identical (AC6)', () => {
+  const opts = { realpath: () => 'SAME-INODE' };
+  const exec = '/opt/homebrew/Cellar/node/25.9.0_2/bin/node';
+
+  const first = gen.entryNodePath(exec, opts);
+  const second = gen.entryNodePath(exec, opts);
+  assert.equal(first, second);
+  assert.equal(first, '/opt/homebrew/opt/node/bin/node');
+
+  const render = () =>
+    gen.launchdPlist({
+      name: 'daily-digest',
+      hour: 7,
+      minute: 0,
+      node: gen.entryNodePath(exec, opts),
+      launcher: LAUNCHER,
+      descriptor: DESC,
+      expectDigest: DIGEST,
+      home: HOME,
+      core: CORE,
+      logDir: '/Users/ada/.wienerdog/logs/daily-digest',
+    });
+  assert.equal(render(), render());
+});
+
+// T5 — the role-split detector (AC4, Table E row 7): a fabricated Homebrew
+// layout, exercised through the REAL fs.realpathSync against a REAL symlink,
+// with NO seam at all. `nodePath()` must still return process.execPath
+// unchanged; `entryNodePath()` must return the durable alias; and the two
+// must differ. POSIX-only — a Windows execPath is a drive-letter path, which
+// Table A row 1 correctly returns unchanged (already covered by AC2/Table F
+// row 4), so gating this test loses no coverage (see AC4).
+const posixOnly = { skip: process.platform === 'win32' };
+
+test('node-path-durability: nodePath() vs entryNodePath() under a fabricated Homebrew layout — the role split, no seam (AC4, Table E row 7)', posixOnly, () => {
+  const fs = require('node:fs');
+  const os = require('node:os');
+  const path = require('node:path');
+
+  // (i) realpath the temp root FIRST — on macOS /tmp is a symlink to
+  // /private/tmp, and building paths off the unresolved root would compare
+  // two different strings later.
+  const TMP = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'wd-nodepath-')));
+  const originalExecPath = process.execPath;
+
+  try {
+    // (iii) the fabricated Cellar binary must be a REAL regular file (never
+    // executed, only realpath'd); TMP/opt must exist as a directory BEFORE
+    // the symlink is created, since fs.symlinkSync does not create parents.
+    const cellarDir = path.join(TMP, 'Cellar', 'node', '9.9.9', 'bin');
+    fs.mkdirSync(cellarDir, { recursive: true });
+    const cellarNode = path.join(cellarDir, 'node');
+    fs.writeFileSync(cellarNode, '');
+
+    fs.mkdirSync(path.join(TMP, 'opt'), { recursive: true });
+    fs.symlinkSync(path.join('..', 'Cellar', 'node', '9.9.9'), path.join(TMP, 'opt', 'node'));
+
+    // (ii) restored in the `finally` below — never leak a fake execPath into
+    // the rest of the suite.
+    Object.defineProperty(process, 'execPath', { value: cellarNode, configurable: true, writable: true });
+
+    assert.equal(gen.nodePath(), process.execPath);
+    const alias = path.join(TMP, 'opt', 'node', 'bin', 'node');
+    assert.equal(gen.entryNodePath(), alias);
+    assert.notEqual(gen.nodePath(), gen.entryNodePath());
+  } finally {
+    Object.defineProperty(process, 'execPath', { value: originalExecPath, configurable: true, writable: true });
+    // (iv) clean the temp dir in the same finally.
+    fs.rmSync(TMP, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/scheduler-schedule.test.js
+++ b/tests/unit/scheduler-schedule.test.js
@@ -1251,7 +1251,8 @@ test('scheduler-schedule: repointSchedules rewrites a stale embedded node path (
   // stable out-of-tree launcher (<core>/launcher/launch.js) rather than a
   // version-scoped bin, so the node path is the absolute value repoint migrates.
   const file = primaryEntryFile(paths, 'dream');
-  const stableNode = gen.nodePath();
+  // ENTRY-role value — the node path the renderer embeds (Table H site 1).
+  const stableNode = gen.entryNodePath();
   const oldNode = '/old/versions/node/v1.0.0/bin/node';
   const stale = fs.readFileSync(file, 'utf8').split(stableNode).join(oldNode);
   assert.ok(stale.includes(oldNode) && !stale.includes(stableNode), 'seeded a stale entry');
@@ -1544,7 +1545,9 @@ function scriptedDarwinLoader(paths, scriptedLabel, responses) {
  *  @param {import('../../src/core/paths').WienerdogPaths} paths
  *  @param {string} name @param {number} hour @param {number} minute */
 function darwinJobExpect(paths, name, hour, minute) {
-  const node = gen.nodePath();
+  // ENTRY-role value: mirrors the value the register site now hoists
+  // (WP-scheduler-node-path-durability, Table B row 1 / Table H site 2).
+  const node = gen.entryNodePath();
   const launcher = gen.launcherPath(paths);
   const descriptorPath = require('../../src/scheduler/descriptor').descriptorPath(paths, name);
   const label = gen.launchdLabel(name);
@@ -1566,7 +1569,8 @@ function darwinJobExpect(paths, name, hour, minute) {
 
 /** The catch-up analogue of `darwinJobExpect`. */
 function darwinCatchupExpect(paths) {
-  const node = gen.nodePath();
+  // ENTRY-role value — see darwinJobExpect (Table H site 3).
+  const node = gen.entryNodePath();
   const launcher = gen.launcherPath(paths);
   const label = 'ai.wienerdog.catchup';
   const plistPath = path.join(paths.home, 'Library', 'LaunchAgents', `${label}.plist`);
@@ -1589,7 +1593,8 @@ function darwinCatchupExpect(paths) {
  *  unfindable job `name` (expectDigest ''), so a test can pre-plant an
  *  UNCHANGED (`changed:false`) fixture. */
 function canonicalJobPlistContent(paths, name, hour, minute) {
-  const node = gen.nodePath();
+  // ENTRY-role value — see darwinJobExpect (Table H site 4).
+  const node = gen.entryNodePath();
   const launcher = gen.launcherPath(paths);
   const descriptorPath = require('../../src/scheduler/descriptor').descriptorPath(paths, name);
   const logDir = path.join(paths.logs, name);
@@ -2067,7 +2072,7 @@ test('verified-register: T3 case (xi) — the catch-up shape: Minute-only, NO Ho
   const manifest = manifestLib.load(paths);
   const expect = darwinCatchupExpect(paths);
   const content = gen.catchupPlist({
-    node: gen.nodePath(), launcher: gen.launcherPath(paths), expectDigest: '', jobDigests: gen.encodeJobDigests({}),
+    node: gen.entryNodePath(), launcher: gen.launcherPath(paths), expectDigest: '', jobDigests: gen.encodeJobDigests({}),
     home: paths.home, core: paths.core, logDir: path.join(paths.logs, 'catchup'),
   });
   fs.mkdirSync(path.dirname(expect.plistPath), { recursive: true });
@@ -2087,7 +2092,7 @@ test('verified-register: T3 case (xii) — the same catch-up record but carrying
   const manifest = manifestLib.load(paths);
   const expect = darwinCatchupExpect(paths);
   const content = gen.catchupPlist({
-    node: gen.nodePath(), launcher: gen.launcherPath(paths), expectDigest: '', jobDigests: gen.encodeJobDigests({}),
+    node: gen.entryNodePath(), launcher: gen.launcherPath(paths), expectDigest: '', jobDigests: gen.encodeJobDigests({}),
     home: paths.home, core: paths.core, logDir: path.join(paths.logs, 'catchup'),
   });
   fs.mkdirSync(path.dirname(expect.plistPath), { recursive: true });

--- a/tests/unit/sync-repoint.test.js
+++ b/tests/unit/sync-repoint.test.js
@@ -147,7 +147,8 @@ test('sync-repoint: rewrites a stale scheduler entry to the vendored bin, then i
 
   await runSync(env);
 
-  const stableNode = gen.nodePath();
+  // ENTRY-role value — the node path the renderer embeds (Table H site 7).
+  const stableNode = gen.entryNodePath();
   const launcher = path.join(paths.core, 'launcher', 'launch.js');
   const after = fs.readFileSync(entry.file, 'utf8');
   assert.ok(after.includes(stableNode), 'entry now targets the current node');


### PR DESCRIPTION
Spec: docs/specs/WP-scheduler-node-path-durability.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
      (`src/scheduler/generators.js`, `src/cli/schedule.js`,
      `tests/unit/scheduler-generators.test.js`, plus — added by the Table H
      boundary amendment `5b5a8c5` — `tests/unit/scheduler-schedule.test.js`
      and `tests/unit/sync-repoint.test.js`, plus the spec file itself:
      the five Deliverables files + spec, nothing else)
- [x] Spec status flipped to In-Review

## Verification output

All commands run from the worktree root at commit `8ecf7f0` (branch
`wp/scheduler-node-path-durability`, based on `179173b`).

```
$ git fetch origin main --quiet     # prerequisite for V5 and V6
```

### V1 (PRESERVATION of `fail 0`; its `pass` count feeds V2)

```
$ npm test -- tests/unit/scheduler-generators.test.js \
              tests/unit/scheduler-schedule.test.js \
              tests/unit/sync-repoint.test.js
ℹ tests 131
ℹ suites 0
ℹ pass 124
ℹ fail 0
ℹ skipped 7
```

*(Re-run 2026-08-02 after the Table H oracle amendment `76d3cff`; the
original run at the implementation commit showed `pass 109 / fail 15` — all
15 later classified as stale oracles and resolved by the amendment, see the
appended section below.)* **`fail 0` preserved; `pass 124` > 120 as
required.**

### V2 (CHANGE — anti-vacuity)

```
$ npm test --silent -- --test-reporter=tap tests/unit/scheduler-generators.test.js \
  | grep -cE "^ok [0-9]+ - node-path-durability: "
4
```

Required and satisfied: V1's `pass 124` strictly greater than 120, `fail`
exactly 0. Anchored subtest count: **4** (required `>= 4`; one each for
T1/T2/T4/T5).

### V3 (CHANGE — Table B row 1 / AC3)

```
$ echo "gen.nodePath():      $(grep -c 'gen\.nodePath()' src/cli/schedule.js)"
gen.nodePath():      0
$ echo "gen.entryNodePath(): $(grep -c 'gen\.entryNodePath()' src/cli/schedule.js)"
gen.entryNodePath(): 6
```

Required: `0 / 6`. On `main`: `6 / 0`. Matches.

### V4 (PRESERVATION — Table B row 2 / AC4)

```
$ echo "run-job.js:         $(grep -c 'gen\.nodePath()' src/cli/run-job.js)"
run-job.js:         2
$ echo "routine-runtime.js: $(grep -c 'gen\.nodePath()' src/core/routine-runtime.js)"
routine-runtime.js: 1
```

Identical to `main`. Preserved.

### V5 (PRESERVATION — Table A row 6 / AC5)

```
$ grep -n "node: process.execPath" src/scheduler/descriptor.js
215:    node: process.execPath,
$ git diff --name-only origin/main...HEAD
docs/specs/WP-scheduler-node-path-durability.md
src/cli/schedule.js
src/scheduler/generators.js
tests/unit/scheduler-generators.test.js
tests/unit/scheduler-schedule.test.js
tests/unit/sync-repoint.test.js
```

*(Re-run 2026-08-02 post-amendment.)* Same single `descriptor.js:215` line
as `main`; `descriptor.js` absent from the name-only diff, which lists
exactly the FIVE Deliverables files plus the spec.

### V5b (PRESERVATION — AC5's zero-coupling argument; EXIT STATUS is the verdict)

```
$ grep -nE "generators|nodePath|entryNodePath" src/scheduler/descriptor.js \
  && echo "FAIL: descriptor.js now references the generator surface" \
  || echo "OK: descriptor.js has zero coupling to generators.js (grep exit 1)"
OK: descriptor.js has zero coupling to generators.js (grep exit 1)
```

Identical to `main`.

### V6 (CHANGE — AC8)

```
$ git diff origin/main...HEAD -- src/scheduler/generators.js src/cli/schedule.js \
  | grep -E "^\+" \
  | grep -vE "^\+[[:space:]]*(\*|//|/\*)" \
  | grep -nE "require\(|spawn(Sync)?\(|exec(Sync|File|FileSync)?\(|setInterval|setTimeout" \
  || echo "OK: no new require/spawn/timer in the production diff"
OK: no new require/spawn/timer in the production diff
```

*(Amended command per `c5ed306` — the original V6's bare `spawn` pattern
false-positived on the spec's own mandated JSDoc line; the amended form is
comment-tolerant and call-anchored, and was verified two-sided at
`c5ed306`: the OK line on the real diff with nothing above it, and a
synthetic control diff carrying five real spawn/require/timer code lines
matched all five while still ignoring the JSDoc line.)* AC8 holds.

### V8 (CHANGE + PRESERVATION — Table H / AC10 (i) and (ii); added by the amendment)

```
$ for f in tests/unit/scheduler-schedule.test.js tests/unit/sync-repoint.test.js; do … done
tests/unit/scheduler-schedule.test.js  main: nodePath=6 entryNodePath=0 execPath=7
tests/unit/scheduler-schedule.test.js  HEAD: nodePath=0 entryNodePath=6 execPath=7
tests/unit/sync-repoint.test.js  main: nodePath=1 entryNodePath=0 execPath=0
tests/unit/sync-repoint.test.js  HEAD: nodePath=0 entryNodePath=1 execPath=0
```

Counts flipped `6/0 → 0/6` and `1/0 → 0/1`; both `execPath` counts
(`7` and `0`) unmoved — the PRESERVATION half holds.

### V8b (PRESERVATION — Table H / AC10 (iii); EXIT STATUS is the verdict)

```
$ git diff origin/main...HEAD -- tests/unit/scheduler-schedule.test.js \
    tests/unit/sync-repoint.test.js | grep … (Table H's filter chain)
OK: every changed line is an enumerated oracle swap or its added comment
```

The OK line printed with nothing above it.

### V7 (boundary gate + full lint/test)

```
$ node scripts/boundary-check.js docs/specs/WP-scheduler-node-path-durability.md \
    src/scheduler/generators.js src/cli/schedule.js \
    tests/unit/scheduler-generators.test.js \
    tests/unit/scheduler-schedule.test.js tests/unit/sync-repoint.test.js
(exit 0, no output — all FIVE Deliverables files named, per amended DoD 10)

$ npm run lint
markdownlint-cli2 v0.23.0 (markdownlint v0.41.0)
Finding: docs/**/*.md skills/**/*.md templates/**/*.md tests/**/*.md *.md
Linting: 386 file(s)
Summary: 0 error(s)
--- shellcheck ---
--- PSScriptAnalyzer ---
--- frontmatter check ---
frontmatter check passed: 209 spec(s), 4 agent(s)
lint passed

$ npm test
ℹ tests 1901
ℹ suites 0
ℹ pass 1892
ℹ fail 0
ℹ skipped 9
```

*(Re-run 2026-08-02 post-amendment; the pre-amendment run showed the same
15 failures as the old V1 — now zero.)* Full suite green; `npm run lint`
fully green.

### Table E — mutation matrix (all 8 rows demonstrated RED, then restored byte-for-byte)

Each row: mutation applied → named test/command run with an anchored
pattern selecting exactly one subtest (or read, for V3) → confirmed RED →
file restored (`diff` against the pre-mutation copy confirms byte-identity
after each row and at the end).

| # | Mutation | Test run | Result |
|---|---|---|---|
| 1 | `return execPath;` as entryNodePath's first statement | T1 (`--test-name-pattern "takes the alias only when realpath proves"`) | RED — `AssertionError: expected '/opt/homebrew/opt/node/bin/node', actual '/opt/homebrew/Cellar/node/25.9.0_2/bin/node'` |
| 2 | delete `RP(ALIAS) !== RP(exec)`, keep `RP(ALIAS)` inside `try` | T1 (same pattern) | RED — `AssertionError: expected the Cellar path (different-inode negative), actual the alias` |
| 3 | change `catch` to `return ALIAS;` (hoisted) | T1 (same pattern) | RED — `AssertionError: expected the Cellar path (throwing negative), actual the alias` |
| 4 | `parts[i] !== 'Cellar'` → `!execPath.includes('/Cellar/')`, `i` via `indexOf` | T2 (`--test-name-pattern "returns every non-alias input verbatim"`) | RED — `realpath was reached for: Table F row 8 — Cellar at the wrong depth` (`reached.realpath` flag caught it even though the injected `assert.fail()` throw is swallowed by entryNodePath's own catch — see note below) |
| 5 | delete the `formula` regex test | T2 (same pattern) | RED — `realpath was reached for: Table F row 9 — formula 'pnpm' is not a node keg` |
| 6 | delete the `version` regex test | T2 (same pattern) | RED — `realpath was reached for: Table F row 11 — traversal in the version position` |
| 7 | `nodePath()`'s body → `return entryNodePath();` | T5 (`--test-name-pattern "the role split, no seam"`) | RED — `AssertionError: expected .../Cellar/node/9.9.9/bin/node, actual .../opt/node/bin/node` — demonstrated on **macOS** (this machine) |
| 8 | revert `schedule.js:611` to `const node = gen.nodePath();` | V3 (read the two counts) | RED by reading — counts become `5 / 1` (required: `0 / 6`) |

**Note on rows 4-6's test design.** `entryNodePath` is contracted to
**never throw** (the whole body is wrapped in one `try {…} catch { return
execPath; }`), so an injected `realpath` that calls `assert.fail()` when
reached would have its `AssertionError` **silently swallowed** by that
same catch — meaning a naive "does the return value still equal the
fixture" check cannot distinguish the mutated code (which reaches
`realpath`, throws, gets caught, and returns `execPath` anyway — the same
value) from the correct code (which never calls `realpath` at all). T2
therefore also tracks a `reached` flag, set as a side effect **before**
the injected `assert.fail()` throws, and asserts it is still `false`
**after** the call returns — a side effect survives being caught, so this
correctly detects any code path that reaches row 5, regardless of whether
the exception itself propagates.

## Table C — post-`sync` convergence, by platform and starting state (canonical)

*(Reproduced verbatim from the spec, including its RECONCILED preamble and
Row 5's superseded-text retention, per AC9.)*

This table was prose in round 1. It is now a canonical contract table, because the
round-1 acceptance criteria asserted file idempotence and let a reader infer
scheduler-state convergence from it — which rows 4 and 5 showed is false.

**Rows 2 and 3 were one fused "linux / windows" row until round 3.** They are
split because the two platforms behave *differently*. Do not re-fuse them.

> **RECONCILED 2026-08-02 against `1093e51` (PR #140, merge `7b22d71`) — read this
> before the table.** The prerequisite
> `WP-scheduler-register-replaces-loaded-record` **landed**, and it changed the
> mechanism behind three of these rows. The verdicts below are **re-derived from
> the code at `1093e51`**, not carried forward. Two rows changed outcome:
>
> | Row | Verdict at `5f0ffc0` | Verdict at `1093e51` | Why it changed |
> |---|---|---|---|
> | 4 (linux, degraded reload) | **NO**, and *silently* reported as success | **NO**, but **LOUD and retried on every `sync`** | `loaded = reloadOk && enableOk` (`:681`); reload hoisted out of `if (changed)` (`:671`) |
> | 5 (macOS, healthy loaded record) | **NO**, and silently reported as success | **YES — converges on the FIRST `sync`** | `ensureDarwinEntryRegistered` replaces on `'mismatch-fatal'`, and this WP's change *is* a FATAL-tier change (Current state §8) |
>
> **Row 5 flipping is a settled contract row changing outcome, so it is recorded
> as a reconciliation and not rewritten in place.** The old row-5 text is retained
> verbatim in the row's own cell. Nothing about `entryNodePath` or the six swaps
> changed; only what the OS does with the bytes afterwards.
>
> **Row 5 rests on Table G, and Table G is SETTLED.** Row 5's convergence requires
> launchd to echo the symlinked `ProgramArguments[0]` verbatim into `program`
> rather than realpath-resolving it. That premise was **executed and confirmed
> TRUE on 2026-08-02** (Current state §9 — scratch label with a discriminating
> literal ≠ realpath path; full teardown). **Row 5 is therefore an observed
> outcome, not a conditional one.**
>
> **Row 7 is NEW.** It is the residual that survives the sibling's landing.

| # | Platform + starting state | Unit/plist/XML on disk | What the OS actually holds afterwards | Converged? |
|---|---------------------------|------------------------|---------------------------------------|-----------|
| 1 | any platform, job registered for the first time after this ships | durable path | durable path | **yes** |
| 2 | **windows (schtasks)**, existing job, first `sync` | durable path | durable path — `ensureWindowsTaskRegistered` (**`schedule.js:412-417`**, MOVED from `:240-245`; body unchanged by PR #140) forces `schtasks /create /f` whenever `o.changed`, and even when unchanged it re-reads the LOADED task and force-creates on any mismatch | **yes** |
| 3 | **linux (systemd)**, existing job, first `sync`, `daemon-reload` **succeeds** | durable path | durable path — systemd re-reads the unit files, then `systemctl --user enable --now` (**`schedule.js:680`**, MOVED from `:466`) starts the reloaded timer | **yes** |
| 4 | **linux (systemd)**, existing job, first `sync`, `daemon-reload` **degraded** | durable path | **possibly still the pinned Cellar path** — systemd may be serving stale units. *(At `5f0ffc0`: "`daemon-reload` is explicitly best-effort and **not gated**; only `enable --now` counts … while `loaded` is reported `true`". **That is no longer the code.** At `1093e51` `loaded = reloadOk && enableOk` (`:681`), so a degraded reload reports `loaded:false`, and reload+enable are **hoisted out of `if (changed)`** (`:666-681`) so both are **retried on every later `sync`** until the reload succeeds.)* | **NO** — but no longer silent, and self-retrying (Table D-b) |
| 5 | **macOS, existing job whose loaded record is healthy** | durable path | **the durable path, on the first `sync`** — `ensureEntry` reports `changed`, the readback grades the loaded record `'mismatch-fatal'` (this WP changes `expect.argv[0]`, which is compared **twice** at FATAL tier: as `arguments[0]` and as `program` — Current state §8), the non-destructive `bootstrap` is refused, `plutil -lint` passes, and `bootout` + `bootstrap` + `verifyLoaded()` replace the record. *(At `5f0ffc0` this row read: "**still the pinned Cellar path** — the bare `launchctl bootstrap` is refused because the label is already loaded". The bare bootstrap no longer exists.)* | **YES** (changed 2026-08-02, PR #140) |
| 6 | macOS, existing job, after the Cellar path is deleted | durable path | durable path — step 8b grades the entry `mismatched`, it enters the heal set, `reloadJob` → `darwinReplaceEntry` boots out and re-bootstraps | **yes**, one upgrade late — **now a backstop rather than the primary path**, since row 5 converges at the first `sync` |
| 7 | **NEW (2026-08-02) — macOS, existing job whose `launchctl print` readback is `'indeterminate'`** (degraded, truncated or format-skewed output: any of `arguments`, calendar, `environment`, `path`, `program`, either log path or `spawn type` fails to parse — `schedule.js:124-130`) | durable path | **still the pinned Cellar path** — `'indeterminate'` is the *absence of evidence*, so it buys the non-destructive `bootstrap` attempt (refused on a loaded label) and **explicitly never authorizes a teardown** (`:208`, sibling Table A1) | **NO** — but reported `loaded:false` and **re-attempted on every `sync`** (the readback is ungated by `changed`), so it is loud and never falsely converged |

**Row 6 has NO Linux analogue.** `deriveIdentityArgv` returns
`{kind:'systemd', argv:null}` for a `.timer` basename — the identity query is
*declared unimplemented* (`generators.js:178-180` — **unchanged at `1093e51`**) —
so `defaultProbe` step 6 returns `'unknown'`, which is **not** in `HEAL_SET`
(`status.js:80`). The shipped test
`entry-identity: a systemd entry yields unknown, not a health claim`
(`tests/unit/scheduler-entry-identity.test.js:423-430` — unchanged) pins exactly
that. A Linux entry therefore never enters the heal set, never reaches step 8b's
execution-position existence check, and never self-repairs the way row 6 does.

**Be precise about that — `reloadJob`'s linux `daemon-reload`
(`schedule.js:995`, MOVED from `:777`) IS reachable on Linux, just never for row
4.** A timer that is absent or inactive makes the step-3 probe
(`systemctl --user is-active …`) exit non-zero, so `defaultProbe` step 4 returns
`'missing'`, which **is** in `HEAL_SET`, and `reloadJob` runs. What row 4 describes
is an **active** timer running from stale units: `is-active` exits 0, so step 4
does not apply, and the entry short-circuits at step 6 to `'unknown'` before any
identity or execution-position check. So Linux has a heal path for *absent*
timers and **no** heal path for *stale-but-running* ones. **What PR #140 added is
not a heal path but a `register` path that keeps retrying and keeps reporting** —
which is why row 4 is no longer the silent failure it was.

## Table D — what `wienerdog sync` REPORTS in Table C rows 4, 5 and 7 (canonical)

*(Reproduced verbatim from the spec, including D-a's call-count scoping
paragraph and both dated correction notes, per AC9.)*

> **RECONCILED 2026-08-02 (PR #140). This table's central finding is DISCHARGED.**
> At `5f0ffc0` both sub-tables ended in a **false success**: a later `sync` made
> **zero** OS calls, told the user **nothing**, and left the pinned path in place.
> That row — *"the last row of each sub-table is the false success"* — was the
> substance of the round-1 and round-2 blocking findings and **the entire reason
> this WP carried a dispatch blocker**.
>
> **Both false-success rows are gone at `1093e51`**, by two independent
> mechanisms, neither of which is in this WP's Deliverables:
> - **macOS:** the readback runs on **every** register, ungated by `changed`, so
>   there is no "bytes now identical ⇒ zero OS calls" path any more. A later `sync`
>   makes **two** read-only `print`s (per-job + catch-up — see D-a's call-count
>   scoping), grades both `'match'`, and is correct to be silent.
> - **linux:** `daemon-reload` + `enable --now` are **hoisted out of
>   `if (changed)`**, so a degraded reload re-warns and re-reports **on every
>   `sync`**, never once.
>
> The old rows are retained below, struck through in prose rather than deleted, so
> the record shows what was fixed rather than implying it was never true.

Every literal below is quoted **byte-exact from source at `1093e51`** (round 2
shipped two that were not, and AC9 copies this table into the merge artifact).

**D-a — macOS (Table C row 5), at `1093e51`.**

**Call-count scoping — read before reproducing this table (CORRECTED 2026-08-02).**
The **OS calls** column below is scoped to the **per-job helper**
(`ensureDarwinEntryRegistered`, one invocation), **not** to a whole `sync` run.
That is deliberate, and it follows the landed sibling's own canonical rule
(`docs/specs/done/WP-scheduler-register-replaces-loaded-record.md:1880-1883`),
quoted verbatim:

> *"A full darwin `registerPlatform` on an unchanged healthy install therefore
> issues **two** read-only `print`s and zero mutating calls. Assert per helper, or
> assert two through the full path — never 'exactly one' through the full path."*

The multiplier is `registerPlatformEntries`, which registers the per-job entry and
then calls `ensureCatchup` (**`schedule.js:646`**; `loaded: loaded && cu.loaded` at
`:647`), and `ensureCatchup` performs its **own** readback via its own
`ensureDarwinEntryRegistered` call (`:495`). **So multiply every row's call list by
the two darwin entries — per-job and catch-up — to get the full-`sync` figure.**
For the steady state that is **two read-only `print`s and zero mutating calls**.

| Run | Readback verdict | OS calls (**per-job helper only** — see scoping above) | What the user is told | Reality |
|-----|------------------|--------------------------------------------------------|-----------------------|---------|
| first `sync` after this ships | `'mismatch-fatal'` (`program` **and** `arguments[0]` both differ) | `print`; `bootstrap` (refused); `/usr/bin/plutil -lint` (passes); `bootout`; `bootstrap` (exit 0); `print` again to verify | **nothing** — `loaded` is `true`, so no notice fires | **launchd holds the DURABLE path** |
| `doctor`, immediately after | — | read-only probe | `[ok] scheduled job 'dream' is loaded (launchd)` (`status.js:283` message + `doctor.js:317` `[${status}] ${msg}` wrapper — **including the `(launchd)` suffix**; both lines unchanged at `1093e51`) | true, and now for the right reason |
| **every later `sync`** | `'match'` | **one read-only `print`, zero mutations** (`:184`) — **two `print`s through the full `sync` path** (per-job + catch-up), still zero mutations | **nothing** | **launchd holds the durable path** |

*(Corrected 2026-08-02: the "every later `sync`" cell previously read "**one
read-only `print`, zero mutations**" with no scoping note, which under-counts a
`sync` run and is exactly the "'exactly one' through the full path" claim the
sibling forbids. The zero-mutations half was and is correct.)*

*Superseded `5f0ffc0` row, retained:* ~~"every later `sync`: `changed = false`,
**zero** OS calls, **nothing** told, **launchd still holds the pinned path**."~~

**D-b — Linux, degraded `daemon-reload` (Table C row 4), at `1093e51`.**

| Run | OS calls | What the user is told | Reality |
|-----|----------|-----------------------|---------|
| first `sync` after this ships | `daemon-reload` (degraded) then `enable --now` | stderr line `wienerdog: warning — 'systemctl --user daemon-reload' returned <status>; the timer may load from stale units. Run 'wienerdog doctor'.` (**`schedule.js:678`**, MOVED from `:464`) **AND** the `repointSchedules` notice `"<job>" schedule file written but the OS scheduler did not accept it — run 'wienerdog doctor'.` (**`schedule.js:802`**, MOVED from `:584`, **including the trailing period**), because `loaded` is now `false` (`:681`, `:801-803`) | systemd may hold stale units |
| `doctor`, immediately after | read-only probe | **nothing about this entry** — a systemd entry probes `unknown`, which `doctorSchedulerChecks` does not report as a health claim. **This gap is unchanged by PR #140 and is a recorded residual** | same |
| **every later `sync`** | `daemon-reload` **and** `enable --now`, **again** — both hoisted out of `if (changed)` (`:666-681`) | **the same warning and the same notice, every time**, until the reload succeeds | same, and visibly so |

*Superseded `5f0ffc0` row, retained:* ~~"every later `sync`: `changed = false`,
**zero** OS calls, **nothing** told … and **no** `repointSchedules` notice, because
`loaded` is `true`."~~

**D-c — macOS, `'indeterminate'` readback (Table C row 7), at `1093e51`. NEW.**
Same per-job-helper call-count scoping as D-a.

| Run | Readback verdict | OS calls (**per-job helper only**) | What the user is told | Reality |
|-----|------------------|-------------------------------------|-----------------------|---------|
| **every `sync`**, first and later alike | `'indeterminate'` | `print`; `bootstrap` (refused); `/usr/bin/plutil -lint` (**runs** — the preflight at `:201-203` precedes the teardown guard; skipped only when `/usr/bin/plutil` is absent, since it is gated on `fs.existsSync(PLUTIL)`). **No `bootout`** — `:208` returns before it | the `repointSchedules` notice, byte-exact as quoted in D-b, **on every run** | launchd holds the pinned path |

*(Corrected 2026-08-02: this cell previously read "**No `plutil`, no `bootout`** —
`:208` returns before them". **The `plutil` half was false.** The preflight is at
`:201-203` and the teardown guard at `:208`, so on a real macOS host the lint
**does** run on the `'indeterminate'` path — only the `bootout` half was right.
This also reconciles D-c with D-a's own first-`sync` row, which sequences the lint
correctly.)*

**What this WP may now claim, and what it still may not.** It **may** say the
macOS non-convergence of Table C row 5 is closed, and that no `sync` reports a
false success on either platform. It **may not** say the incident class is closed:
Table C rows 4 and 7 still do not converge — they are merely loud now — and AC9's
prohibition on "closes the class" stands unchanged.

## AC9's four required statements

(i) Table C rows **4** (linux, degraded reload) and **7** (macOS,
`'indeterminate'` readback) do **not** converge.

(ii) Table C row **5 now DOES converge**, on the first `sync`, because of
PR #140 — the sibling's fix, **not** this WP's achievement.

(iii) Table D's false-success rows are **gone on both platforms**, so no
`sync` reports a silent success — while rows 4 and 7 remain non-convergent,
merely loud.

(iv) **Table G's premise is SETTLED — P is TRUE**, executed 2026-08-02
pre-implementation (Current state §9), so row 5's convergence rests on an
observed fact rather than an assumption.

This PR does **not** claim the incident class is closed, and contains no
occurrence of the phrase "closes the class" or any equivalent.

## Definition of done item 9 — live smoke test

**Pending-orchestrator.** Per the dispatch brief, this live smoke test
(`wienerdog sync` on a real Homebrew macOS install, then
`launchctl print gui/$(id -u)/ai.wienerdog.dream | grep program`, then a
second `sync` confirming no mutation) is run by the orchestrator against
this branch before merge, not by the implementer. Not run here.

That said, this exact machine **is** a real Homebrew macOS install with the
`ai.wienerdog.dream` job already registered and loaded (see "Discovered
issues" below — the local test failures are direct evidence the alias
substitution is live and working on it), so the orchestrator's smoke test
has a real, non-synthetic install to run against.

## Decisions made

- **T2's mutation-detection mechanism.** The spec's AC2 says T2 uses "an
  injected `realpath` that calls `assert.fail()` if reached." A literal
  reading — the injected function's `AssertionError` propagating out —
  cannot work, because `entryNodePath` is contracted to catch every
  exception and return `execPath` (Table A row 5's fail-safe direction),
  so the throw is silently swallowed and the return value is unchanged
  either way, mutated or not. I resolved this by having the injected
  `realpath` set a `reached` flag (a side effect, which survives being
  caught) **before** calling `assert.fail()`, and asserting `reached ===
  false` after `entryNodePath` returns. This is the simplest fix that
  preserves the spec's stated intent (a realpath that must not be reached)
  and demonstrably makes Table E rows 4-6 RED (see the mutation matrix
  above) — a literal `assert.fail()`-only realpath would not have.
- **T1/T5's realpath fixtures.** Table A row 5 fixtures use `() => 'SAME-
  INODE'` (positives) and `(p) => p` (different-inode negative) as the
  simplest strings that produce the required equal/unequal comparison,
  since the exact string returned by a real `fs.realpathSync` is not part
  of the contract — only equality/inequality is.
- **Everything else** followed the spec's Exact contracts / Implementation
  notes / Table A pseudocode directly; no other ambiguity required a call.

## Discovered issues (out of scope, not fixed)

> **SUPERSEDED 2026-08-02 by the Table H boundary amendment (`5b5a8c5` +
> `76d3cff`) — retained as the discovery record only.** Everything below was
> written at the implementation commit, BEFORE the amendment. Three of its
> statements no longer hold: (1) both files ARE now Deliverables (D3/D4);
> (2) the seven oracle expressions WERE subsequently changed (by the
> architect's `76d3cff`, under Table H's bounded enumeration — "I did not
> touch either file" was true of the implementation commit only); (3) the
> quoted "must pass unmodified — proof nothing else moved" role is
> WITHDRAWN for these two files and replaced by the narrowed claim: *no
> assertion changes beyond Table H's enumerated oracle swaps* (verified by
> V8/V8b above). The CI-safety reasoning below was confirmed correct by the
> actual CI run (green on both platforms at the implementation commit).

**15 pre-existing tests in `tests/unit/scheduler-schedule.test.js` (14) and
`tests/unit/sync-repoint.test.js` (1) — both explicitly NOT deliverables —
fail on THIS machine after D1/D2, for one shared reason that is not a code
defect in this WP.**

This machine is a real Homebrew macOS install whose `process.execPath`
(`/opt/homebrew/Cellar/node/25.9.0_2/bin/node`) has a currently-working
`/opt/homebrew/opt/node` alias resolving to the same inode — i.e., exactly
the positive case Table A row 6 exists to take, and exactly the layout
measured in this spec's own Current state §4 (this is presumably the same
machine the spec was authored and last re-verified against). After D1/D2,
every freshly-registered darwin entry on this machine legitimately embeds
the alias (`/opt/homebrew/opt/node/bin/node`), not `process.execPath`
verbatim — this is the WP working exactly as designed.

The 15 failing tests (all in the two named NOT-deliverable files) use
`gen.nodePath()` (i.e., the unchanged `process.execPath`) as their own test
oracle for "what a freshly-written entry embeds" — an assumption that held
universally on `main` (where `entryNodePath` did not exist and every ENTRY
site used `gen.nodePath()`), and that this WP's entire purpose is to
invalidate on hosts exactly like this one. Two concrete examples:

- `tests/unit/sync-repoint.test.js:150-153` computes `stableNode =
  gen.nodePath()` and asserts the post-sync file `.includes(stableNode)`.
  On this host the file now contains the alias instead, so the assertion
  fails.
- `tests/unit/scheduler-schedule.test.js`'s `darwinJobExpect`/
  `darwinCatchupExpect` helpers (`:1546-1580`) build the `expect.argv[0]`
  fixture from `gen.nodePath()`, then compare it against
  `registerPlatformEntries`'s real output, which now uses
  `gen.entryNodePath()`. On this host the two diverge, which cascades
  through the 13 other `verified-register:`/`scheduler-schedule:` cases
  that reuse those helpers.

**I did not touch either file** — both are named in the spec's Deliverables
table as explicitly NOT deliverables, with the note that their assertions
"must pass unmodified — that is this WP's proof that nothing else moved."
That proof holds for every OTHER file in the repo (the full `npm test`
run above shows exactly these same 15 failures and zero others across
1901 tests), but not for these two, on this specific host shape.

**Why this is very likely CI-safe.** `.github/workflows/ci.yml`'s `test`
job uses `actions/setup-node@v4` on both `ubuntu-latest` and
`macos-latest`, which installs a Node.js build into the GitHub Actions
tool cache (a path with no `/Cellar/` segment), not via Homebrew. On such
a runner, `entryNodePath()` short-circuits at Table A row 2 and returns
`process.execPath` unchanged — identical to `gen.nodePath()` — so these 15
tests' assumption holds and they should all pass in CI. I cannot confirm
this directly (no CI access from here); flagging so the actual CI run on
this PR is checked before merge, and so a reviewer isn't surprised by the
local failure count.

**Not fixed, per CLAUDE.md ("touch only Deliverables files... found
something else broken? note it, don't fix it").** If confirmed CI-safe,
no action may be needed at all — the two files' assumption already breaks
on any real Homebrew install with a working alias, and that is precisely
the class of host this WP is written for. If it is NOT CI-safe, the fix
belongs in those two NOT-deliverable files (update their `stableNode`/
`expect` oracles to `gen.entryNodePath()`, or inject a `realpath` seam
that forces the negative case), which is out of this WP's scope to do
unilaterally.

## Lessons

- WP-scheduler-node-path-durability: `entryNodePath`'s never-throw contract
  (whole body in one `try {...} catch { return execPath; }`) means an
  injected `realpath` that calls `assert.fail()` when reached has its
  exception silently swallowed — the return value doesn't change, so a
  naive "assert equal to the unchanged fixture" test cannot detect the
  mutation. Detecting "was the filesystem seam reached at all" requires an
  out-of-band flag set as a side effect before the throw, checked after the
  call returns, not the throw itself.
- WP-scheduler-node-path-durability: a spec measured and tested against a
  real Homebrew macOS dev machine can bake host-specific assumptions into
  sibling test files that then become "must pass unmodified" NOT-deliverable
  constraints — assumptions that this exact kind of change (an ENTRY path
  now correctly differing from `process.execPath` on that same host shape)
  legitimately breaks. Worth a spec-authoring note next time: state whether
  a NOT-deliverable file's assertions were actually re-run post-implementation
  on the measured host, or only checked against unmodified `main`.
- WP-scheduler-node-path-durability: `git diff origin/main...HEAD` is empty
  until something is actually committed to the branch — V5/V6's diff-based
  commands need to run AFTER the commit, not against a dirty worktree, or
  they silently report "no changes" instead of the real diff.

Generated-by: claude-sonnet-5


---

## Post-open spec amendment — Table H, the host-shape oracle collision (2026-08-02, commits `5b5a8c5` + `76d3cff`)

The 15 local failures flagged above were routed to wd-architect and resolved
as a **spec-boundary amendment** (the same defect class as the sibling's
D6/T8 NOOP collision): all 15 classified as **stale oracles, zero behavioral
regressions**, tracing to exactly seven expressions that used
`gen.nodePath()` (= `process.execPath`) as the oracle for what a
freshly-written entry embeds — an assumption this WP exists to invalidate on
Homebrew hosts. The spec's proof mechanism was **host-shape-dependent**:
green on CI runners (where the alias never resolves to the runner's node,
so `entryNodePath` falls back and the change is inert) and red on the exact
machine class the WP protects. That asymmetry was the defect; the reds were
its symptom.

- New canonical **Table H** enumerates the seven authorized oracle swaps
  (six in `scheduler-schedule.test.js`, one in `sync-repoint.test.js`);
  both files promoted to Deliverables (D3/T6, D4/T7); anything outside the
  table is out of boundary, mechanically pinned by new V8/V8b.
- One of the seven (T3 case xii) was **green for the wrong reason** — a
  stale node supplied a second reason to attempt, so the test no longer
  isolated the `Hour`-key rule its name pins. Repaired and recorded.
- Rejected alternatives recorded: deriving oracles from rendered output
  (tautologizes the FATAL-tier argv comparison), literals/host probes
  (reintroduce host dependence), leaving CI-green/local-red (ships a suite
  that fails on the owner's production machine), and a test-only escape
  hatch in `entryNodePath` (same rejection logic as the sibling's refusal
  to teach the NOOP seam to fabricate readbacks).
- **Narrowed proof claim (per amended DoD 10):** the former blanket
  "non-deliverable assertions pass unmodified" proof is withdrawn for these
  two files and replaced by: *no assertion changes beyond Table H's
  enumerated oracle swaps* — verified by V8/V8b (main-vs-branch token
  counts + per-changed-line check, both green). All seven
  `process.execPath` RUNTIME-role occurrences untouched.
- Also folded in: PR #144's deferred citation nit (`:1881-1883` →
  `:1880-1883` at all three sites).

Post-amendment verification on a real Homebrew macOS host (per amended
DoD 1): both files green; **full `npm test`: 1901 tests, 1892 pass, 0 fail,
9 skipped**; lint green; boundary-check exit 0 (with a non-vacuity control
proving it still rejects out-of-table files).

**Round-2 gate follow-up (`c5ed306`, spec-only):** V6 amended
(comment-tolerant + call-anchored — the original could never print its OK
line against a conformant diff); Table H's comment-budget prose reconciled
with its own branch-column arithmetic (two-line comment authorized where
the citation needs it); Table B re-anchored to `1093e51` (dead `5f0ffc0`
numbers retained as provenance) plus a fourth stale mirror found and fixed
(§Windows: three Windows-reachable sites, not two — `:611`'s hoisted
`const node` feeds the win32 argline at `:716`); `(+r8)` rule recorded
("when a line-number entry moves, Table B moves first"). Reviewer verified
all four against the tree; final verdict **APPROVE**.


---

## DoD item 9 — live smoke test (orchestrator-run, 2026-08-02, branch @ `c5ed306`)

Real Homebrew macOS host, real launchd, branch code (`node <worktree>/bin/wienerdog.js sync`):

- **Baseline (pre-smoke):** `launchctl print gui/501/ai.wienerdog.dream` showed
  `program = /opt/homebrew/Cellar/node/25.9.0_2/bin/node` — the pinned-path
  incident shape this WP fixes, live in production.
- **Sync 1 (the transition):** completed quietly ("repointed 1 schedule(s)",
  no `did not accept` notice). Post-sync readback: `program =
  /opt/homebrew/opt/node/bin/node` AND `arguments[0]` = the alias, on BOTH
  `ai.wienerdog.dream` and `ai.wienerdog.catchup`. The fatal-mismatch
  replace path executed and converged in one run.
- **Sync 2 (the verified skip):** zero schedule-related output, and the full
  `launchctl print` record is **byte-identical** before/after — zero
  launchctl mutations, exactly Table C row 5's steady state and Table G's
  P-TRUE prediction.

DoD 9 satisfied. Double gate complete (Codex: approve, no material
findings; wd-reviewer: two rounds → APPROVE). Merging under the owner's
session merge authorization.
