### PR TITLE
fix(uninstall): prove a managed-block separator's position before stripping it (WP-managed-block-insertion-anchor)

### DIFF
--- a/docs/specs/WP-managed-block-insertion-anchor.md
+++ b/docs/specs/WP-managed-block-insertion-anchor.md
@@ -1,7 +1,7 @@
 ---
 id: WP-managed-block-insertion-anchor
 title: Record a managed-block insertion anchor at forward time so uninstall strips only separators it can prove are ours
-status: Ready
+status: In-Review
 model: opus
 size: M
 depends_on: [WP-147]

--- a/src/adapters/shared.js
+++ b/src/adapters/shared.js
@@ -2,7 +2,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { hashDir } = require('../core/manifest');
+const { hashDir, insertionAnchor } = require('../core/manifest');
 const { WienerdogError } = require('../core/errors');
 
 const BEGIN = '<!-- wienerdog:begin -->';
@@ -109,8 +109,12 @@ function recordSettingsEntry(manifest, settingsPath, createdFile, commands) {
  *  @param {boolean} inserted TRUE only on the two branches that actually WRITE
  *  separators (createdFile, append). The replace branch splices between existing
  *  sentinels and writes none, so it passes false and the recorded separators
- *  are left exactly as they are. */
-function recordManagedBlock(manifest, mdPath, createdFile, sepBefore, sepAfter, inserted) {
+ *  are left exactly as they are.
+ *  @param {string|null} anchorBefore the insertionAnchor() of the content that
+ *  immediately preceded sepBefore. Moves with sepBefore/sepAfter under the SAME
+ *  update-on-insert rule — the three fields are one fact and must never be
+ *  written apart (Table P rule P-1). */
+function recordManagedBlock(manifest, mdPath, createdFile, sepBefore, sepAfter, inserted, anchorBefore) {
   if (!manifest) return;
   if (!Array.isArray(manifest.entries)) manifest.entries = [];
   const existing = manifest.entries.find((e) => e.kind === 'managed-block' && e.path === mdPath);
@@ -123,6 +127,7 @@ function recordManagedBlock(manifest, mdPath, createdFile, sepBefore, sepAfter, 
   if (inserted) {
     entry.sepBefore = sepBefore;
     entry.sepAfter = sepAfter;
+    entry.anchorBefore = anchorBefore;
   }
   if (!existing) manifest.entries.push(entry);
 }
@@ -176,7 +181,7 @@ function applyManagedBlock(mdPath, digest, dryRun, manifest, out) {
       fs.mkdirSync(path.dirname(mdPath), { recursive: true });
       fs.writeFileSync(mdPath, next);
     }
-    recordManagedBlock(manifest, mdPath, true, '', '\n', true);
+    recordManagedBlock(manifest, mdPath, true, '', '\n', true, insertionAnchor(''));
     out.changed.push(mdPath);
     return;
   }
@@ -194,7 +199,7 @@ function applyManagedBlock(mdPath, digest, dryRun, manifest, out) {
       out.changed.push(mdPath);
     }
     // Manifest entry (if any) already exists from a prior run; do not re-record.
-    recordManagedBlock(manifest, mdPath, false, null, null, false);
+    recordManagedBlock(manifest, mdPath, false, null, null, false, null);
     return;
   }
 
@@ -207,7 +212,7 @@ function applyManagedBlock(mdPath, digest, dryRun, manifest, out) {
   const sepAfter = '\n'; // the block's own line terminator
   const next = `${current}${sepBefore}${block}${sepAfter}`;
   if (!dryRun) fs.writeFileSync(mdPath, next);
-  recordManagedBlock(manifest, mdPath, false, sepBefore, sepAfter, true); // inserted → UPDATE
+  recordManagedBlock(manifest, mdPath, false, sepBefore, sepAfter, true, insertionAnchor(current)); // inserted → UPDATE
   out.changed.push(mdPath);
 }
 

--- a/src/core/manifest.js
+++ b/src/core/manifest.js
@@ -19,11 +19,14 @@ const { WienerdogError } = require('./errors');
  *                                                     must still resolve to
  *                                                     (absent on legacy entries)
  *   {kind:'managed-block', path, createdFile:bool,
- *    sepBefore?:string, sepAfter?:string}           — a sentinel block we wrote
+ *    sepBefore?:string, sepAfter?:string,
+ *    anchorBefore?:string}                          — a sentinel block we wrote
  *                                                     into a (maybe user-owned) file;
  *                                                     sepBefore/sepAfter (WP-147) are
  *                                                     the exact separator bytes the
