### PR TITLE
feat(launcher): refusal banner file (WP-launcher-refusal-banner)

### DIFF
--- a/docs/specs/WP-launcher-refusal-banner.md
+++ b/docs/specs/WP-launcher-refusal-banner.md
@@ -137,6 +137,7 @@ with the manifest save and the `changed/unchanged` summary console lines.
 | modify | src/cli/sync.js | clear the banner at the end of a successful non-dry-run sync |
 | create | tests/unit/refusal-banner.test.js | app-side helpers + the A5 membership |
 | modify | tests/unit/launcher.test.js | banner written on refuse; content shape; failure is swallowed |
+| modify | tests/unit/private-fs.test.js | IMPLEMENTER AMENDMENT (see PR "Decisions made"): this file pins `A5_PRIVATE_FILE_BASENAMES` by value under the comment *"it must not be able to grow without someone noticing"*. B13 mandates growing it, so the one-line membership update is a **required** consequence of a Deliverable, not an extra. Add the entry and nothing else — never weaken the assertion |
 
 ### Exact contracts
 

--- a/docs/specs/WP-launcher-refusal-banner.md
+++ b/docs/specs/WP-launcher-refusal-banner.md
@@ -1,7 +1,7 @@
 ---
 id: WP-launcher-refusal-banner
 title: Give a launcher-stage refusal its own delivery channel — a code-owned banner file the launcher writes without app-tree code
-status: Draft
+status: In-Review
 model: opus
 size: M
 depends_on: []

--- a/src/cli/run-job.js
+++ b/src/cli/run-job.js
@@ -10,6 +10,7 @@ const { getPaths } = require('../core/paths');
 const { WienerdogError } = require('../core/errors');
 const { maybeRefresh } = require('../core/update-check');
 const { appendAlert, clearAlerts } = require('../core/alerts');
+const { clearRefusalBanner } = require('../core/refusal-banner');
 const { redactOnly } = require('../core/secret-scan');
 const { readDreamConfig } = require('../core/dream/config');
 const jobsLib = require('../scheduler/jobs');
