### PR TITLE
fix(uninstall): prove a skill symlink's authorship before unlinking it (WP-symlink-authorship-identity)

### DIFF
--- a/docs/specs/WP-symlink-authorship-identity.md
+++ b/docs/specs/WP-symlink-authorship-identity.md
@@ -1,7 +1,7 @@
 ---
 id: WP-symlink-authorship-identity
 title: Record symlink authorship and lstat identity at forward time so uninstall unlinks only links it can prove it created
-status: Ready
+status: In-Review
 model: opus
 size: S
 depends_on: [WP-153, WP-managed-block-insertion-anchor]

--- a/src/adapters/shared.js
+++ b/src/adapters/shared.js
@@ -2,7 +2,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { hashDir, insertionAnchor } = require('../core/manifest');
+const { hashDir, insertionAnchor, linkIdentity } = require('../core/manifest');
 const { WienerdogError } = require('../core/errors');
 
 const BEGIN = '<!-- wienerdog:begin -->';
@@ -436,7 +436,10 @@ function applySkillLinks(skillsDir, targetSkillsDir, dryRun, manifest, out, opts
       }
       if (currentTarget === target) {
         out.unchanged.push(linkPath);
-        recordOnce(manifest, { kind: 'symlink', path: linkPath, target });
+        // The link was ALREADY on disk — we did not create it, so no lstat
+        // identity is recorded (Table B / rule S-1) and `origin: 'adopted'`
+        // makes uninstall preserve it (row 4a): it is the user's.
+        recordOnce(manifest, { kind: 'symlink', path: linkPath, target, origin: 'adopted' });
       } else {
         // A wienerdog-* symlink whose target is NOT our core skill source — a user's
         // own link, or a stale one from another install root. Never silently clobber
@@ -487,13 +490,26 @@ function applySkillLinks(skillsDir, targetSkillsDir, dryRun, manifest, out, opts
       out.notices.push(`left user file untouched: ${linkPath}`);
     } else if (dryRun) {
       // A dry run does not probe symlink permission; report the common case.
-      recordOnce(manifest, { kind: 'symlink', path: linkPath, target });
+      // Nothing exists to lstat, so no identity (Table B); this manifest is a
+      // report only — sync.js gates save() on !dryRun, so it is never persisted.
+      recordOnce(manifest, { kind: 'symlink', path: linkPath, target, origin: 'created' });
       out.changed.push(linkPath);
     } else {
       // Absent: prefer a symlink; copy where symlink creation is unpermitted.
       try {
         symlink(target, linkPath);
-        recordOnce(manifest, { kind: 'symlink', path: linkPath, target });
+        // symlink() has just succeeded: record the link's lstat identity so
+        // uninstall can prove this exact file object is the one we created
+        // (row 4b). Written out explicitly — never spread a possibly-null
+        // identity into the literal; when linkIdentity() cannot establish one,
+        // record `origin: 'created'` alone and keep base behaviour (rule S-2).
+        const id = linkIdentity(linkPath);
+        const symlinkEntry = { kind: 'symlink', path: linkPath, target, origin: 'created' };
+        if (id) {
+          symlinkEntry.dev = id.dev;
+          symlinkEntry.ino = id.ino;
+        }
+        recordOnce(manifest, symlinkEntry);
       } catch (err) {
         if (err && (err.code === 'EPERM' || err.code === 'EACCES')) {
           fs.cpSync(target, linkPath, { recursive: true });

--- a/src/core/manifest.js
+++ b/src/core/manifest.js
@@ -236,6 +236,7 @@ function isSymlink(p) {
  * @param {boolean} dryRun
  * @param {string[]} removed @param {string[]} skipped @param {Set<string>} removedSet
  * @param {string[]} skillsRoots the harness skills roots (row 4 OWNED gate)
+ * @param {{identity?: function}} [opts]  test seam only — see D4
  */
 function reverseSymlink(entry, dryRun, removed, skipped, removedSet, skillsRoots, opts = {}) {
   const identityOf = opts.identity || linkIdentity;   // test seam only

--- a/src/core/manifest.js
+++ b/src/core/manifest.js
@@ -17,7 +17,14 @@ const { WienerdogError } = require('./errors');
  *   {kind:'symlink', path, target?}                 — a symlink we created;
  *                                                     `target` is the source it
  *                                                     must still resolve to
- *                                                     (absent on legacy entries)
+ *                                                     (absent on legacy entries);
+ *                                                     origin? is 'created' or
+ *                                                     'adopted' — whether we made
+ *                                                     the link or found it on
+ *                                                     disk; dev?/ino? are the
+ *                                                     link's lstat identity at
+ *                                                     creation time, as decimal
+ *                                                     strings (create site only)
  *   {kind:'managed-block', path, createdFile:bool,
  *    sepBefore?:string, sepAfter?:string,
  *    anchorBefore?:string}                          — a sentinel block we wrote
@@ -47,6 +54,7 @@ const { WienerdogError } = require('./errors');
  *
  * @typedef {{kind: string, path: string, hash?: string, createdFile?: boolean,
  *            commands?: string[], unload?: string[], sepBefore?: string,
+ *            origin?: string, dev?: string, ino?: string,
  *            sepAfter?: string, anchorBefore?: string}} ManifestEntry
  * @typedef {{version: number, createdAt: string, entries: ManifestEntry[]}} Manifest
  */
@@ -104,6 +112,22 @@ function anchorProvesPosition(entry, candidate, userText) {
   if (win === '') return true;
   const first = userText.indexOf(win);
   return first !== -1 && userText.indexOf(win, first + 1) === -1;
+}
+
+/** lstat identity of a SYMLINK, as decimal strings (bigint: a 64-bit inode
+ *  exceeds Number.MAX_SAFE_INTEGER, and BigInt is not JSON-serializable).
+ *  Returns null when the path is not a symlink, is unreadable, or the platform
+ *  cannot supply a non-zero (dev, ino) pair — see Table P rule S-2.
+ *  @param {string} linkPath @returns {{dev: string, ino: string}|null} */
+function linkIdentity(linkPath) {
+  try {
+    const st = fs.lstatSync(linkPath, { bigint: true });
+    if (!st.isSymbolicLink()) return null;
+    if (st.dev === 0n || st.ino === 0n) return null;
+    return { dev: String(st.dev), ino: String(st.ino) };
+  } catch {
+    return null;
+  }
 }
 
 /** Locate the SINGLE managed block by FULL-LINE sentinel match (a line whose
@@ -213,7 +237,8 @@ function isSymlink(p) {
  * @param {string[]} removed @param {string[]} skipped @param {Set<string>} removedSet
  * @param {string[]} skillsRoots the harness skills roots (row 4 OWNED gate)
  */
-function reverseSymlink(entry, dryRun, removed, skipped, removedSet, skillsRoots) {
+function reverseSymlink(entry, dryRun, removed, skipped, removedSet, skillsRoots, opts = {}) {
+  const identityOf = opts.identity || linkIdentity;   // test seam only
   const L = entry.path;
   const T = entry.target;
   // Row 1: not a symlink (real file/dir, or already gone) — never ours to delete.
@@ -257,6 +282,32 @@ function reverseSymlink(entry, dryRun, removed, skipped, removedSet, skillsRoots
     );
     skipped.push(L);
     return;
+  }
+  // Row 4a: ADOPTED — the link was already on disk when we first recorded it, so
+  // it is the USER's, not ours, however exactly it matches. Preserve.
+  if (entry.origin === 'adopted') {
+    process.stderr.write(
+      `wienerdog: keeping ${L} — not the Wienerdog skill link we recorded (replaced, or unverifiable)\n`
+    );
+    skipped.push(L);
+    return;
+  }
+  // Row 4b: IDENTITY — when we recorded a (dev, ino) pair, the link on disk must
+  // still BE that file object. A delete-and-recreate gets a new inode, so a user's
+  // same-source replacement no longer passes for ours. Fail closed on any doubt.
+  // A PARTIAL pair (one of the two) is a shape the forward step never writes, so
+  // it is unverifiable, not absent — preserve (Table P rule S-4, Table S).
+  const hasDev = typeof entry.dev === 'string';
+  const hasIno = typeof entry.ino === 'string';
+  if (hasDev || hasIno) {
+    const id = hasDev && hasIno ? identityOf(L) : null;
+    if (id === null || id.dev !== entry.dev || id.ino !== entry.ino) {
+      process.stderr.write(
+        `wienerdog: keeping ${L} — not the Wienerdog skill link we recorded (replaced, or unverifiable)\n`
+      );
+      skipped.push(L);
+      return;
+    }
   }
   // Row 5: OWNED, in-namespace, and provably resolves to our recorded source.
   if (!dryRun) fs.unlinkSync(L);
@@ -965,7 +1016,7 @@ function reverse(paths, manifest, { dryRun = false } = {}) {
 const ENTRY_FIELD_TYPES = {
   file: { hash: 'string' },
   dir: {},
-  symlink: { target: 'string' },
+  symlink: { target: 'string', origin: 'string', dev: 'string', ino: 'string' },
   // sepBefore/sepAfter (WP-147) are deliberately NOT type-gated here: a non-string
   // forgery must reach reverseManagedBlock so its SEP_BEFORE_OK allowlist degrades
   // to the legacy conservative strip and still removes the block (Table M:
@@ -1119,4 +1170,4 @@ function disposeCoreMechanics(paths, { dryRun = false, vaultPath = null } = {}) 
   return { removed, skippedForVault };
 }
 
-module.exports = { load, record, save, reverse, disposeCoreMechanics, reverseSchedulerEntry, reverseVendoredTree, reverseCopiedSkill, reverseSymlink, hashDir, insertionAnchor, sha256File, validateEntry, withinAllowedRoot, withinSchedulerRoot };
+module.exports = { load, record, save, reverse, disposeCoreMechanics, reverseSchedulerEntry, reverseVendoredTree, reverseCopiedSkill, reverseSymlink, hashDir, insertionAnchor, linkIdentity, sha256File, validateEntry, withinAllowedRoot, withinSchedulerRoot };

--- a/tests/unit/manifest.test.js
+++ b/tests/unit/manifest.test.js
@@ -1927,3 +1927,349 @@ test('reverseSymlink: a forged (path,target) pair for a non-OWNED link is preser
     assert.ok(skipped.includes(link));
   }
 });
+
+// ── WP-symlink-authorship-identity: forward-time authorship evidence ──────────
+// Rows 4a/4b of reverseSymlink (Table A2): `origin: 'adopted'` preserves — the
+// link was already on disk when we first recorded it, so it is the user's — and
+// a recorded (dev, ino) pair must still BE the live link's lstat identity before
+// row 5 may unlink. Fail closed on any doubt; ALL provenance fields absent keeps
+// shipped 0.12.0 behaviour byte-for-byte (AC8a). Fixtures mirror WP-153's:
+// OWNED links live at <claudeDir>/skills/wienerdog-* and their destinations sit
+// inside claudeDir so reverse()'s withinAllowedRoot gate passes.
+
+const { applySkillLinks } = require('../../src/adapters/shared');
+
+/** Run fn with stderr captured; returns { result, err }. */
+function captureStderr(fn) {
+  const origWrite = process.stderr.write.bind(process.stderr);
+  let err = '';
+  process.stderr.write = (chunk) => { err += chunk; return true; };
+  try {
+    const result = fn();
+    return { result, err };
+  } finally {
+    process.stderr.write = origWrite;
+  }
+}
+
+/** Honest forward step: a claudeDir-contained core skill source, linked into the
+ *  harness skills dir by the REAL applySkillLinks (the create branch). */
+function honestSkillLink(paths, manifest) {
+  const skillsDir = path.join(paths.claudeDir, 'core-skills');
+  const targetSkillsDir = path.join(paths.claudeDir, 'skills');
+  const coreSkill = path.join(skillsDir, 'wienerdog-foo');
+  fs.mkdirSync(coreSkill, { recursive: true });
+  fs.writeFileSync(path.join(coreSkill, 'SKILL.md'), '# skill\n');
+  const out = { changed: [], unchanged: [], notices: [] };
+  applySkillLinks(skillsDir, targetSkillsDir, false, manifest, out);
+  return { skillsDir, targetSkillsDir, coreSkill, link: path.join(targetSkillsDir, 'wienerdog-foo'), out };
+}
+
+test('WP-symlink-authorship-identity B-T1: a user same-source replacement (new file object) survives uninstall — row 4b', (t) => {
+  if (!isPosix) return t.skip('symlink creation may be unavailable');
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  const { coreSkill, link } = honestSkillLink(paths, manifest);
+  const entry = manifest.entries.find((e) => e.kind === 'symlink' && e.path === link);
+  assert.equal(entry.origin, 'created');
+  assert.equal(typeof entry.dev, 'string');
+  assert.equal(typeof entry.ino, 'string');
+  // The user deletes our link and re-makes it — same path, same target, but a
+  // NEW file object (honest-use case 1).
+  fs.unlinkSync(link);
+  fs.symlinkSync(coreSkill, link);
+  // Precondition, asserted explicitly (Test index B-T1): the recreated link's
+  // identity must differ from the recorded pair, so a filesystem that recycled
+  // the inode fails HERE, loudly, instead of making the row a vacuous pass.
+  const now = manifestLib.linkIdentity(link);
+  assert.notEqual(now, null);
+  assert.ok(
+    now.dev !== entry.dev || now.ino !== entry.ino,
+    'precondition: delete+recreate must change the (dev, ino) pair'
+  );
+  manifestLib.save(paths, manifest);
+  const { result: res, err } = captureStderr(() => manifestLib.reverse(paths, manifestLib.load(paths), {}));
+  // At base this link was DELETED (measured): target equality alone authorized
+  // the unlink. Row 4b now refuses — the file object is not the one we made.
+  assert.equal(fs.lstatSync(link).isSymbolicLink(), true, "the user's same-source replacement is preserved");
+  assert.ok(!res.removed.includes(link));
+  assert.ok(res.skipped.includes(link));
+  assert.match(err, /wienerdog: keeping .* — not the Wienerdog skill link we recorded/);
+});
+
+test('WP-symlink-authorship-identity B-T2: a pre-existing exact-target link is adopted and survives uninstall — row 4a', (t) => {
+  if (!isPosix) return t.skip('symlink creation may be unavailable');
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  const skillsDir = path.join(paths.claudeDir, 'core-skills');
+  const targetSkillsDir = path.join(paths.claudeDir, 'skills');
+  const coreSkill = path.join(skillsDir, 'wienerdog-foo');
+  fs.mkdirSync(coreSkill, { recursive: true });
+  fs.writeFileSync(path.join(coreSkill, 'SKILL.md'), '# skill\n');
+  // The USER made this link before we ever synced (honest-use case 2).
+  fs.mkdirSync(targetSkillsDir, { recursive: true });
+  const link = path.join(targetSkillsDir, 'wienerdog-foo');
+  fs.symlinkSync(coreSkill, link);
+  const out = { changed: [], unchanged: [], notices: [] };
+  applySkillLinks(skillsDir, targetSkillsDir, false, manifest, out);
+  assert.ok(out.unchanged.includes(link), 'the adopt branch reports unchanged');
+  // Assert the entry shape too (Test index B-T2): the end state alone says
+  // something preserved the link; `origin: 'adopted'` with NO identity says
+  // WHICH rule fired — row 4a, off the adopt branch's recording (rule S-1).
+  const entry = manifest.entries.find((e) => e.kind === 'symlink' && e.path === link);
+  assert.ok(entry, 'the adopt branch records an entry');
+  assert.equal(entry.origin, 'adopted');
+  assert.equal(entry.dev, undefined);
+  assert.equal(entry.ino, undefined);
+  manifestLib.save(paths, manifest);
+  const { result: res, err } = captureStderr(() => manifestLib.reverse(paths, manifestLib.load(paths), {}));
+  // At base this link was DELETED (measured). Row 4a now preserves it.
+  assert.equal(fs.lstatSync(link).isSymbolicLink(), true, "the user's pre-existing link is preserved");
+  assert.ok(!res.removed.includes(link));
+  assert.ok(res.skipped.includes(link));
+  assert.match(err, /wienerdog: keeping .* — not the Wienerdog skill link we recorded/);
+});
+
+test('WP-symlink-authorship-identity B-T3: our own untouched link is still removed; the forward step is idempotent (AC11)', (t) => {
+  // PATCH: none — baseline / ordinary path (ADR-0036 A1 exemption (ii)). Red
+  // against making identity REQUIRED, and against any row 4a/4b that fires on
+  // our own untouched link.
+  if (!isPosix) return t.skip('symlink creation may be unavailable');
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  const { skillsDir, targetSkillsDir, link } = honestSkillLink(paths, manifest);
+  // AC11: run the forward step a SECOND time before uninstalling — deep-equal
+  // manifest entries (recordOnce no-ops; the entry keeps its first-run identity)
+  // and zero `changed`.
+  const snapshot = JSON.parse(JSON.stringify(manifest.entries));
+  const out2 = { changed: [], unchanged: [], notices: [] };
+  applySkillLinks(skillsDir, targetSkillsDir, false, manifest, out2);
+  assert.deepEqual(manifest.entries, snapshot, 'second run leaves every entry exactly as recorded');
+  assert.deepEqual(out2.changed, [], 'second run reports zero changed');
+  assert.ok(out2.unchanged.includes(link));
+  manifestLib.save(paths, manifest);
+  const { result: res } = captureStderr(() => manifestLib.reverse(paths, manifestLib.load(paths), {}));
+  assert.equal(fs.existsSync(link), false, 'our own untouched link is removed — uninstall stays complete');
+  assert.ok(res.removed.includes(link));
+});
+
+/** Table S harness (B-T4): an OWNED, resolving wienerdog-* link plus a crafted
+ *  entry whose {origin, dev, ino} shape comes from `shape(id)`. When
+ *  `opts.baseControl`, a second link with an ALL-ABSENT entry rides along and
+ *  must be removed in the same run — the all-absent shape reproduces base
+ *  behaviour byte-for-byte (AC8a), which is how the base contrast the ledger's
+ *  wrong-pair row demands is asserted in-tree. */
+function tableSRow(t, shape, expect, opts = {}) {
+  if (!isPosix) return t.skip('symlink creation may be unavailable');
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  const skillsRoot = path.join(paths.claudeDir, 'skills');
+  fs.mkdirSync(skillsRoot, { recursive: true });
+  const source = path.join(paths.claudeDir, 'core-skills', 'wienerdog-foo');
+  fs.mkdirSync(source, { recursive: true });
+  const link = path.join(skillsRoot, 'wienerdog-foo');
+  fs.symlinkSync(source, link);
+  const id = manifestLib.linkIdentity(link);
+  assert.notEqual(id, null, 'precondition: the live link has an establishable identity');
+  manifestLib.record(manifest, { kind: 'symlink', path: link, target: source, ...shape(id) });
+  let control = null;
+  if (opts.baseControl) {
+    control = path.join(skillsRoot, 'wienerdog-ctl');
+    fs.symlinkSync(source, control);
+    manifestLib.record(manifest, { kind: 'symlink', path: control, target: source });
+  }
+  manifestLib.save(paths, manifest);
+  const { result: res } = captureStderr(() => manifestLib.reverse(paths, manifestLib.load(paths), {}));
+  if (expect === 'removed') {
+    assert.equal(fs.existsSync(link), false, 'Table S says removed');
+    assert.ok(res.removed.includes(link));
+  } else {
+    assert.equal(fs.lstatSync(link).isSymbolicLink(), true, 'Table S says PRESERVED');
+    assert.ok(!res.removed.includes(link));
+    assert.ok(res.skipped.includes(link));
+  }
+  if (control) {
+    assert.equal(fs.existsSync(control), false, 'base contrast: the no-provenance control is removed');
+    assert.ok(res.removed.includes(control));
+  }
+}
+
+test('WP-symlink-authorship-identity B-T4: all provenance absent (pre-WP install) — removed, the backward-compatibility fence (AC8a)', (t) => {
+  // Red against "absent identity ⇒ preserve", which would strand every install
+  // written before this WP with permanent leftovers.
+  tableSRow(t, () => ({}), 'removed');
+});
+
+test("WP-symlink-authorship-identity B-T4: 'created' + matching identity — removed (the mainline)", (t) => {
+  tableSRow(t, (id) => ({ origin: 'created', dev: id.dev, ino: id.ino }), 'removed');
+});
+
+test("WP-symlink-authorship-identity B-T4: 'created' + no identity (S-2: identity never establishable) — removed, base behaviour", (t) => {
+  tableSRow(t, () => ({ origin: 'created' }), 'removed');
+});
+
+test("WP-symlink-authorship-identity B-T4: 'adopted' + no identity — PRESERVED (row 4a, the adopt shape)", (t) => {
+  tableSRow(t, () => ({ origin: 'adopted' }), 'preserved');
+});
+
+test("WP-symlink-authorship-identity B-T4: 'adopted' + matching identity — PRESERVED (row 4a fires first; identity never consulted)", (t) => {
+  tableSRow(t, (id) => ({ origin: 'adopted', dev: id.dev, ino: id.ino }), 'preserved');
+});
+
+test('WP-symlink-authorship-identity B-T4: unknown origin string + no identity — removed (never more permissive than created)', (t) => {
+  tableSRow(t, () => ({ origin: 'bogus' }), 'removed');
+});
+
+test('WP-symlink-authorship-identity B-T4: unknown origin string + matching identity — removed (behaves exactly as created)', (t) => {
+  tableSRow(t, (id) => ({ origin: 'bogus', dev: id.dev, ino: id.ino }), 'removed');
+});
+
+test('WP-symlink-authorship-identity B-T4: dev-only partial pair — PRESERVED (unverifiable, not absent)', (t) => {
+  // One of the two partial directions; its sibling below is required too — one
+  // alone is passed by an implementation that checks only the field it tests.
+  tableSRow(t, (id) => ({ origin: 'created', dev: id.dev }), 'preserved');
+});
+
+test('WP-symlink-authorship-identity B-T4: ino-only partial pair — PRESERVED (unverifiable, not absent)', (t) => {
+  tableSRow(t, (id) => ({ origin: 'created', ino: id.ino }), 'preserved');
+});
+
+test('WP-symlink-authorship-identity B-T4: both identity fields wrong — PRESERVED where base removed (the corruption-only ledger row)', (t) => {
+  tableSRow(t, (id) => ({ origin: 'created', dev: `${id.dev}0`, ino: `${id.ino}0` }), 'preserved', { baseControl: true });
+});
+
+test('WP-symlink-authorship-identity B-T4: ino wrong only — PRESERVED where base removed', (t) => {
+  tableSRow(t, (id) => ({ origin: 'created', dev: id.dev, ino: `${id.ino}0` }), 'preserved', { baseControl: true });
+});
+
+test('WP-symlink-authorship-identity B-T4: dev wrong only — PRESERVED where base removed', (t) => {
+  tableSRow(t, (id) => ({ origin: 'created', dev: `${id.dev}0`, ino: id.ino }), 'preserved', { baseControl: true });
+});
+
+/** B-T5 harness: an honest-shaped entry with ONE field forged to a non-string.
+ *  validateEntry must reject it upstream (D5's type gates) and the link must be
+ *  preserved — where base VALIDATED the same entry and removed the link,
+ *  because its `symlink: {}` cell gated none of these keys. */
+function nonStringRow(t, field, value) {
+  if (!isPosix) return t.skip('symlink creation may be unavailable');
+  const paths = tempPaths();
+  const manifest = makeInstall(paths);
+  const skillsRoot = path.join(paths.claudeDir, 'skills');
+  fs.mkdirSync(skillsRoot, { recursive: true });
+  const source = path.join(paths.claudeDir, 'core-skills', 'wienerdog-foo');
+  fs.mkdirSync(source, { recursive: true });
+  const link = path.join(skillsRoot, 'wienerdog-foo');
+  fs.symlinkSync(source, link);
+  const id = manifestLib.linkIdentity(link);
+  assert.notEqual(id, null);
+  const entry = { kind: 'symlink', path: link, target: source, origin: 'created', dev: id.dev, ino: id.ino };
+  entry[field] = value;
+  // The rejection is validateEntry's, with a `why` naming the forged field.
+  const shape = manifestLib.validateEntry(entry);
+  assert.equal(shape.ok, false);
+  assert.match(shape.why, new RegExp(`${field} must be a string`));
+  // Base contrast (the ledger's schema-rejection cost): base's `symlink: {}`
+  // cell gated NONE of these keys, so the same entry validated and the link was
+  // removed. Proved in-test with an ungated key, which still validates today.
+  assert.equal(manifestLib.validateEntry({ kind: 'symlink', path: link, target: source, zzz: 12345 }).ok, true);
+  manifestLib.record(manifest, entry);
+  manifestLib.save(paths, manifest);
+  const { result: res, err } = captureStderr(() => manifestLib.reverse(paths, manifestLib.load(paths), {}));
+  assert.equal(fs.lstatSync(link).isSymbolicLink(), true, 'the link is preserved — the safe direction for a symlink');
+  assert.ok(!res.removed.includes(link));
+  assert.ok(res.skipped.includes(link));
+  assert.match(err, /wienerdog: skipping manifest entry with invalid symlink shape/);
+}
+
+test('WP-symlink-authorship-identity B-T5: non-string origin is rejected upstream and the link preserved', (t) => {
+  nonStringRow(t, 'origin', 1);
+});
+
+test('WP-symlink-authorship-identity B-T5: non-string dev is rejected upstream and the link preserved', (t) => {
+  nonStringRow(t, 'dev', 1);
+});
+
+test('WP-symlink-authorship-identity B-T5: non-string ino is rejected upstream and the link preserved', (t) => {
+  nonStringRow(t, 'ino', 12345);
+});
+
+/** B-T7 harness: honest OWNED link with its real recorded identity, then a
+ *  DIRECT reverseSymlink call (WP-153 blessed the direct unit call) with the
+ *  identity SEAM as the 7th argument, making the filesystem-dependent row-4b
+ *  behaviours deterministic. Returns everything the arms assert on. */
+function seamArm(makeIdentity) {
+  const paths = tempPaths();
+  const skillsRoot = path.join(paths.claudeDir, 'skills');
+  fs.mkdirSync(skillsRoot, { recursive: true });
+  const source = path.join(paths.claudeDir, 'core-skills', 'wienerdog-foo');
+  fs.mkdirSync(source, { recursive: true });
+  const link = path.join(skillsRoot, 'wienerdog-foo');
+  fs.symlinkSync(source, link);
+  const recorded = manifestLib.linkIdentity(link);
+  assert.notEqual(recorded, null);
+  const entry = { kind: 'symlink', path: link, target: source, origin: 'created', dev: recorded.dev, ino: recorded.ino };
+  const removed = [];
+  const skipped = [];
+  const removedSet = new Set();
+  const { err } = captureStderr(() =>
+    manifestLib.reverseSymlink(entry, false, removed, skipped, removedSet, [skillsRoot], {
+      identity: makeIdentity(recorded, link, source),
+    })
+  );
+  return { link, removed, skipped, err };
+}
+
+test('WP-symlink-authorship-identity B-T7(a): a changed device preserves — the seam, deterministic', (t) => {
+  if (!isPosix) return t.skip('symlink creation may be unavailable');
+  const { link, removed, skipped, err } = seamArm((recorded) => () => ({ dev: recorded.dev + 1, ino: recorded.ino }));
+  assert.equal(fs.lstatSync(link).isSymbolicLink(), true, 'the link survives');
+  assert.ok(skipped.includes(link));
+  assert.deepEqual(removed, []);
+  assert.match(err, /wienerdog: keeping .* — not the Wienerdog skill link we recorded/);
+});
+
+test('WP-symlink-authorship-identity B-T7(b): a changed inode preserves — the deterministic proof behind B-T1', (t) => {
+  if (!isPosix) return t.skip('symlink creation may be unavailable');
+  const { link, removed, skipped, err } = seamArm((recorded) => () => ({ dev: recorded.dev, ino: recorded.ino + 1 }));
+  assert.equal(fs.lstatSync(link).isSymbolicLink(), true, 'the link survives');
+  assert.ok(skipped.includes(link));
+  assert.deepEqual(removed, []);
+  assert.match(err, /wienerdog: keeping .* — not the Wienerdog skill link we recorded/);
+});
+
+test('WP-symlink-authorship-identity B-T7(c): an unavailable identity (null) preserves — never treated as a match', (t) => {
+  if (!isPosix) return t.skip('symlink creation may be unavailable');
+  const { link, removed, skipped, err } = seamArm(() => () => null);
+  assert.equal(fs.lstatSync(link).isSymbolicLink(), true, 'the link survives');
+  assert.ok(skipped.includes(link));
+  assert.deepEqual(removed, []);
+  assert.match(err, /wienerdog: keeping .* — not the Wienerdog skill link we recorded/);
+});
+
+test('WP-symlink-authorship-identity B-T7(d): a reused (recycled) identity is removed — R4 residual pin', (t) => {
+  // PATCH: none — residual pin. This arm pins CURRENT behaviour at its declared
+  // size, not a fix: an inode the filesystem recycled back to the same pair
+  // passes row 4b, exactly as Table A2 declares (equal to base, which removes
+  // the same link with no check at all).
+  if (!isPosix) return t.skip('symlink creation may be unavailable');
+  const { link, removed } = seamArm((recorded) => () => ({ dev: recorded.dev, ino: recorded.ino }));
+  assert.equal(fs.existsSync(link), false, 'the link is removed');
+  assert.ok(removed.includes(link));
+});
+
+test('WP-symlink-authorship-identity B-T8: a replacement landing between the identity check and the unlink is deleted — R7 residual pin', (t) => {
+  // PATCH: none — residual pin. Row 4b's check and row 5's unlink are two
+  // syscalls with nothing binding them (the verify→unlink race). This pins R7
+  // at its declared size: if it ever goes red, either an atomic
+  // compare-and-unlink primitive was adopted or the mechanism changed.
+  if (!isPosix) return t.skip('symlink creation may be unavailable');
+  const { link, removed } = seamArm((recorded, linkPath, source) => () => {
+    // The seam replaces the link on disk and THEN reports the recorded pair —
+    // simulating a same-user process winning the race after the check ran.
+    fs.unlinkSync(linkPath);
+    fs.symlinkSync(source, linkPath);
+    return { dev: recorded.dev, ino: recorded.ino };
+  });
+  assert.equal(fs.existsSync(link), false, 'the replacement is deleted');
+  assert.ok(removed.includes(link));
+});

--- a/tests/unit/manifest.test.js
+++ b/tests/unit/manifest.test.js
@@ -1974,19 +1974,27 @@ test('WP-symlink-authorship-identity B-T1: a user same-source replacement (new f
   assert.equal(entry.origin, 'created');
   assert.equal(typeof entry.dev, 'string');
   assert.equal(typeof entry.ino, 'string');
-  // The user deletes our link and re-makes it — same path, same target, but a
-  // NEW file object (honest-use case 1).
-  fs.unlinkSync(link);
-  fs.symlinkSync(coreSkill, link);
-  // Precondition, asserted explicitly (Test index B-T1): the recreated link's
-  // identity must differ from the recorded pair, so a filesystem that recycled
-  // the inode fails HERE, loudly, instead of making the row a vacuous pass.
+  // The user replaces our link — same path, same target, but a NEW file object
+  // (honest-use case 1). Built by RENAME, not delete+recreate ("B-T1's
+  // construction", amended 2026-08-03): the naive form asserted an allocator
+  // coin flip and ext4 falsifies it by reusing a freed inode immediately.
+  // Here the replacement's inode is allocated WHILE the original still holds
+  // its own — two live files on one device cannot share an inode number — and
+  // renameSync then swaps the dirent, which POSIX defines as a directory-entry
+  // operation that preserves the inode.
+  const tmp = `${link}.tmp`;
+  fs.symlinkSync(coreSkill, tmp); // 1. new inode, allocated while `link` is still live
+  const tmpId = manifestLib.linkIdentity(tmp);
+  assert.notEqual(tmpId, null);
+  // Derivation check (i) — a POSIX guarantee, not a coin flip: the temp link's
+  // inode differs from the still-live original's.
+  assert.notEqual(tmpId.ino, entry.ino, 'construction: the temp inode must differ from the recorded one');
+  fs.unlinkSync(link); // 2. free the original
+  fs.renameSync(tmp, link); // 3. move the DIRENT; the inode is preserved
+  // Derivation check (ii): rename moved the name, not the inode.
   const now = manifestLib.linkIdentity(link);
   assert.notEqual(now, null);
-  assert.ok(
-    now.dev !== entry.dev || now.ino !== entry.ino,
-    'precondition: delete+recreate must change the (dev, ino) pair'
-  );
+  assert.equal(now.ino, tmpId.ino, 'construction: rename must preserve the temp inode');
   manifestLib.save(paths, manifest);
   const { result: res, err } = captureStderr(() => manifestLib.reverse(paths, manifestLib.load(paths), {}));
   // At base this link was DELETED (measured): target equality alone authorized

--- a/tests/unit/shared-skill-links.test.js
+++ b/tests/unit/shared-skill-links.test.js
@@ -7,7 +7,7 @@ const os = require('node:os');
 const path = require('node:path');
 
 const shared = require('../../src/adapters/shared');
-const { hashDir } = require('../../src/core/manifest');
+const { hashDir, linkIdentity } = require('../../src/core/manifest');
 
 /** Fresh temp core skills dir (with one wienerdog-* skill) + empty target dir. */
 function setup() {
@@ -49,10 +49,20 @@ test('skill symlinked into the target dir with the default seam (POSIX)', () => 
   assert.ok(fs.lstatSync(linkPath).isSymbolicLink(), 'a symlink is created');
   assert.equal(fs.readlinkSync(linkPath), coreSkill);
   assert.ok(out.changed.includes(linkPath));
-  assert.deepEqual(
-    manifest.entries.filter((e) => e.path === linkPath),
-    [{ kind: 'symlink', path: linkPath, target: coreSkill }]
-  );
+  // The create-branch entry carries machine-specific dev/ino, so it cannot be a
+  // literal (Table F row 1). Field-by-field, with the identity asserted against
+  // the LIVE linkIdentity() so the row is portable — and non-null on POSIX so
+  // the identity assertion cannot pass vacuously.
+  const entries = manifest.entries.filter((e) => e.path === linkPath);
+  assert.equal(entries.length, 1);
+  const entry = entries[0];
+  assert.equal(entry.kind, 'symlink');
+  assert.equal(entry.path, linkPath);
+  assert.equal(entry.target, coreSkill);
+  assert.equal(entry.origin, 'created');
+  const id = linkIdentity(linkPath);
+  assert.notEqual(id, null, 'linkIdentity must establish an identity on POSIX');
+  assert.deepEqual({ dev: entry.dev, ino: entry.ino }, id, 'the recorded pair is the live link identity');
 });
 
 test('EPERM on symlink falls back to copying the folder + records copied-skill', () => {
@@ -190,7 +200,7 @@ test('dry-run records a symlink entry and reports the change without writing', (
   assert.ok(out.changed.includes(linkPath));
   assert.deepEqual(
     manifest.entries.filter((e) => e.path === linkPath),
-    [{ kind: 'symlink', path: linkPath, target: path.join(skillsDir, 'wienerdog-setup') }]
+    [{ kind: 'symlink', path: linkPath, target: path.join(skillsDir, 'wienerdog-setup'), origin: 'created' }]
   );
 });
 
@@ -336,7 +346,7 @@ test('a pre-existing correct symlink is adopted into the manifest (recorded, rep
   assert.ok(!out.changed.includes(linkPath));
   assert.deepEqual(
     manifest.entries.filter((e) => e.path === linkPath),
-    [{ kind: 'symlink', path: linkPath, target: coreSkill }]
+    [{ kind: 'symlink', path: linkPath, target: coreSkill, origin: 'adopted' }]
   );
 });
 


### PR DESCRIPTION
Spec: docs/specs/WP-symlink-authorship-identity.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
      (`src/core/manifest.js`, `src/adapters/shared.js`,
      `tests/unit/manifest.test.js`, `tests/unit/shared-skill-links.test.js`,
      plus the spec itself — status flip only)
- [x] Spec status flipped to In-Review

## Verification output

Worktree verified at `81f43b7` before work began (`git rev-parse HEAD` =
`81f43b7559c66237cddc5914320440c7977ca16f`, clean). V11 was run as the first
act, pre-implementation, per the dispatch record.

**V11 — first act, at `81f43b7`, before any edit (the gate of record):**

```
  anchors resolved: 47   citations checked: 180   grouped runs: 10   unbound: 42
V11 ok (every src/ citation resolves, per file, to a content-anchored line)
  control ok: cross-file caught
  control ok: exempt-reuse caught
  control ok: grouped caught
  control ok: qualified-group caught
  control ok: fenced-comment caught
V11 controls ok (5 false negatives all reproduce as failures)
EXIT=0
```

**V0 — spec diff is the status flip only:**

```
-status: Ready
+status: In-Review
```

(one hunk; nothing else in the spec changed — `git diff` on the spec shows
exactly these two lines)

**V1 — full suite:**

```
ℹ tests 1936
ℹ suites 0
ℹ pass 1927
ℹ fail 0
ℹ cancelled 0
ℹ skipped 9
ℹ todo 0
```

Baseline at `8515eb1`/`81f43b7` was `1913 / 1904 / 0`; this WP adds exactly its
23 test rows (B-T1, B-T2, B-T3, twelve B-T4 rows, three B-T5 rows, four B-T7
arms, B-T8): `1913+23 / 1904+23 / 0`. B-T6 edits three shipped assertions in
place and adds no row.

**V2 — targeted:**

```
ℹ tests 133
ℹ suites 0
ℹ pass 132
ℹ fail 0
ℹ cancelled 0
ℹ skipped 1
ℹ todo 0
```

**V3 … V8 — run verbatim from the spec (green + red arms), block exit 0:**

```
V3 ok
MISSING inside reverseManagedBlock: fs.ftruncateSync(fd, 0)
FORBIDDEN inside reverseManagedBlock: fs.writeFileSync(
V3 ok (red, as required)
V4 ok (byte-identical to the spec's expected function)
V4 self-check ok (base + mandated snippets == the fence, byte for byte)
V4 ok (red, as required)
V4 self-check ok (red: an inside-span branch is caught)
V4z ok (31 refused, 14 accepted)
V5 ok
V6 ok
V7 ok
V8 ok
```

**V4 base direction** (must differ at base, by construction):

```
Files /tmp/wd-expected-symlink.js and /tmp/wd-base-fn.js differ
V4 base direction ok (differs at base, as required)
```

**V8 base direction** (red signal is `origin`/`dev`/`ino`; `anchorBefore`
passes at base — exactly the six MISSING lines the spec measured):

```
AC2: entry-shape doc comment does not mention origin
AC2: @typedef ManifestEntry does not mention origin
AC2: entry-shape doc comment does not mention dev
AC2: @typedef ManifestEntry does not mention dev
AC2: entry-shape doc comment does not mention ino
AC2: @typedef ManifestEntry does not mention ino
V8 base exit=1 (must be 1)
```

**V11 — post-implementation re-run** (see Discovered issues; all five red
controls still catch):

```
  anchors resolved: 47   citations checked: 180   grouped runs: 10   unbound: 42
  [69 UNRESOLVED citation lines — every one a base-pinned line number this
   WP's own insertions shifted; 0 anchor failures]
V11 BROKEN — 69 citation(s) + 0 anchor(s)
  control ok: cross-file caught
  control ok: exempt-reuse caught
  control ok: grouped caught
  control ok: qualified-group caught
  control ok: fenced-comment caught
```

**V9 — lint:**

```
frontmatter check passed: 213 spec(s), 4 agent(s)

lint passed
```

## Decisions made

- **`reverseSymlink` transcription is mechanical, not manual**: the
  EXPECTED-FUNCTION fence bytes were extracted with the spec's own V4y slice
  and spliced over the V4x span, so V4's byte-diff is green by construction.
- **Doc-comment shape (D6b)**: `origin?`/`dev?`/`ino?` are documented as
  description text under the existing `{kind:'symlink', path, target?}` shape
  literal rather than inside the braces — V11's content anchor requires that
  exact literal to occur exactly twice in `manifest.js`, so the brace list
  cannot grow. Same reason the `@typedef` gains its three fields on a new line
  *before* the `sepAfter?/anchorBefore?` closing line, whose exact text is a
  V11 anchor.
- **`reverseSymlink`'s JSDoc block is left byte-identical** (no `opts` @param
  added): D4 and Table U mandate the function edits only, and the fence starts
  at the `function` keyword. Surgical over thorough.
- **B-T4's base contrast** is asserted with an all-absent control entry
  (`wienerdog-ctl`) removed in the same `reverse()` run: the all-absent shape
  reproduces base behaviour byte-for-byte (AC8a — the fence is base plus
  narrowing-only rows), which is the only base proxy expressible in-tree. The
  three both-wrong rows carry it, per AC8a′.
- **B-T4's partial-pair rows** use the *matching* half of the live identity
  with `origin: 'created'` — stronger than an arbitrary string: even a correct
  half preserves, proving "partial ⇒ unverifiable" rather than "wrong value ⇒
  mismatch".
- **B-T7(a)/(b)** perturb the recorded pair by string concatenation
  (`recorded.dev + 1`), exactly as the Test index writes it.

## Discovered issues (out of scope, not fixed)

> **Both bullets below were raised against commit 1 and have since been
> adjudicated by spec amendment PR #158** (V11 directionality now stated in the
> spec's own header; roster pins T6 *and* T7). Kept as the record of what this
> PR reported; see the second-commit section.

- **V11 cannot stay green through this WP's own implementation, by
  construction.** The spec's 180 citations are pinned to the base tree
  (`8515eb1`, re-verified in PR #156); the mandated edits insert lines above
  nearly every cited region (module doc comment at the top of `manifest.js`,
  `linkIdentity` above `reverseSymlink`, three producer-site edits in
  `shared.js`), so the post-implementation re-run flags 69 shifted
  coordinates — while **all 47 content anchors still resolve exactly once**
  (0 anchor failures), i.e. nothing was lost, everything renumbered. V0
  restricts this PR's spec edit to the status flip, so re-deriving citations
  here is out of scope. Routing: the post-merge reconciliation pass the
  architect ran for Part A (PR #156 precedent). The pre-implementation run at
  `81f43b7` (47/180/0, five controls red) is the gate of record per the
  dispatch instruction.
- **AC10 names WP-153's roster as "T1–T3, T4a–T4c and T6", but the shipped
  WP-153 symlink block in `tests/unit/manifest.test.js` labels its seventh row
  T7** ("Table A row 4 (T7)"); no symlink-suite T6 exists ("WP-147 T6" and
  "A-T6" belong to other suites). All seven WP-153 tests pass byte-unmodified
  either way; the roster id looks like a spec typo for the architect to
  confirm.

## Second commit — B-T1 amendment (spec PR #158, main `ee4ab07`)

**The CI failure.** ubuntu-latest reddened B-T1's precondition assert:
*"precondition: delete+recreate must change the (dev, ino) pair — expected
true, actual false"*. ext4 reuses a freed inode immediately, so the mandated
delete+recreate fixture asserted an allocator coin flip — a **spec defect**
(the amendment's own words), green on APFS, hard-red on the one platform CI
gates on.

**The amendment** (PR #158, merged as `ee4ab07`): B-T1 is now a **rename
construction** — allocate the replacement's inode at a sibling `.tmp` path
while the original is still live (two live files on one device cannot share an
inode number), assert the inodes differ, unlink the original, `renameSync` the
temp into place (a POSIX directory-entry operation that preserves the inode),
assert the inode carried over. Also amended: **D6c** mandates the exact
`@param {{identity?: function}} [opts]` JSDoc line (gated by new **V8b**), the
WP-153 roster pins **T6 and T7** both, V11's directionality is now stated in
its own header (base-only, red-after-landing by design — matching what this
PR's first commit reported as a deviation), and the DoD records that this spec
has no commit-count rule, licensing this second commit on the open PR.

**Applied here:** `origin/main` merged into the branch (so the amended spec is
this PR's spec; V0's licensed diff is again exactly the status flip), B-T1
rewritten to the mandated construction with both derivation checks, the D6c
JSDoc line added verbatim. Everything else untouched — the fence, rows 4a/4b,
producers, schema, and the other 22 test rows are byte-identical to commit 1.

**Re-run gate table (second commit, `7b689ce`):**

| Gate | Result |
|---|---|
| V0 | spec diff vs amended main = `Ready` → `In-Review` flip only (merge, no rebase) |
| V3 + red | ok / red ok |
| V4 + self-check + both reds | ok — fence untouched by the amendment, still byte-identical |
| V4z | 31 refused / 14 accepted |
| V5 / V6 / V7 | ok |
| V8 | ok (green); base direction already shown above (six MISSING, exit 1) |
| **V8b** | **ok** — the mandated `[opts]` line found in `reverseSymlink`'s own JSDoc (red direction is historical: red at base where `opts` did not exist) |
| V11 | **not re-run, per the amended header**: base-only gate; the first-act green run at `81f43b7` stands as the gate of record |
| V2 | 133 / 132 / 0 (1 skip) — B-T1 green |
| V1 | 1936 / 1927 / 0 |
| V9 lint | passed |
| Boundary | second commit touches only `src/core/manifest.js` (+1 JSDoc line) and `tests/unit/manifest.test.js` |

## Lessons (memory dogfooding)

- WP-symlink-authorship-identity: V11 is a *dispatch-time* gate by
  construction — any implementation that inserts lines above cited regions
  un-resolves the spec's base-pinned citations while V0 forbids re-deriving
  them in the WP branch. Pre-implementation green plus post-merge
  reconciliation is the only consistent reading; a future spec could say so
  explicitly next to V11.
- WP-symlink-authorship-identity: transcribing the EXPECTED-FUNCTION fence by
  mechanically splicing the V4y-extracted bytes over the V4x span made V4
  green on the first run — hand-retyping a 60-line fence is where byte-diffs
  die.
- WP-symlink-authorship-identity: V11's content anchors constrain *how* doc
  comments may grow (the symlink shape literal and the typedef closing line
  are pinned), so check the scan's anchor list before choosing an edit shape,
  not after it fails.
- WP-symlink-authorship-identity: asserting a filesystem precondition does not
  remove a filesystem dependency — it converts a silent vacuous pass into a
  hard failure on the platform that falsifies it (ext4 inode reuse vs APFS).
  Constructions built on POSIX guarantees (allocate-while-live + rename) are
  the deterministic form; skip-guards forfeit exactly the platform CI gates on.

---
Generated-by: claude-fable-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THDN8Y8Syk7Lft4GDpBBhP