- *                                                     last insertion added
+ *                                                     last insertion added; anchorBefore
+ *                                                     is the insertionAnchor() of the
+ *                                                     content that preceded them
  *   {kind:'settings-entry', path, createdFile:bool, commands:string[]}
  *                                                   — hook commands we merged into
  *                                                     a JSON settings file
@@ -44,7 +47,7 @@ const { WienerdogError } = require('./errors');
  *
  * @typedef {{kind: string, path: string, hash?: string, createdFile?: boolean,
  *            commands?: string[], unload?: string[], sepBefore?: string,
- *            sepAfter?: string}} ManifestEntry
+ *            sepAfter?: string, anchorBefore?: string}} ManifestEntry
  * @typedef {{version: number, createdAt: string, entries: ManifestEntry[]}} Manifest
  */
 
@@ -57,6 +60,51 @@ const END_SENTINEL = '<!-- wienerdog:end -->';
  *  reverseManagedBlock accepts sepBefore only from this allowlist (and sepAfter
  *  only as '\n'); anything else degrades to the legacy conservative strip. */
 const SEP_BEFORE_OK = new Set(['', '\n', '\n\n']);
+
+/** The bounded context window an insertion anchor covers, in JS string units
+ *  (UTF-16 code units — both sides slice JS strings read with 'utf8'). Bounded
+ *  ON PURPOSE: an unbounded/full-prefix anchor breaks on any edit anywhere above
+ *  the block, which is the COMMON case; 256 is roughly three to four lines of
+ *  markdown, enough to identify the block's neighbourhood and short enough that a
+ *  distant edit does not disturb it. */
+const ANCHOR_WINDOW = 256;
+/** An anchor is a sha256 hex digest and nothing else. Read from the UNTRUSTED
+ *  manifest, so the shape is checked before it is compared (Table N). */
+const ANCHOR_HEX = /^[0-9a-f]{64}$/;
+
+/** Hash of the last ANCHOR_WINDOW characters of the content that immediately
+ *  preceded an inserted separator. HASHED, not stored raw: the manifest is a
+ *  plaintext file and must never carry a copy of the user's document text.
+ *  @param {string} prefix @returns {string} 64-char lowercase hex */
+function insertionAnchor(prefix) {
+  return crypto.createHash('sha256').update(String(prefix).slice(-ANCHOR_WINDOW), 'utf8').digest('hex');
+}
+
+/** Does the recorded anchor prove the block is still at its RECORDED POSITION?
+ *  A hash match alone does NOT: it proves only that `candidate` ends with the
+ *  same window we recorded, and a window that occurs twice in the user's own
+ *  document has two positions that satisfy it (Table Q row Q10 — measured, no
+ *  forgery and no hash collision needed). So the match is paired with a
+ *  UNIQUENESS test. Both together are the position proof; either alone is not.
+ *  @param {ManifestEntry} entry
+ *  @param {string} candidate  the content that would remain in front of the block
+ *  @param {string} userText   the RECONSTRUCTED user document: `candidate + after`,
+ *    i.e. what uninstall is about to leave on disk. It must NOT be the whole
+ *    `content`, nor `content` with only the block excised — both still hold
+ *    Wienerdog's own separator bytes, which manufacture false ambiguity on
+ *    newline-only content (Table Q row Q13, measured).
+ *  @returns {boolean} */
+function anchorProvesPosition(entry, candidate, userText) {
+  const rec = entry.anchorBefore;
+  // LEGACY (absent or not a sha256 hex digest) → shipped 0.12.0 behaviour.
+  if (typeof rec !== 'string' || !ANCHOR_HEX.test(rec)) return true;
+  if (insertionAnchor(candidate) !== rec) return false;
+  const win = candidate.slice(-ANCHOR_WINDOW);
+  // The empty prefix exists at exactly one offset (0), so it is self-locating.
+  if (win === '') return true;
+  const first = userText.indexOf(win);
+  return first !== -1 && userText.indexOf(win, first + 1) === -1;
+}
 
 /** Locate the SINGLE managed block by FULL-LINE sentinel match (a line whose
  *  trimmed content equals the sentinel). Returns {begin, end} character offsets
@@ -305,9 +353,21 @@ function reverseManagedBlock(entry, dryRun, removed, skipped, removedSet, fd, ta
       (weSuppliedTerminator && after === '') ||
       after.startsWith('\n');
 
-    // BOTH are required. They are independent: (1) alone fuses (Table N row 7),
-    // (2) alone eats a user blank line on relocation (row 6).
-    if (ownershipOk && noFusion) before = candidate;
+    // (3) INSERTION ANCHOR + UNIQUENESS. `candidate` is the content that would
+    //     remain in front of the block. It must hash to the anchor we recorded
+    //     when we wrote sepBefore, AND that window must occur exactly once in the
+    //     user's document — otherwise a block moved to a second occurrence of the
+    //     same window passes the hash at the wrong position. An ABSENT or
+    //     malformed anchor is a LEGACY entry: shipped behaviour, never stricter.
+    //     The corpus is `candidate + after` — the document uninstall is about to
+    //     leave — NOT `content`, which still holds our own separator and makes
+    //     newline-only files look ambiguous (Table Q row Q13).
+    const anchorOk = anchorProvesPosition(entry, candidate, candidate + after);
+
+    // ALL THREE are required, and the anchor is a CONJUNCT — never a disjunct.
+    // It may only ever withhold a strip the other two would have allowed
+    // (Table N); it may never authorise one they refused.
+    if (anchorOk && ownershipOk && noFusion) before = candidate;
   }
   const remaining = before + after;
 
@@ -1059,4 +1119,4 @@ function disposeCoreMechanics(paths, { dryRun = false, vaultPath = null } = {}) 
   return { removed, skippedForVault };
 }
 
-module.exports = { load, record, save, reverse, disposeCoreMechanics, reverseSchedulerEntry, reverseVendoredTree, reverseCopiedSkill, reverseSymlink, hashDir, sha256File, validateEntry, withinAllowedRoot, withinSchedulerRoot };
+module.exports = { load, record, save, reverse, disposeCoreMechanics, reverseSchedulerEntry, reverseVendoredTree, reverseCopiedSkill, reverseSymlink, hashDir, insertionAnchor, sha256File, validateEntry, withinAllowedRoot, withinSchedulerRoot };

--- a/tests/unit/manifest.test.js
+++ b/tests/unit/manifest.test.js
@@ -1393,6 +1393,11 @@ test('WP-147 T7 (Table M): forged out-of-vocabulary separator metadata cannot de
   }
 });
 
+// WP-managed-block-insertion-anchor (Table F): the bound TIGHTENED. The forged
+// '\n\n' makes `candidate` = 'foo', which no longer hashes to the recorded
+// anchor of 'foo\n' — the strip is withheld, so the forgery now loses ZERO user
+// bytes (it used to lose exactly the trailing newline; our blank line is left
+// behind instead).
 test('WP-147 T9 (Table M bound): an in-vocabulary at-EOF forgery loses exactly one newline, never text', () => {
   const { applyManagedBlock } = require('../../src/adapters/shared');
   /** Honest install of "foo\n"; optionally hand-edit the manifest entry to the
@@ -1414,7 +1419,7 @@ test('WP-147 T9 (Table M bound): an in-vocabulary at-EOF forgery loses exactly o
   const control = run(false);
   const forged = run(true);
   assert.equal(control, 'foo\n', 'honest control restores byte-perfectly');
-  assert.equal(forged, 'foo', 'forged entry loses exactly the trailing newline');
+  assert.equal(forged, 'foo\n\n', 'forged entry now loses NOTHING — the anchor refuses the forged separator claim and our blank line is left instead');
   assert.equal(
     control.replace(/\n/g, ''),
     forged.replace(/\n/g, ''),
@@ -1478,6 +1483,211 @@ test('WP-147 T12 (AC14): non-string separator metadata still strips the block, n
     assert.ok(res.removed.includes(md), `${label}: block still removed (entry NOT rejected upstream)`);
     assert.match(err, /ignoring out-of-vocabulary separator metadata/, `${label}: the stderr notice fires`);
   }
+});
+
+// ── WP-managed-block-insertion-anchor: forward-time position evidence ─────────
+// A-T1 … A-T11 (A-T5 is the edit to WP-147 T9 above, per Table F). Every fixture
+// is set up HONESTLY through applyManagedBlock (WP-147 T11's harness shape) so
+// the recorded separator + anchor are whatever the forward step actually wrote;
+// manifest hand-editing appears only in the forgery rows (A-T4).
+
+const { applyManagedBlock: anchorApplyMB } = require('../../src/adapters/shared');
+const { insertionAnchor } = manifestLib;
+
+/** Honest-setup harness (WP-147 T11's `run` shape): sync `original` through
+ *  applyManagedBlock, assert the recorded sepBefore, then rewrite the file from
+ *  `template` with <BLOCK> substituted (`null` = leave the honest write as is),
+ *  optionally mutate the manifest entry (forgery rows only), and uninstall.
+ *  @param {string} original @param {string} expectedSep
+ *  @param {string|null} template @param {(e: object) => void} [mutate]
+ *  @returns {{final: string|null, pre: string, block: string, entry: object,
+ *             res: object, err: string, md: string}} */
+function anchorRun(original, expectedSep, template, mutate) {
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  fs.mkdirSync(paths.claudeDir, { recursive: true });
+  const md = path.join(paths.claudeDir, 'CLAUDE.md');
+  fs.writeFileSync(md, original);
+  anchorApplyMB(md, 'body', false, manifest, { changed: [], unchanged: [], notices: [] });
+  const entry = manifest.entries.find((e) => e.kind === 'managed-block' && e.path === md);
+  assert.equal(entry.sepBefore, expectedSep, `honest sync records sepBefore ${JSON.stringify(expectedSep)}`);
+  const written = fs.readFileSync(md, 'utf8');
+  const block = written.slice(written.indexOf(MB_BEGIN), written.indexOf(MB_END) + MB_END.length);
+  const pre = template === null ? written : template.split('<BLOCK>').join(block);
+  if (template !== null) fs.writeFileSync(md, pre);
+  if (mutate) mutate(entry);
+  const origWrite = process.stderr.write.bind(process.stderr);
+  let err = '';
+  process.stderr.write = (chunk) => { err += chunk; return true; };
+  let res;
+  try {
+    res = manifestLib.reverse(paths, manifest, {});
+  } finally {
+    process.stderr.write = origWrite;
+  }
+  return { final: fs.existsSync(md) ? fs.readFileSync(md, 'utf8') : null, pre, block, entry, res, err, md };
+}
+
+test('WP-managed-block-insertion-anchor A-T1 (Q1): the routed residual is closed — a moved block restores the user blank line byte-perfectly', () => {
+  const { final, entry } = anchorRun('paraA\n\nparaB\n', '\n', 'paraA\n\n<BLOCK>\nparaB\n');
+  assert.equal(typeof entry.anchorBefore, 'string', 'the honest sync recorded an anchor — this row must not pass by the legacy arm');
+  assert.equal(final, 'paraA\n\nparaB\n', 'byte-perfect: the user blank line survives the relocation (base eats it)');
+});
+
+test('WP-managed-block-insertion-anchor A-T2 (Q3+Q4): the ordinary path and a distant edit restore byte-perfectly; the forward step is idempotent (AC11)', () => {
+  // (a) ordinary in-place uninstall, with the AC11 idempotency check: sync TWICE.
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  fs.mkdirSync(paths.claudeDir, { recursive: true });
+  const md = path.join(paths.claudeDir, 'CLAUDE.md');
+  fs.writeFileSync(md, 'foo\n');
+  anchorApplyMB(md, 'body', false, manifest, { changed: [], unchanged: [], notices: [] });
+  const find = () => manifest.entries.find((e) => e.kind === 'managed-block' && e.path === md);
+  const snapshot = JSON.parse(JSON.stringify(find()));
+  const bytes = fs.readFileSync(md, 'utf8');
+  const out2 = { changed: [], unchanged: [], notices: [] };
+  anchorApplyMB(md, 'body', false, manifest, out2);
+  assert.deepEqual(find(), snapshot, 'second sync leaves the manifest entry deep-equal (AC11)');
+  assert.equal(fs.readFileSync(md, 'utf8'), bytes, 'second sync leaves the file bytes unchanged (AC11)');
+  assert.deepEqual(out2.unchanged, [md], 'second sync reports the file unchanged');
+  manifestLib.reverse(paths, manifest, {});
+  assert.equal(fs.readFileSync(md, 'utf8'), 'foo\n', '(a) in-place uninstall restores byte-perfectly');
+  // (b) a distant edit — first line changed, 400 filler chars between it and the
+  // block. Red against a full-prefix or prefix-length anchor: this is the row
+  // that justifies ANCHOR_WINDOW being bounded.
+  const filler = 'f'.repeat(400);
+  const edited = `HEAD-EDITED\n${filler}\ntail-para\n`;
+  const { final } = anchorRun(`head\n${filler}\ntail-para\n`, '\n', `${edited}\n<BLOCK>\n`);
+  assert.equal(final, edited, '(b) an edit far above the block does not withhold the strip');
+});
+
+test('WP-managed-block-insertion-anchor A-T3 (Q5, R2): an in-window edit withholds the strip — the declared cost, BOTH producer-valid separators', () => {
+  // (a) newline-terminated original ⇒ sepBefore '\n' ⇒ one-character surplus.
+  const a = anchorRun('paraA\n', '\n', 'paraA-EDITED\n\n<BLOCK>\n');
+  const aBase = 'paraA-EDITED\n'; // what shipped base produces on this fixture
+  assert.equal(a.final, 'paraA-EDITED\n\n', '(a) our separator is left — the strip is withheld');
+  assert.equal(a.final.length - aBase.length, a.entry.sepBefore.length, '(a) the surplus against base equals sepBefore.length');
+  assert.equal(a.final.replace(/\n/g, ''), aBase.replace(/\n/g, ''), '(a) no user byte is lost');
+  // (b) unterminated original ⇒ sepBefore '\n\n' ⇒ TWO-character surplus.
+  const b = anchorRun('paraA', '\n\n', 'paraA-EDITED\n\n<BLOCK>\n');
+  const bBase = 'paraA-EDITED';
+  assert.equal(b.final, 'paraA-EDITED\n\n', '(b) our two-byte separator is left — the strip is withheld');
+  assert.equal(b.final.length - bBase.length, b.entry.sepBefore.length, '(b) the surplus against base equals sepBefore.length (2)');
+  assert.equal(b.final.replace(/\n/g, ''), bBase.replace(/\n/g, ''), '(b) no user byte is lost');
+});
+
+test('WP-managed-block-insertion-anchor A-T4 (Q7/Q8): a deleted or non-string anchor degrades to EXACTLY base behaviour — narrowing only', () => {
+  const cases = [
+    ['deleted anchor', (e) => { delete e.anchorBefore; }],
+    ['non-string anchor', (e) => { e.anchorBefore = 42; }],
+  ];
+  for (const [label, mutate] of cases) {
+    const { final, res, err, md } = anchorRun('paraA\n\nparaB\n', '\n', 'paraA\n\n<BLOCK>\nparaB\n', mutate);
+    assert.equal(final, 'paraA\nparaB\n', `${label}: exactly shipped 0.12.0 behaviour, no more and no less`);
+    assert.ok(res.removed.includes(md), `${label}: the block is still removed — uninstall is not made incomplete`);
+    assert.doesNotMatch(err, /ignoring out-of-vocabulary separator metadata/, `${label}: the separator notice belongs to sepBefore/sepAfter, not the anchor`);
+  }
+});
+
+test('WP-managed-block-insertion-anchor A-T6 (Q10): the duplicate-window move — uniqueness, not the hash alone, proves position', () => {
+  const W = 'w'.repeat(251) + '\nEND\n';
+  assert.equal(W.length, 256, 'the fixture sits exactly on the window boundary');
+  const original = `${W}\nTAIL\n${W}`;
+  const { final } = anchorRun(original, '\n', `${W}\n<BLOCK>\nTAIL\n${W}`);
+  assert.equal(final, original, 'byte-perfect: the ambiguous window withholds the strip at the wrong position');
+  const count = (s) => s.split(W).length - 1;
+  assert.ok(count(final) >= count(original), 'no W occurrence was consumed — the withhold never became a strip');
+});
+
+test('WP-managed-block-insertion-anchor A-T7 (Q12): boundary sweep at candidate.length 255/256/257 — nothing special happens at the window edge', () => {
+  for (const len of [255, 256, 257]) {
+    const P = 'x'.repeat(len - 1) + '\n';
+    assert.equal(P.length, len);
+    // ordinary in-place uninstall
+    const inPlace = anchorRun(P, '\n', null);
+    assert.equal(inPlace.final, P, `in-place restores byte-perfectly at candidate.length ${len}`);
+    // honest relocation (Q1 shape scaled to the boundary)
+    const original = `${P}\nparaB\n`;
+    const moved = anchorRun(original, '\n', `${P}\n<BLOCK>\nparaB\n`);
+    assert.equal(moved.final, original, `relocation preserves byte-perfectly at candidate.length ${len}`);
+  }
+});
+
+test('WP-managed-block-insertion-anchor A-T8 (Table B :179/:197): the createdFile branch anchors the empty prefix; replace preserves; uninstall deletes', () => {
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  const md = path.join(paths.claudeDir, 'CLAUDE.md'); // ABSENT — the createdFile branch
+  anchorApplyMB(md, 'body', false, manifest, { changed: [], unchanged: [], notices: [] });
+  const find = () => manifest.entries.find((e) => e.kind === 'managed-block' && e.path === md);
+  const entry = find();
+  assert.equal(entry.createdFile, true);
+  assert.equal(entry.sepBefore, '');
+  assert.equal(entry.sepAfter, '\n');
+  assert.equal(entry.anchorBefore, insertionAnchor(''), 'the empty prefix is anchored via insertionAnchor(\'\'), not null');
+  const snapshot = JSON.parse(JSON.stringify(entry));
+  const bytes = fs.readFileSync(md, 'utf8');
+  // Second sync runs the REPLACE branch (:197): inserted=false must preserve all
+  // three recorded fields (rule P-3) and change nothing on disk (AC11).
+  anchorApplyMB(md, 'body', false, manifest, { changed: [], unchanged: [], notices: [] });
+  assert.deepEqual(find(), snapshot, 'the replace branch preserves the whole entry — sepBefore/sepAfter/anchorBefore untouched');
+  assert.equal(fs.readFileSync(md, 'utf8'), bytes, 'second sync leaves the file bytes unchanged (AC11)');
+  manifestLib.reverse(paths, manifest, {});
+  assert.equal(fs.existsSync(md), false, 'uninstall deletes the file we created');
+});
+
+test('WP-managed-block-insertion-anchor A-T9 (Q14/Q15, R2c): a reproduced window strips exactly sepBefore — EQUAL to base, both arms', () => {
+  // (a) 256-char newline-terminated window ⇒ sepBefore '\n' ⇒ one character.
+  const Wa = 'w'.repeat(251) + '\nEND\n';
+  assert.equal(Wa.length, 256);
+  const a = anchorRun(`PPPP\n${Wa}`, '\n', `QQ\n${Wa}\n<BLOCK>\n`);
+  assert.equal(a.final, `QQ\n${Wa}`, '(a) the strip proceeds at the reproduced, unique window');
+  const aNoBlock = a.pre.replace(a.block + '\n', ''); // block + sepAfter excised, leading separator RETAINED
+  assert.equal(aNoBlock.length - a.final.length, a.entry.sepBefore.length, '(a) exactly sepBefore.length characters removed');
+  assert.equal(aNoBlock.replace(/\s/g, ''), a.final.replace(/\s/g, ''), '(a) the removed characters are whitespace');
+  // (b) 256-char UNTERMINATED window ⇒ sepBefore '\n\n' ⇒ two characters, block at EOF.
+  const Wb = 'w'.repeat(253) + 'END';
+  assert.equal(Wb.length, 256);
+  const b = anchorRun(`PPPP\n${Wb}`, '\n\n', `QQ\n${Wb}\n\n<BLOCK>\n`);
+  assert.equal(b.final, `QQ\n${Wb}`, '(b) both separator bytes stripped — equal to base, the two-character arm');
+  const bNoBlock = b.pre.replace(b.block + '\n', '');
+  assert.equal(bNoBlock.length - b.final.length, b.entry.sepBefore.length, '(b) exactly sepBefore.length (2) characters removed');
+  assert.equal(bNoBlock.replace(/\s/g, ''), b.final.replace(/\s/g, ''), '(b) the removed characters are whitespace');
+});
+
+test('WP-managed-block-insertion-anchor A-T10 (Q13): the ordinary-path corpus sweep — newline-only, repeated-line, CRLF and empty content all round-trip', () => {
+  for (const original of ['\n', '\n\n\n', 'a\na\na\n', 'x\r\ny\r\n', 'foo\n', '']) {
+    const expectedSep = original.endsWith('\n') ? '\n' : '\n\n';
+    const { final } = anchorRun(original, expectedSep, null);
+    assert.equal(final, original, `${JSON.stringify(original)} restores byte-perfectly`);
+  }
+  // Ambiguous sentinels: the entry is skipped with the shipped notice and the file
+  // is untouched — the anchor never runs on a file locateManagedBlock refuses.
+  const amb = anchorRun('foo\n', '\n', 'foo\n\n<BLOCK>\n<BLOCK>\n');
+  assert.match(amb.err, /ambiguous wienerdog managed-block markers/, 'the shipped ambiguity notice fires');
+  assert.ok(amb.res.skipped.includes(amb.md), 'the ambiguous entry is skipped');
+  assert.equal(amb.final, amb.pre, 'the ambiguous file is left byte-untouched');
+});
+
+test('WP-managed-block-insertion-anchor A-T11 (Q16, R2b): a repeated short window after the block withholds — the cost, pinned with controls', () => {
+  // [original, appended-after-block, expectedSep, base result]
+  const costing = [
+    ['A\n', 'A\n', '\n', 'A\nA\n'],
+    ['hi\n', 'hi\n', '\n', 'hi\nhi\n'],
+    ['# Notes\n', '# Notes\n', '\n', '# Notes\n# Notes\n'],
+    ['A', '\nA', '\n\n', 'A\nA'], // the unterminated, two-byte arm
+  ];
+  for (const [original, appended, expectedSep, base] of costing) {
+    const { final, entry } = anchorRun(original, expectedSep, `${original}${expectedSep}<BLOCK>\n${appended}`);
+    assert.equal(final, `${original}${expectedSep}${appended}`, `${JSON.stringify(original)}+${JSON.stringify(appended)}: the surplus is the recorded separator`);
+    assert.equal(final.length - base.length, entry.sepBefore.length, `${JSON.stringify(original)}: the surplus equals sepBefore.length`);
+    assert.equal(final.replace(/\n/g, ''), base.replace(/\n/g, ''), `${JSON.stringify(original)}: no user byte moves`);
+  }
+  // Controls: a NON-repeating append costs nothing — the withhold is caused by
+  // the repetition, not by the append.
+  const c1 = anchorRun('A\n', '\n', 'A\n\n<BLOCK>\nB\n');
+  assert.equal(c1.final, 'A\nB\n', 'control (\\n arm): base exactly — zero cost');
+  const c2 = anchorRun('A', '\n\n', 'A\n\n<BLOCK>\n\nB');
+  assert.equal(c2.final, 'A\nB', 'control (\\n\\n arm): base exactly — zero cost');
 });
 
 // ── WP-153: target-aware symlink reverser (audit A13 follow-up) ───────────────