@@ -1059,6 +1060,12 @@ async function runJob(paths, job, opts = {}) {
   if (!failure && code === 0 && !reapFailure && !logStreamFailed) {
     jobsLib.writeScheduleState(paths, name, { last_success: nowIso(), last_status: 'ok' });
     clearAlerts(paths, name);
+    // UNCONDITIONAL (WP-launcher-refusal-banner, Table B row B11): the banner is
+    // not keyed to the job that wrote it. A `--catch-up` refusal is a pseudo-job
+    // that never reports success, so a per-job clear would never fire for it. Any
+    // job succeeding means the app tree works, which means the richer alerts.jsonl
+    // channel is back — the banner exists only to cover the case where it is not.
+    clearRefusalBanner(paths);
     if (platform === 'darwin' || platform === 'win32') {
       try {
         noticeIfCatchupMissing(paths, platform);

--- a/src/cli/sync.js
+++ b/src/cli/sync.js
@@ -9,6 +9,7 @@ const { writeFilePrivate, repairPrivateModes, scanPrivateModes } = require('../c
 const identityApprovals = require('../core/identity-approvals');
 const { renderUpdateLine } = require('../core/update-check');
 const { readAlerts } = require('../core/alerts');
+const { clearRefusalBanner } = require('../core/refusal-banner');
 const { unacknowledgedAlerts } = require('../core/alert-ack');
 const ledgerLib = require('../core/dream/ledger');
 const { readVaultLayout } = require('../core/layout');
@@ -263,6 +264,16 @@ async function run(argv, opts = {}) {
     const { changed } = repairPrivateModes(paths);
     if (changed > 0) console.log(`wienerdog: hardened ${changed} artifact permission(s).`);
   }
+
+  // 0b. The launcher's refusal banner clears on an attended sync (owner ruling D4,
+  //     ADR-0039, WP-launcher-refusal-banner Table B rows B10/B11/B12). Reaching
+  //     here means the app tree runs, so the richer alerts.jsonl channel — which
+  //     counts occurrences and honours `wienerdog alerts ack` — is back and
+  //     supersedes the banner; the refusal's own alert record is untouched.
+  //     UNCONDITIONAL: never keyed to the job that wrote it. Placed BEFORE the
+  //     renderDigest call below so this sync's own digest does not carry a banner
+  //     it just invalidated. Dry-run never clears (B12).
+  if (!dryRun) clearRefusalBanner(paths);
 
   // 1. Digest + managed block need a vault. Skip both when unset (exit 0).
   const skipManagedBlock = !vaultPath;

--- a/src/core/private-fs.js
+++ b/src/core/private-fs.js
@@ -119,6 +119,10 @@ const A5_PRIVATE_FILE_BASENAMES = [
   'alerts-ack.json',
   'transcript-ledger.json',
   'identity-approvals.json',
+  // The launcher's refusal banner (WP-launcher-refusal-banner, Table B row B13).
+  // The launcher chmods it 0600 itself, but it is written by a process that must
+  // swallow every error, so the A5 set is what guarantees it self-heals.
+  'refusal-banner.md',
 ];
 
 /** A9-scoped private DIRECTORIES (0700): the credential store. `secrets/` is

--- a/src/core/refusal-banner.js
+++ b/src/core/refusal-banner.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * App-side reader/clearer for the launcher's refusal banner (WP-launcher-refusal-banner,
+ * ADR-0039 §5, Table B).
+ *
+ * The banner is a code-owned, fixed-shape markdown file at `<core>/state/refusal-banner.md`
+ * that the LAUNCHER writes when it refuses to run a scheduled job. It exists only for the
+ * case where the app tree is broken: a refusing launcher never reaches `renderDigest`, so
+ * the refusal's promise of "your next digest" cannot be kept through the normal channel.
+ *
+ * DIRECTION OF THE DEPENDENCY (Table B row B9). The launcher must never require code from
+ * the tree it is verifying, so it carries its OWN self-contained writer
+ * (`writeRefusalBanner` in `src/scheduler/launcher.js`). This module is the app-side half:
+ * it only ever READS and CLEARS. It is not — and must not become — the launcher's writer.
+ */
+
+/** Basename of the refusal banner inside <core>/state. */
+const REFUSAL_BANNER_FILE = 'refusal-banner.md';
+
+/** Absolute path to the banner. @param {import('./paths').WienerdogPaths} paths
+ *  @returns {string} */
+function refusalBannerPath(paths) {
+  return path.join(paths.state, REFUSAL_BANNER_FILE);
+}
+
+/** The banner text, or '' when absent/unreadable/empty. NEVER throws — a missing
+ *  banner is the normal case. Trailing newline trimmed.
+ *  @param {import('./paths').WienerdogPaths} paths @returns {string} */
+function readRefusalBanner(paths) {
+  try {
+    return fs.readFileSync(refusalBannerPath(paths), 'utf8').replace(/\n+$/, '');
+  } catch {
+    return ''; // absent is the normal case, unreadable is not worth a throw
+  }
+}
+
+/** Remove the banner. Idempotent; never throws (a missing file is success).
+ *  @param {import('./paths').WienerdogPaths} paths @returns {void} */
+function clearRefusalBanner(paths) {
+  try {
+    fs.rmSync(refusalBannerPath(paths), { force: true });
+  } catch {
+    /* clearing is best-effort — a stale banner must never fail a successful job or sync */
+  }
+}
+
+module.exports = { REFUSAL_BANNER_FILE, refusalBannerPath, readRefusalBanner, clearRefusalBanner };

--- a/src/scheduler/launcher.js
+++ b/src/scheduler/launcher.js
@@ -203,6 +203,47 @@ function appendRefuseAlert(p, job, reason) {
   }
 }
 
+/** Hard cap on the folded banner text. A DELIBERATE duplicate of MAX_FIELD_CHARS
+ *  in src/core/alerts.js (its twin — the two move together): this file cannot
+ *  require the app tree it is verifying (Table B row B9/B4). */
+const BANNER_MAX_CHARS = 2000;
+
+/** Write the single-line refusal banner (Table B). Overwrites any previous banner:
+ *  the newest refusal is the one worth showing. Atomic (temp + rename) so a hook
+ *  reading concurrently never sees a partial line. Best-effort in EVERY step —
+ *  a failure here must never affect the refusal, which stands on its non-zero exit
+ *  and zero spawn.
+ *
+ *  The launcher writes this because a refusing launcher never reaches renderDigest,
+ *  so the refusal's own promise ("your next digest") has no other channel. Same
+ *  self-contained discipline as appendRefuseAlert: Node builtins only, never a
+ *  require from `src/` — NOT src/core/refusal-banner.js, which is the app-side
+ *  reader/clearer half of the same contract.
+ *  @param {{state:string}} p @param {string} text the refusalText() output */
+function writeRefusalBanner(p, text) {
+  try {
+    // Fold BEFORE prefixing (B4): a newline inside the reason would end the
+    // markdown blockquote and let the tail render as ordinary prose. Folding is
+    // the whole defence, and it is the ONLY transformation — the text is
+    // code-owned control-plane text, so no second sanitizer belongs here.
+    const folded = String(text).replace(/\s+/g, ' ').trim().slice(0, BANNER_MAX_CHARS);
+    fs.mkdirSync(p.state, { recursive: true, mode: 0o700 });
+    const file = path.join(p.state, 'refusal-banner.md');
+    const tmp = `${file}.${process.pid}.tmp`;
+    fs.writeFileSync(tmp, `> [!warning] ${folded}\n`);
+    fs.renameSync(tmp, file);
+    if (process.platform !== 'win32') {
+      try {
+        fs.chmodSync(file, 0o600);
+      } catch {
+        /* best-effort */
+      }
+    }
+  } catch {
+    /* the banner is best-effort — the refusal (non-zero exit, zero spawn) stands regardless */
+  }
+}
+
 /** Read + JSON-parse the descriptor file. @param {string} descriptorPath
  *  @returns {object|null} null on missing/corrupt */
 function readDescriptorFile(descriptorPath) {
@@ -503,9 +544,13 @@ function main(argv, opts = {}) {
    *  (the next digest banner) plus the remedy for THIS refusal's class, chosen from
    *  the verdict's structured `remedy` field, never from the reason text
    *  (WP-refusal-remedy-discriminator, Table R). `wienerdog doctor` is still never
-   *  named — it reads no A7 state (F27). Zero spawn, non-zero exit. */
+   *  named — it reads no A7 state (F27). Zero spawn, non-zero exit.
+   *  The banner (WP-launcher-refusal-banner) is the channel that survives a broken
+   *  app tree, where the promised "next digest" is never rendered at all; both it
+   *  and the durable alert are best-effort and neither can hold up the exit. */
   const refuse = (jobName, why, remedy) => {
     const reason = refusalText(jobName, why, remedy);
+    writeRefusalBanner(p, reason);
     appendRefuseAlert(p, jobName, reason);
     process.stderr.write(`${reason}\n`);
     exit(1);
@@ -552,7 +597,7 @@ function main(argv, opts = {}) {
   return code;
 }
 
-module.exports = { verifyAndResolve, verifyCatchup, appTreeDigestOf, verifyContainment, liveStance, parseArgv, refusalText, remedyOf, main };
+module.exports = { verifyAndResolve, verifyCatchup, appTreeDigestOf, verifyContainment, liveStance, parseArgv, refusalText, remedyOf, writeRefusalBanner, main };
 
 // When the vendored copy at <core>/launcher/launch.js is executed by the OS
 // scheduler, run main with the real argv.

--- a/tests/unit/launcher.test.js
+++ b/tests/unit/launcher.test.js
@@ -821,3 +821,122 @@ test('remedy: an INHERITED remedy does not select the sync tail (ownership)', ()
     delete Object.prototype.remedy;
   }
 });
+
+// -------------------------------------------------------------------------
+// WP-launcher-refusal-banner: a refusing launcher never reaches renderDigest,
+// so the refusal's promise of "your next digest" needs a channel the launcher
+// itself owns. Table B decides the banner's path, content, folding, write mode,
+// permissions, multiplicity and failure policy; these tests pin every row this
+// WP implements (the two readers land in WP-refusal-banner-delivery).
+// -------------------------------------------------------------------------
+
+/** The banner file for a temp install. @param {{state:string}} paths */
+function bannerOf(paths) {
+  return path.join(paths.state, 'refusal-banner.md');
+}
+
+/** Drive main() through a drift refusal, capturing stderr (which carries the
+ *  exact refusalText output) and whether anything was spawned. */
+function refuseOnDrift(fixture) {
+  const { env, descriptorPath, digest, paths } = fixture;
+  let spawned = false;
+  let stderr = '';
+  const origErr = process.stderr.write;
+  process.stderr.write = (s) => {
+    stderr += s;
+    return true;
+  };
+  let code;
+  try {
+    code = launcher.main(['dream', '--descriptor', descriptorPath, '--expect-digest', digest], {
+      env,
+      core: paths.core,
+      platform: process.platform,
+      spawn: () => {
+        spawned = true;
+        return { status: 0 };
+      },
+      exit: () => {},
+    });
+  } finally {
+    process.stderr.write = origErr;
+  }
+  return { code, spawned, stderr };
+}
+
+test('banner: a refusal writes exactly one blockquote line to state/refusal-banner.md (B1/B3, AC-1/AC-2)', () => {
+  const fixture = setupProd();
+  jobsLib.saveJob(fixture.paths, { ...DREAM_JOB, run: 'skill:wienerdog-weekly-review' }); // drift
+  const { stderr } = refuseOnDrift(fixture);
+  const content = fs.readFileSync(bannerOf(fixture.paths), 'utf8');
+  assert.match(content, /^> \[!warning\] wienerdog: refusing to run/, 'AC-1: the banner line shape');
+  assert.equal(content.split('\n').length, 2, 'AC-1: exactly one line plus a trailing newline');
+  // AC-2: byte-for-byte the folded refusalText output for THIS refusal — stderr
+  // carries that same text, so the expectation is not hardcoded a second time.
+  assert.equal(content, `> [!warning] ${stderr.trim()}\n`);
+});
+
+test('banner: whitespace runs and newlines in the reason fold to single spaces (B4, AC-3)', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-banner-fold-'));
+  launcher.writeRefusalBanner({ state: dir }, '  a\nb\t\tc \n\n d  ');
+  assert.equal(fs.readFileSync(path.join(dir, 'refusal-banner.md'), 'utf8'), '> [!warning] a b c d\n');
+});
+
+test('banner: a reason longer than 2000 characters is cut before prefixing (B4, AC-4)', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-banner-cut-'));
+  launcher.writeRefusalBanner({ state: dir }, 'x'.repeat(2500));
+  const content = fs.readFileSync(path.join(dir, 'refusal-banner.md'), 'utf8');
+  assert.equal(content, `> [!warning] ${'x'.repeat(2000)}\n`);
+  assert.equal(content.length, '> [!warning] '.length + 2000 + 1, 'the cut lands on the text, not the prefix');
+});
+
+test('banner: a second refusal OVERWRITES — banners never accumulate (B7, AC-5)', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-banner-over-'));
+  launcher.writeRefusalBanner({ state: dir }, 'first');
+  launcher.writeRefusalBanner({ state: dir }, 'second');
+  assert.equal(fs.readFileSync(path.join(dir, 'refusal-banner.md'), 'utf8'), '> [!warning] second\n');
+  assert.equal(
+    fs.readdirSync(dir).filter((n) => n.startsWith('refusal-banner')).length,
+    1,
+    'the temp+rename leaves nothing behind'
+  );
+});
+
+test('banner: the file is 0600 after a refusal (B6, AC-6)', { skip: process.platform === 'win32' }, () => {
+  const fixture = setupProd();
+  jobsLib.saveJob(fixture.paths, { ...DREAM_JOB, run: 'skill:wienerdog-weekly-review' }); // drift
+  refuseOnDrift(fixture);
+  assert.equal(fs.statSync(bannerOf(fixture.paths)).mode & 0o777, 0o600);
+});
+
+test(
+  'banner: a failed banner write changes NOTHING about the refusal (B8, AC-7)',
+  { skip: process.platform === 'win32' || (process.getuid && process.getuid() === 0) },
+  () => {
+    const fixture = setupProd();
+    jobsLib.saveJob(fixture.paths, { ...DREAM_JOB, run: 'skill:wienerdog-weekly-review' }); // drift
+    // alerts.jsonl already exists, so appending to it needs no write permission on
+    // the DIRECTORY — but creating the banner's temp file does. That asymmetry is
+    // what makes the banner alone fail: the durable alert must survive it.
+    const alertsFile = path.join(fixture.paths.state, 'alerts.jsonl');
+    fs.writeFileSync(alertsFile, '', { mode: 0o600 });
+    fs.chmodSync(fixture.paths.state, 0o500);
+    let out;
+    try {
+      out = refuseOnDrift(fixture);
+    } finally {
+      fs.chmodSync(fixture.paths.state, 0o700);
+    }
+    assert.equal(out.spawned, false, 'still zero spawn');
+    assert.equal(out.code, 1, 'still a non-zero exit');
+    assert.match(out.stderr, /refusing to run/, 'still the stderr line');
+    assert.match(fs.readFileSync(alertsFile, 'utf8'), /refusing to run/, 'still the durable alert');
+    assert.equal(fs.existsSync(bannerOf(fixture.paths)), false, 'the banner write failed, silently');
+  }
+);
+
+test('banner: the launcher requires NO app-tree code to write it (B9, AC-10)', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'scheduler', 'launcher.js'), 'utf8');
+  assert.doesNotMatch(src, /require\((['"])\.\.?\/(\.\.\/)?src/, 'no relative require into the app tree');
+  assert.doesNotMatch(src, /refusal-banner['"]\)/, 'in particular, never src/core/refusal-banner.js');
+});

--- a/tests/unit/private-fs.test.js
+++ b/tests/unit/private-fs.test.js
@@ -641,6 +641,10 @@ test('private-fs: the A5-scoped set matches the OWNER-APPROVED membership', () =
     'alerts-ack.json',
     'transcript-ledger.json',
     'identity-approvals.json',
+    // WP-launcher-refusal-banner, Table B row B13: the launcher's refusal banner.
+    // Written by a process that must swallow every error (its chmod is
+    // best-effort), so the A5 set is what guarantees the mode self-heals.
+    'refusal-banner.md',
   ]);
 });
 

--- a/tests/unit/refusal-banner.test.js
+++ b/tests/unit/refusal-banner.test.js
@@ -1,0 +1,172 @@
+'use strict';
+
+// WP-launcher-refusal-banner — the APP-SIDE half of the banner contract
+// (Table B). The launcher owns the write (pinned in tests/unit/launcher.test.js);
+// this file pins the read/clear helpers, the A5 private-file membership, and the
+// two lifecycle facts that only a real `sync` can demonstrate: a dry run never
+// clears the banner (B12) and a real run does (B10) while staying idempotent.
+//
+// The sync tests reuse the hermetic sync-repoint/sync-digest-quarantine harness:
+// temp HOME + WIENERDOG_HOME, WIENERDOG_LOADER_NOOP=1 so nothing spawns
+// launchctl/systemctl, harness dirs pointed at absent paths, stdout silenced.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const { getPaths } = require('../../src/core/paths');
+const manifestLib = require('../../src/core/manifest');
+const { A5_PRIVATE_FILE_BASENAMES } = require('../../src/core/private-fs');
+const sync = require('../../src/cli/sync');
+const {
+  REFUSAL_BANNER_FILE,
+  refusalBannerPath,
+  readRefusalBanner,
+  clearRefusalBanner,
+} = require('../../src/core/refusal-banner');
+
+// Hermeticity: CI sets XDG_CONFIG_HOME to the real ~/.config, which
+// systemdUserDir() prefers over $HOME. Unset it (this file runs in its own
+// `node --test` process) so nothing resolves under a real dir.
+delete process.env.XDG_CONFIG_HOME;
+
+/** @param {string} c @returns {string} */
+function sha256(c) {
+  return crypto.createHash('sha256').update(c).digest('hex');
+}
+
+/** A bare temp state dir — enough for the read/clear helpers, which only ever
+ *  touch `paths.state`. @returns {{state:string}} */
+function tempPaths() {
+  const state = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-banner-'));
+  return { state };
+}
+
+/** Isolated temp core + vault + matching manifest + absent harness dirs. */
+function setupSync() {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'wd-bannersync-')));
+  const vault = path.join(root, 'vault');
+  fs.mkdirSync(vault, { recursive: true });
+  const env = {
+    HOME: root,
+    WIENERDOG_HOME: path.join(root, 'wd'),
+    CLAUDE_CONFIG_DIR: path.join(root, 'absent-claude'),
+    CODEX_HOME: path.join(root, 'absent-codex'),
+  };
+  const paths = getPaths(env);
+  fs.mkdirSync(paths.core, { recursive: true });
+  fs.mkdirSync(paths.state, { recursive: true });
+  fs.mkdirSync(paths.logs, { recursive: true });
+  const cfg = `version: 1\nvault: ${vault}\n`;
+  fs.writeFileSync(paths.config, cfg);
+  manifestLib.save(paths, {
+    version: 1,
+    createdAt: new Date().toISOString(),
+    entries: [
+      { kind: 'dir', path: paths.core },
+      { kind: 'file', path: paths.config, hash: sha256(cfg) },
+    ],
+  });
+  return { root, env, paths };
+}
+
+/** Run sync.run with process.env pointed at the temp core and the loader no-op
+ *  set; returns everything it printed. */
+async function runSync(env, argv = []) {
+  const savedKeys = ['HOME', 'WIENERDOG_HOME', 'CLAUDE_CONFIG_DIR', 'CODEX_HOME', 'WIENERDOG_LOADER_NOOP'];
+  const saved = Object.fromEntries(savedKeys.map((k) => [k, process.env[k]]));
+  Object.assign(process.env, env, { WIENERDOG_LOADER_NOOP: '1' });
+  const origWrite = process.stdout.write.bind(process.stdout);
+  const origLog = console.log;
+  let out = '';
+  console.log = (...a) => {
+    out += `${a.join(' ')}\n`;
+  };
+  process.stdout.write = (s) => {
+    out += s;
+    return true;
+  };
+  try {
+    await sync.run(argv, { interactive: false });
+  } finally {
+    process.stdout.write = origWrite;
+    console.log = origLog;
+    for (const k of savedKeys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  }
+  return out;
+}
+
+/** The launcher's exact on-disk shape, written by hand — the app side must never
+ *  reach into the launcher to produce one. */
+function plantBanner(paths, text = 'wienerdog: refusing to run "--catch-up" — cannot resolve app/current') {
+  fs.writeFileSync(refusalBannerPath(paths), `> [!warning] ${text}\n`, { mode: 0o600 });
+}
+
+test('refusal-banner: the path is <core>/state/refusal-banner.md (Table B row B1)', () => {
+  const paths = tempPaths();
+  assert.equal(REFUSAL_BANNER_FILE, 'refusal-banner.md');
+  assert.equal(refusalBannerPath(paths), path.join(paths.state, 'refusal-banner.md'));
+});
+
+test('refusal-banner: reading an absent banner is the normal case — returns "", never throws', () => {
+  assert.equal(readRefusalBanner(tempPaths()), '');
+});
+
+test('refusal-banner: reading returns the line with the trailing newline trimmed', () => {
+  const paths = tempPaths();
+  plantBanner(paths, 'X');
+  assert.equal(readRefusalBanner(paths), '> [!warning] X');
+});
+
+test('refusal-banner: an empty or unreadable banner reads as ""', () => {
+  const paths = tempPaths();
+  fs.writeFileSync(refusalBannerPath(paths), '');
+  assert.equal(readRefusalBanner(paths), '', 'empty file');
+  fs.rmSync(refusalBannerPath(paths));
+  fs.mkdirSync(refusalBannerPath(paths)); // EISDIR on read — must not escape
+  assert.equal(readRefusalBanner(paths), '', 'unreadable file');
+});
+
+test('refusal-banner: clearRefusalBanner removes it and is a no-op when absent (B10, AC-8)', () => {
+  const paths = tempPaths();
+  plantBanner(paths);
+  clearRefusalBanner(paths);
+  assert.equal(fs.existsSync(refusalBannerPath(paths)), false, 'removed');
+  clearRefusalBanner(paths); // idempotent — a missing file is success
+  assert.equal(readRefusalBanner(paths), '');
+});
+
+test("refusal-banner: 'refusal-banner.md' is an A5 private file (B13, AC-9)", () => {
+  assert.ok(
+    A5_PRIVATE_FILE_BASENAMES.includes('refusal-banner.md'),
+    'repairPrivateModes/scanPrivateModes must cover the banner'
+  );
+  assert.equal(
+    A5_PRIVATE_FILE_BASENAMES.filter((b) => b === 'refusal-banner.md').length,
+    1,
+    'registered exactly once'
+  );
+});
+
+test('refusal-banner: `sync --dry-run` leaves the banner in place (B12, AC-11)', async () => {
+  const { env, paths } = setupSync();
+  plantBanner(paths);
+  await runSync(env, ['--dry-run']);
+  assert.equal(readRefusalBanner(paths), '> [!warning] wienerdog: refusing to run "--catch-up" — cannot resolve app/current');
+});
+
+test('refusal-banner: a real `sync` clears the banner and stays idempotent (B10, AC-12)', async () => {
+  const { env, paths } = setupSync();
+  plantBanner(paths);
+  await runSync(env);
+  assert.equal(fs.existsSync(refusalBannerPath(paths)), false, 'the first sync cleared it');
+  const second = await runSync(env);
+  assert.match(second, /wienerdog: 0 changed,/, 'the second sync reports zero changes');
+  assert.equal(fs.existsSync(refusalBannerPath(paths)), false, 'and the banner stays gone');
+});


### PR DESCRIPTION
Spec: docs/specs/WP-launcher-refusal-banner.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table — **one row was added to that table by me**; see Decisions made #1, please confirm it
- [x] Spec status flipped to In-Review

Files changed:

| Action | Path | In Deliverables table |
|--------|------|-----------------------|
| modify | `src/scheduler/launcher.js` | yes |
| create | `src/core/refusal-banner.js` | yes |
| modify | `src/core/private-fs.js` | yes |
| modify | `src/cli/run-job.js` | yes |
| modify | `src/cli/sync.js` | yes |
| create | `tests/unit/refusal-banner.test.js` | yes |
| modify | `tests/unit/launcher.test.js` | yes |
| modify | `tests/unit/private-fs.test.js` | **added to the table by this PR — see Decisions made #1** |
| modify | `docs/specs/WP-launcher-refusal-banner.md` | n/a — `status:` flip (Definition of done item 4) + the amendment above |

## Verification output

```
$ npm test -- --test-name-pattern refusal-banner
> node tests/run.js --test-name-pattern refusal-banner
✔ banner: a refusal writes exactly one blockquote line to state/refusal-banner.md (B1/B3, AC-1/AC-2) (112.816167ms)
✔ refusal-banner: the path is <core>/state/refusal-banner.md (Table B row B1) (0.964291ms)
✔ refusal-banner: reading an absent banner is the normal case — returns "", never throws (0.186333ms)
✔ refusal-banner: reading returns the line with the trailing newline trimmed (0.836209ms)
✔ refusal-banner: an empty or unreadable banner reads as "" (1.252666ms)
✔ refusal-banner: clearRefusalBanner removes it and is a no-op when absent (B10, AC-8) (0.508834ms)
✔ refusal-banner: 'refusal-banner.md' is an A5 private file (B13, AC-9) (0.092917ms)
✔ refusal-banner: `sync --dry-run` leaves the banner in place (B12, AC-11) (54.251125ms)
✔ refusal-banner: a real `sync` clears the banner and stays idempotent (B10, AC-12) (102.934125ms)
ℹ tests 109
ℹ pass 109
ℹ fail 0

$ npm test -- --test-name-pattern launcher
ℹ tests 143
ℹ pass 143
ℹ fail 0
ℹ skipped 0

$ node --test tests/unit/launcher.test.js   # the new block, verbatim
✔ banner: a refusal writes exactly one blockquote line to state/refusal-banner.md (B1/B3, AC-1/AC-2) (39.272084ms)
✔ banner: whitespace runs and newlines in the reason fold to single spaces (B4, AC-3) (0.317875ms)
✔ banner: a reason longer than 2000 characters is cut before prefixing (B4, AC-4) (0.276167ms)
✔ banner: a second refusal OVERWRITES — banners never accumulate (B7, AC-5) (0.4895ms)
✔ banner: the file is 0600 after a refusal (B6, AC-6) (38.544458ms)
✔ banner: a failed banner write changes NOTHING about the refusal (B8, AC-7) (37.833459ms)
✔ banner: the launcher requires NO app-tree code to write it (B9, AC-10) (0.192833ms)
ℹ tests 46
ℹ pass 46
ℹ fail 0

$ npm test
ℹ tests 1951
ℹ suites 0
ℹ pass 1942
ℹ fail 0
ℹ cancelled 0
ℹ skipped 9
ℹ todo 0
ℹ duration_ms 45998.74525

$ npm run lint
> wienerdog@0.13.0 lint
> node scripts/lint.js

--- markdownlint ---
markdownlint-cli2 v0.23.0 (markdownlint v0.41.0)
Finding: docs/**/*.md skills/**/*.md templates/**/*.md tests/**/*.md *.md
Linting: 402 file(s)
Summary: 0 error(s)
--- shellcheck ---
--- PSScriptAnalyzer ---
--- frontmatter check ---
frontmatter check passed: 221 spec(s), 4 agent(s)

lint passed

# B9 — the launcher still requires no app-tree code (expect NO output):
$ grep -n "require(['\"]\.\./src\|require(['\"]\.\./\.\./src" src/scheduler/launcher.js
(no output; exit 1)

# B1/B13 — the basename is registered exactly once in the A5 set:
$ grep -n "refusal-banner.md" src/core/private-fs.js
125:  'refusal-banner.md',

# B10 — both clearer sites exist:
$ grep -n "clearRefusalBanner" src/cli/run-job.js src/cli/sync.js
src/cli/run-job.js:13:const { clearRefusalBanner } = require('../core/refusal-banner');
src/cli/run-job.js:1068:    clearRefusalBanner(paths);
src/cli/sync.js:12:const { clearRefusalBanner } = require('../core/refusal-banner');
src/cli/sync.js:276:  if (!dryRun) clearRefusalBanner(paths);
```

## Decisions made

1. **`tests/unit/private-fs.test.js` had to be touched, and the spec's Deliverables table
   did not list it — I added the row. Please confirm this amendment.**
   That file pins `A5_PRIVATE_FILE_BASENAMES` by value (`assert.deepEqual`) under the
   comment *"it must not be able to grow without someone noticing, which is what this
   assertion is for"*. Table B row B13 mandates growing it, so the WP cannot land green
   without the matching one-line update — `npm test` fails, and the `boundary` CI check
   failed on the first push for exactly this file. The two ways out were to weaken the
   assertion (wrong: the tripwire fired exactly as designed) or to record the file as
   the required deliverable it is. I took the second, in a separate commit
   (`docs(spec): record the private-fs membership test as a required deliverable`), and
   made the minimal change in the test itself: one array entry plus a comment naming B13,
   nothing else. The same gap will hit any future WP that adds an A5 or A9 basename.

2. **`writeRefusalBanner` is exported from `src/scheduler/launcher.js`.** AC-3 (folding)
   and AC-4 (the 2000-character cut) are properties of the writer, not of any refusal the
   verifier can be driven to produce — reaching them through `main()` would mean planting
   a verdict reason with an embedded newline, which no current return site emits. Exporting
   the function is the simpler option; it changes nothing about the launcher's runtime
   behaviour or its self-containment (the AC-10 test asserts that directly, by source grep).

3. **The `sync` clear sits before the digest render, not at the literal end of `run()`.**
   Table B row B10 says "at the end of a successful non-dry-run sync"; the Implementation
   notes say "Clear before render in `sync` … so a successful sync's own digest does not
   carry a banner it just invalidated". These cannot both be satisfied literally, so I
   followed the more specific instruction: the clear is step 0b, immediately after the
   private-modes repair and before the `renderDigest` call, guarded by `!dryRun` (B12).
   Consequence worth naming: a sync that throws *after* step 0b has cleared the banner
   without finishing. That is the direction the notes chose, and it is safe — the refusal's
   `alerts.jsonl` record is untouched, and a still-broken app tree re-banners at the next
   scheduler fire.

4. **`'refusal-banner.md'` is appended at the END of `A5_PRIVATE_FILE_BASENAMES`.** The
   order is not load-bearing (the set is consumed by `map`), and appending keeps the diff
   to one line.

5. **The launcher's clearer site in `run-job.js` is not covered by a new executable test.**
   Exercising it means driving a full job run (spawn, watchdog, log streaming); the
   spec's own verification for B10 is a grep for both call sites, and
   `tests/unit/scheduler-runjob.test.js` is not in the Deliverables table. The `sync`
   clearer *is* covered end-to-end (AC-11/AC-12) through the hermetic sync harness.

6. **`readRefusalBanner` trims *all* trailing newlines** (`/\n+$/`), not just one. The
   contract says "trailing newline trimmed" and the written file has exactly one, so the
   two readings coincide today; the greedier trim is the same length and survives a
   hand-edited file. Leading whitespace is deliberately left alone — the banner's `> `
   prefix is load-bearing markdown.

7. **The banner's temp file is written with the default mode, then chmodded after the
   rename**, exactly as B5/B6 specify, rather than passing `mode: 0o600` to
   `writeFileSync`. The temp lives inside `p.state`, which is `mkdir`ed `0o700` in the
   same call, so the brief window is not reachable by another user. Following the table
   literally beats a local improvement here.

## Discovered issues (out of scope, not fixed)

- **A spec that adds an A5/A9 basename must list `tests/unit/private-fs.test.js`** — see
  Decisions made #1. Worth a line in the architect's spec checklist so the next such WP
  does not learn it from a red `boundary` check.
- **The refusal text still promises "This alert will appear in your next digest."**
  Nothing reads the banner yet, so on a broken app tree that sentence remains
  unkeepable until `WP-refusal-banner-delivery` lands. Changing `refusalText` is
  explicitly out of scope for this WP, and the banner is deliberately byte-identical
  to it — but the promise and its delivery are still one merge apart.
- **The email leg of fail-loud is still dead in exactly the case the banner covers.**
  It spawns the CLI shim, which is unusable when `app/current` is what failed
  (`WP-shim-recovery-message` territory) — noted, not touched.
- **`appendRefuseAlert` still appends to an unbounded `alerts.jsonl`.** A refusal that
  fires hourly for four weeks writes ~700 records. The banner overwrites and so cannot
  grow, but the alert file can; that is `WP-launcher-alert-bound`, untouched here.

---
Generated-by: claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9LjCEYVM481sJirm1HDY1
