### PR TITLE
docs(specs): flip WP-scheduler-node-path-durability to Done (post-merge housekeeping)

### DIFF
--- a/docs/specs/done/WP-scheduler-node-path-durability.md
+++ b/docs/specs/done/WP-scheduler-node-path-durability.md
@@ -1,7 +1,7 @@
 ---
 id: WP-scheduler-node-path-durability
 title: Register scheduler entries against an upgrade-durable node path, not a version-pinned Cellar path
-status: In-Review
+status: Done
 model: sonnet
 size: M
 depends_on: [WP-scheduler-register-replaces-loaded-record]


### PR DESCRIPTION
One-file post-merge housekeeping: PR #145 merged as `19ef264` and verified (full suite on main: 1892 pass / 0 fail; DoD 9 live smoke passed pre-merge — one-sync convergence to the durable alias, second-sync verified skip with a byte-identical loaded record). Spec flips `In-Review` → `Done` and moves to `docs/specs/done/`. Lint + frontmatter green.

This closes the scheduler node-path track end-to-end: ADR-0028 signature (#138) → sibling verified-registration (#140/#143) → pre-dispatch reconciliation (#144) → implementation (#145).

---
Generated-by: Claude Fable 5 (claude-fable-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THDN8Y8Syk7Lft4GDpBBhP