### PR DESCRIPTION
Spec: docs/specs/WP-managed-block-insertion-anchor.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

Changed files vs base `17a2bc5`: `src/core/manifest.js` (D1, D2, D6a),
`src/adapters/shared.js` (D7a, D8, D9), `tests/unit/manifest.test.js`
(A-T1…A-T11, incl. the Table F edit to WP-147 T9), plus the spec's own
status flip (always allowed; only the `status:` line changed). Nothing else —
`git diff --stat 17a2bc5` shows exactly these four files.

Worktree base verified before starting: `git rev-parse HEAD` = `17a2bc5` (the
dispatch SHA).

## Verification output

**Red baseline first (tests applied, src unmodified)** — per the Test index's
"Red against" column, exactly the predicted set went red; the baseline rows
A-T2/A-T4/A-T9/A-T10 stayed green against base (they pin base-equal behaviour):

```
✖ WP-147 T9 (Table M bound): … ('foo\n\n' !== 'foo' — Table F's measured flip, A-T5's edit)
✖ WP-managed-block-insertion-anchor A-T1 (Q1)
✖ WP-managed-block-insertion-anchor A-T3 (Q5, R2)
✖ WP-managed-block-insertion-anchor A-T6 (Q10)
✖ WP-managed-block-insertion-anchor A-T7 (Q12)   (the relocation arms)
✖ WP-managed-block-insertion-anchor A-T8 (Table B :179/:197)
✖ WP-managed-block-insertion-anchor A-T11 (Q16, R2b)
ℹ tests 91  ℹ pass 83  ℹ fail 7
```

**V1 — full suite (post-implementation):** baseline at `17a2bc5` was
`tests 1903 / pass 1894 / fail 0 / skipped 9`; after the WP:

```
ℹ tests 1913
ℹ suites 0
ℹ pass 1904
ℹ fail 0
ℹ cancelled 0
ℹ skipped 9
ℹ todo 0
```

(+10 tests / +10 pass — the ten new A-T blocks; A-T5 is an edit, not a new test.)

**V2 — targeted:**

```
node tests/run.js tests/unit/manifest.test.js
ℹ tests 91  ℹ pass 90  ℹ fail 0
```

**V0/V4x/V4z helpers** were extracted verbatim from THIS spec's heredoc bodies
by a small extraction script (per V4z's "as extracted from this spec"
requirement): `wd-fnguard.js` 1830 B, `wd-fnextract.js` 2077 B,
`wd-rebind-matrix.js` 3277 B.

**V3 GREEN:**

```
node /tmp/wd-fnguard.js src/core/manifest.js reverseManagedBlock \
  "+fs.readFileSync(fd, 'utf8')" "+fs.ftruncateSync(fd, 0)" \
  "+fs.writeSync(fd, buf, 0, buf.length, 0)" "+fs.rmSync(target, { force: true })" \
  "-fs.writeFileSync("
V3 ok (green)
```

**V3 RED (must fail — did, exit 1):**

```
MISSING inside reverseManagedBlock: fs.ftruncateSync(fd, 0)
FORBIDDEN inside reverseManagedBlock: fs.writeFileSync(
exit=1
```

**V3 EVASIONS (both must fail — both did):**

```
evasion 1 (block-commented call):  MISSING inside reverseManagedBlock: fs.ftruncateSync(fd, 0)  → exit=1
evasion 2 (later duplicate defn):  GUARD: 2 top-level definitions of reverseManagedBlock — the LAST one binds; refusing to guess  → exit=1
```

**V4 GREEN (reverseSymlink byte-identical to `9188a1c`):**

```
diff -u /tmp/wd-expected-symlink.js /tmp/wd-actual-symlink.js
V4 ok (byte-identical)
```

**V4 RED (the readlinkSync-under-a-different-identifier mutation must be caught — it was):**

```
diff -q /tmp/wd-expected-symlink.js /tmp/wd-actual-red.js  → exit 1 (files differ)
V4 ok (red, as required)
```

**V4z:**

```
V4z ok (31 refused, 14 accepted)
```

**V5:**

```
grep -cE '^[[:space:]]*const ANCHOR_WINDOW[[:space:]]*=' src/core/manifest.js  → 1
grep -c 'ANCHOR_WINDOW' src/adapters/shared.js                                 → 0
grep -c "createHash('sha256')" src/adapters/shared.js                          → 0
V5 ok
```

**V6:**

```
V6 ok
```

**V7:**

```
V7 ok
```

**V8:**

```
Linting: 392 file(s)
Summary: 0 error(s)
frontmatter check passed: 213 spec(s), 4 agent(s)
lint passed
```

## Decisions made

- **The old two-line `// BOTH are required…` comment (manifest.js:308-309) was
  replaced along with the `if` line**, not kept above the new conjunct. The
  Exact-contracts snippet says it "replaces exactly the line
  `if (ownershipOk && noFusion) before = candidate;`", but keeping a "BOTH are
  required" preamble directly before the snippet's own "ALL THREE are
  required" comment would be self-contradictory, and Table U's pinned range
  for that region deliberately stops at `:306` (the ownershipOk/noFusion
  definitions) — those two comment lines sit outside every pinned region. No
  code semantics involved.
- **A-T5's "leading comment" update**: the shipped T9 test had no leading
  comment, so one was added above the test stating the bound tightened; the
  test name and its control/newline-stripped-equality assertions are
  byte-unmodified, per Table F.
- **A-T9's "removed characters are whitespace" assertion** is implemented as
  `noBlock.replace(/\s/g,'') === final.replace(/\s/g,'')` (the strip changed
  nothing but whitespace), paired with the exact `sepBefore.length` delta —
  the spec names the property, not the mechanism.

## Discovered issues (out of scope, not fixed)

none

## Lessons (memory dogfooding)

- WP-managed-block-insertion-anchor: the spec's red-baseline predictions
  (which A-T rows go red against base, which stay green as base-equality pins)
  matched the actual pre-implementation run exactly, 7/7 red and 4/4 green —
  writing the tests before the code and diffing the failure set against the
  "Red against" column is a cheap whole-spec self-check.
- WP-managed-block-insertion-anchor: V4z's "run the matrix against the helper
  AS EXTRACTED FROM THIS SPEC" is easiest to honor mechanically — a 15-line
  script that pulls the heredoc bodies out of the spec markdown removes the
  transcription-error class the spec itself documents (the lost-backslash
  copy).
- WP-managed-block-insertion-anchor: the sandboxed worktree agent refuses
  compound `cmd && { …; exit 1; }` fallback chains; running each guard plainly
  and reading `$?` reproduces the spec's red-run semantics without altering
  any check.

---
Generated-by: Claude Fable 5 (claude-fable-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THDN8Y8Syk7Lft4GDpBBhP
