### PR TITLE
fix(launcher): bound the refusal alert log (WP-launcher-alert-bound)

### DIFF
--- a/docs/specs/WP-launcher-alert-bound.md
+++ b/docs/specs/WP-launcher-alert-bound.md
@@ -1,7 +1,7 @@
 ---
 id: WP-launcher-alert-bound
 title: Bound the launcher's alert writer without understating a real failure streak — collapse consecutive identical refusals into a count field
-status: Draft
+status: In-Review
 model: opus
 size: M
 depends_on: []

--- a/src/core/alerts.js
+++ b/src/core/alerts.js
@@ -28,32 +28,52 @@ const ALERTS_FILE = 'alerts.jsonl';
 const MAX_ALERTS = 200; // keep only the most-recent N records
 const MAX_FIELD_CHARS = 2000; // cap each string field (control-plane text, not prose)
 const MAX_FILE_BYTES = 512 * 1024; // hard byte bound on the log file / the read
+// Ceiling on a record's `count` — the streak length a collapsed launcher refusal
+// carries (WP-launcher-alert-bound, Table C3). Bounds a parsed-input number before
+// it reaches the digest banner's arithmetic. MAX_ALERTS, MAX_FILE_BYTES and
+// MAX_COUNT are duplicated as literals in src/scheduler/launcher.js, which cannot
+// require this module (Table C11) — update the two copies together.
+const MAX_COUNT = 1000000;
 
 /** @param {import('./paths').WienerdogPaths} paths @returns {string} */
 function alertsPath(paths) {
   return path.join(paths.state, ALERTS_FILE);
 }
 
-/** Coerce a record to the known string fields, each length-capped and then
- *  secret-scrubbed (EP3, audit A5 / ADR-0024 / WP-124): the cap bounds the scan
- *  input, then `redactOnly` guarantees no secret persists to alerts.jsonl or
- *  reaches the digest — `at`/`job`/`log_hint` are code-owned no-ops, but
- *  scanning uniformly is the fail-closed choice. Requires a non-null,
+/** The alert record.
+ *  @typedef {{job:string, at:string, reason:string, log_hint:string, count:number}} Alert
+ *  `count` — how many consecutive identical (job, reason) refusals this row
+ *  represents (Table C1). ALWAYS present after sanitizeAlert; >= 1; an
+ *  absent/invalid input value becomes 1. Only the launcher's writer ever
+ *  collapses, so appendAlert always records 1. */
+
+/** Coerce a record to the known fields: the four string fields, each length-capped
+ *  and then secret-scrubbed (EP3, audit A5 / ADR-0024 / WP-124) — the cap bounds the
+ *  scan input, then `redactOnly` guarantees no secret persists to alerts.jsonl or
+ *  reaches the digest (`at`/`job`/`log_hint` are code-owned no-ops, but scanning
+ *  uniformly is the fail-closed choice) — plus the numeric `count`, coerced FAIL
+ *  CLOSED to 1 (Table C2): anything that is not a safe integer >= 1 (absent, 0, -1,
+ *  1.5, NaN, Infinity, 1e309, an object) becomes 1, and anything larger is clamped to
+ *  MAX_COUNT, so a hand-edited alerts.jsonl cannot push a nonsense or memory-hostile
+ *  number into the digest banner's arithmetic. A pre-WP record with no `count` reads
+ *  as 1, so no migration is needed (Table C13). Requires a non-null,
  *  non-array OBJECT — any other value (null, number, string, array) is
  *  treated as an empty object, so a valid-JSON primitive can't crash the deref.
- *  Drops unknown keys; missing fields become ''.
- *  @param {*} r @returns {{job:string, at:string, reason:string, log_hint:string}} */
+ *  Drops unknown keys; missing string fields become ''.
+ *  @param {*} r @returns {Alert} */
 function sanitizeAlert(r) {
   const o = r && typeof r === 'object' && !Array.isArray(r) ? r : {};
   const scrub = (v) => redactOnly(String(v == null ? '' : v).slice(0, MAX_FIELD_CHARS));
-  return { job: scrub(o.job), at: scrub(o.at), reason: scrub(o.reason), log_hint: scrub(o.log_hint) };
+  const n = Number(o.count);
+  const count = Number.isSafeInteger(n) && n >= 1 ? Math.min(n, MAX_COUNT) : 1;
+  return { job: scrub(o.job), at: scrub(o.at), reason: scrub(o.reason), log_hint: scrub(o.log_hint), count };
 }
 
 /** Append one unresolved failure alert (atomic append; creates state/ if needed).
  *  Compacts to `MAX_ALERTS` records / `MAX_FILE_BYTES` bytes when either bound
  *  is exceeded after the append.
  *  @param {import('./paths').WienerdogPaths} paths
- *  @param {{job:string, at:string, reason:string, log_hint:string}} record */
+ *  @param {{job:string, at:string, reason:string, log_hint:string, count?:number}} record */
 function appendAlert(paths, record) {
   mkdirPrivate(paths.state); // 0700 independent of umask (audit A5, WP-126)
   const file = alertsPath(paths);
@@ -125,7 +145,7 @@ function appendAlert(paths, record) {
  *  Byte-bounds its read (tail window of `MAX_FILE_BYTES` for oversized files) and
  *  sanitizes every parsed line so no unbounded/primitive record reaches callers.
  *  @param {import('./paths').WienerdogPaths} paths
- *  @returns {Array<{job:string, at:string, reason:string, log_hint:string}>} */
+ *  @returns {Alert[]} */
 function readAlerts(paths) {
   const file = alertsPath(paths);
   let fd;
@@ -216,4 +236,5 @@ module.exports = {
   MAX_ALERTS,
   MAX_FIELD_CHARS,
   MAX_FILE_BYTES,
+  MAX_COUNT,
 };

--- a/src/core/digest.js
+++ b/src/core/digest.js
@@ -6,6 +6,7 @@ const { defaultLayout } = require('./layout');
 const { isCapabilityAllowed, CAPABILITY } = require('./safety-profile');
 const { parse, readBool, INVALID } = require('./frontmatter');
 const { hashBytes, foldKey } = require('./identity-approvals');
+const { MAX_COUNT } = require('./alerts');
 // Module-object require (not destructured): EP4's test seam stubs
 // secretScan.scanAndRedact to prove a failing scanner omits, never throws.
 const secretScan = require('./secret-scan');
@@ -287,11 +288,21 @@ function newestDaily(dir) {
  */
 function formatAlerts(alerts) {
   if (!alerts || alerts.length === 0) return '';
+  // The banner counts FAILURES, not rows (WP-launcher-alert-bound, Table C12): the
+  // launcher collapses a repeating identical refusal into one row carrying the streak
+  // in `count`, so summing rows would understate a real recurring failure. `count` is
+  // parsed input, so coerce it fail-closed BEFORE the arithmetic — mirroring
+  // sanitizeAlert (Table C2) for callers that pass records readAlerts did not
+  // sanitize, and reading a pre-WP record with no `count` as 1 (Table C13).
+  const countOf = (a) => {
+    const n = Number(a && a.count);
+    return Number.isSafeInteger(n) && n >= 1 ? Math.min(n, MAX_COUNT) : 1;
+  };
   /** @type {Map<string, {count:number, first:string, lastReason:string, hint:string}>} */
   const byJob = new Map();
   for (const a of alerts) {
     const cur = byJob.get(a.job) || { count: 0, first: a.at, lastReason: a.reason, hint: a.log_hint };
-    cur.count += 1;
+    cur.count = Math.min(cur.count + countOf(a), MAX_COUNT); // clamp the SUM too: 200 rows at MAX_COUNT stays a safe integer
     if (a.at < cur.first) cur.first = a.at;
     cur.lastReason = a.reason; // alerts are oldest-first → last wins
     cur.hint = a.log_hint;

--- a/src/scheduler/launcher.js
+++ b/src/scheduler/launcher.js
@@ -165,9 +165,93 @@ function liveStance(p) {
   return containedIn(p.appDir, p.appCurrent) ? 'prod' : 'dev';
 }
 
+// The alert-log bounds, hand-duplicated as LITERALS because this file may require
+// Node builtins ONLY (WP-launcher-alert-bound Table C11): requiring src/core/alerts.js
+// would execute code from the very app tree the launcher exists to verify. Their twins
+// are MAX_ALERTS, MAX_FILE_BYTES and MAX_COUNT in src/core/alerts.js — the duplication
+// is deliberate and registered as Table C3/C4/C5; update the two copies together.
+const ALERT_MAX_RECORDS = 200; // twin: MAX_ALERTS in src/core/alerts.js
+const ALERT_MAX_FILE_BYTES = 512 * 1024; // twin: MAX_FILE_BYTES in src/core/alerts.js
+const ALERT_MAX_COUNT = 1000000; // twin: MAX_COUNT in src/core/alerts.js
+
+/** Read alerts.jsonl back, oldest-first, for the collapse+bound rewrite below.
+ *  A self-contained minimal twin of readAlerts in src/core/alerts.js (Table C11 —
+ *  no app-tree require). Byte-bounds the read to a trailing ALERT_MAX_FILE_BYTES
+ *  window so a pathologically grown log cannot be slurped whole; when the window
+ *  starts mid-file its first line is dropped as a possible partial (the byte bound
+ *  below would drop that oldest record anyway). Malformed lines are skipped, and
+ *  `count` is coerced fail-closed to 1 BEFORE any arithmetic, exactly as
+ *  sanitizeAlert does (Table C2/C13) — a hand-edited NaN/Infinity/-1/1e309 can never
+ *  reach the rewritten file. Any read failure yields [] (the caller then leaves the
+ *  atomically-appended file alone, Table C9).
+ *  @param {string} file
+ *  @returns {Array<{job:string, at:string, reason:string, log_hint:string, count:number}>} */
+function readAlertRecords(file) {
+  let fd;
+  try {
+    fd = fs.openSync(file, 'r');
+  } catch {
+    return [];
+  }
+  let text;
+  try {
+    const st = fs.fstatSync(fd); // stat the OPEN fd — no stat→read TOCTOU
+    const start = st.size > ALERT_MAX_FILE_BYTES ? st.size - ALERT_MAX_FILE_BYTES : 0;
+    const len = st.size - start;
+    const buf = Buffer.alloc(len);
+    let off = 0;
+    while (off < len) {
+      const n = fs.readSync(fd, buf, off, len - off, start + off);
+      if (n === 0) break;
+      off += n;
+    }
+    text = buf.subarray(0, off).toString('utf8');
+    if (start > 0) {
+      const nl = text.indexOf('\n'); // the window may have split a record → drop that line
+      text = nl === -1 ? '' : text.slice(nl + 1);
+    }
+  } catch {
+    return [];
+  } finally {
+    fs.closeSync(fd);
+  }
+  const out = [];
+  for (const line of text.split('\n')) {
+    if (line.trim() === '') continue;
+    let r;
+    try {
+      r = JSON.parse(line);
+    } catch {
+      continue; // skip malformed
+    }
+    if (!r || typeof r !== 'object' || Array.isArray(r)) continue;
+    const n = Number(r.count);
+    const count = Number.isSafeInteger(n) && n >= 1 ? Math.min(n, ALERT_MAX_COUNT) : 1;
+    const str = (v) => String(v == null ? '' : v);
+    out.push({ job: str(r.job), at: str(r.at), reason: str(r.reason), log_hint: str(r.log_hint), count });
+  }
+  return out;
+}
+
 /** Minimal durable alert append (code-owned reason — no secrets, so no
  *  redaction/compaction machinery from src/core/alerts.js is needed; this must
  *  work even when the app tree is the thing being refused).
+ *
+ *  COLLAPSED + BOUNDED (WP-launcher-alert-bound, Table C). A launcher refusal is
+ *  correct but recurs on the OS schedule, so an unbounded writer grew alerts.jsonl
+ *  forever AND let one repeating refusal crowd every other job out of the app-side
+ *  newest-200 compaction. Two repairs, together because either alone is lossy:
+ *   - a consecutive identical (job, reason) collapses into the previous record's
+ *     `count` (C6/C7) — only the file's LAST record is a candidate, and the
+ *     original `at` is kept so the banner's "since <first>" still names the onset;
+ *     the digest sums `count` (C12), so the honest streak length survives;
+ *   - the same count/byte bounds the app-side writer applies are re-applied here
+ *     (C4/C5/C10).
+ *  Ordering mirrors appendAlert and is load-bearing: append the new record
+ *  ATOMICALLY first so this process never loses its own fail-loud record to a
+ *  concurrent compaction (C8), skip the rewrite entirely on an empty read-back
+ *  because that means the read FAILED rather than the log being empty (C9), then
+ *  budget count-first, bytes-second, always keeping at least the newest record (C10).
  *  @param {{state:string}} p @param {string} job @param {string} reason */
 function appendRefuseAlert(p, job, reason) {
   try {
@@ -189,15 +273,53 @@ function appendRefuseAlert(p, job, reason) {
     } catch {
       /* no existing file */
     }
-    const record = { job, at: new Date().toISOString(), reason, log_hint: '' };
+    const record = { job, at: new Date().toISOString(), reason, log_hint: '', count: 1 };
     fs.appendFileSync(file, `${sep}${JSON.stringify(record)}\n`);
-    if (process.platform !== 'win32') {
-      try {
-        fs.chmodSync(file, 0o600);
-      } catch {
-        /* best-effort */
+    const chmod = () => {
+      if (process.platform !== 'win32') {
+        try {
+          fs.chmodSync(file, 0o600);
+        } catch {
+          /* best-effort */
+        }
+      }
+    };
+    chmod(); // the append may have CREATED the file under umask
+    let size = 0;
+    try {
+      size = fs.statSync(file).size;
+    } catch {
+      size = 0;
+    }
+    const rows = readAlertRecords(file);
+    if (rows.length === 0) return; // C9 — the read failed; leave the appended file intact
+    // C6/C7 — collapse ONLY the just-appended record into its immediate predecessor,
+    // and only on an exact (job, reason) match compared with === on parsed strings.
+    // A non-adjacent match is left alone: merging it would reorder the log and break
+    // the oldest-first contract formatAlerts relies on for "last wins" on the reason.
+    let collapsed = false;
+    if (rows.length >= 2) {
+      const last = rows[rows.length - 1];
+      const prev = rows[rows.length - 2];
+      if (prev.job === last.job && prev.reason === last.reason) {
+        prev.count = Math.min(prev.count + 1, ALERT_MAX_COUNT); // prev.at (the FIRST occurrence) is kept
+        rows.pop();
+        collapsed = true;
       }
     }
+    if (!collapsed && rows.length <= ALERT_MAX_RECORDS && size <= ALERT_MAX_FILE_BYTES) return;
+    // C10 — count budget first, then byte budget; never drop the newest record.
+    let kept = rows.slice(Math.max(0, rows.length - ALERT_MAX_RECORDS));
+    const serialize = (rw) => rw.map((a) => JSON.stringify(a)).join('\n') + '\n';
+    let text = serialize(kept);
+    while (kept.length > 1 && Buffer.byteLength(text) > ALERT_MAX_FILE_BYTES) {
+      kept = kept.slice(1); // drop oldest
+      text = serialize(kept);
+    }
+    const tmp = `${file}.${process.pid}.tmp`;
+    fs.writeFileSync(tmp, text, { mode: 0o600 });
+    fs.renameSync(tmp, file); // atomic replace (mirrors appendAlert/clearAlerts)
+    chmod();
   } catch {
     /* the alert is best-effort — the refusal (non-zero exit, zero spawn) stands regardless */
   }
@@ -552,7 +674,7 @@ function main(argv, opts = {}) {
   return code;
 }
 
-module.exports = { verifyAndResolve, verifyCatchup, appTreeDigestOf, verifyContainment, liveStance, parseArgv, refusalText, remedyOf, main };
+module.exports = { verifyAndResolve, verifyCatchup, appTreeDigestOf, verifyContainment, liveStance, parseArgv, refusalText, remedyOf, appendRefuseAlert, main };
 
 // When the vendored copy at <core>/launcher/launch.js is executed by the OS
 // scheduler, run main with the real argv.

--- a/tests/unit/alerts.test.js
+++ b/tests/unit/alerts.test.js
@@ -15,6 +15,7 @@ const {
   MAX_ALERTS,
   MAX_FIELD_CHARS,
   MAX_FILE_BYTES,
+  MAX_COUNT,
 } = require('../../src/core/alerts');
 const { renderDigest } = require('../../src/core/digest');
 
@@ -133,7 +134,7 @@ test('alerts: unknown keys are dropped and missing fields read back as empty str
   fs.writeFileSync(file, `${JSON.stringify({ job: 'dream', extra: 'nope' })}\n`);
   const got = readAlerts(paths);
   assert.equal(got.length, 1);
-  assert.deepEqual(got[0], { job: 'dream', at: '', reason: '', log_hint: '' });
+  assert.deepEqual(got[0], { job: 'dream', at: '', reason: '', log_hint: '', count: 1 }); // count is always present (C1)
 });
 
 test('alerts: a valid-JSON primitive line does not crash and reads back as an empty-fields record', () => {
@@ -144,7 +145,7 @@ test('alerts: a valid-JSON primitive line does not crash and reads back as an em
   const got = readAlerts(paths);
   assert.equal(got.length, 4, 'all four primitive lines parse without throwing');
   for (const a of got) {
-    assert.deepEqual(a, { job: '', at: '', reason: '', log_hint: '' });
+    assert.deepEqual(a, { job: '', at: '', reason: '', log_hint: '', count: 1 }); // count is always present (C1)
   }
 });
 
@@ -394,4 +395,78 @@ test('alerts: alerts.jsonl ends 0600 after append and after compaction (WP-126)'
   }
   assert.equal(fs.statSync(file).mode & 0o777, 0o600, 'compaction rewrite leaves 0600');
   assert.equal(readAlerts(paths).length, MAX_ALERTS, 'compaction bound unchanged');
+});
+
+// -------------------------------------------------------------------------
+// the `count` field (WP-launcher-alert-bound, Table C1/C2/C3/C13)
+// -------------------------------------------------------------------------
+
+test('alerts: count is coerced fail-closed to 1 for absent/0/-1/1.5/NaN/Infinity/1e309/object; "3" is 3 (AC-1, C2)', () => {
+  /** @type {Array<[string, *, number]>} */
+  const cases = [
+    ['absent', undefined, 1],
+    ['0', 0, 1],
+    ['-1', -1, 1],
+    ['1.5', 1.5, 1],
+    ['NaN', NaN, 1],
+    ['Infinity', Infinity, 1],
+    ['1e309 (overflows to Infinity)', 1e309, 1],
+    ['"9".repeat(400)', '9'.repeat(400), 1],
+    ['an object', {}, 1],
+    ['an array', [], 1],
+    ['null', null, 1],
+    ['the string "3"', '3', 3],
+    ['a plain 5', 5, 5],
+  ];
+  for (const [label, input, want] of cases) {
+    const { paths } = setup();
+    const r = rec('dream', '2026-08-30T03:30:00.000Z', 'exited 1');
+    if (label !== 'absent') r.count = input;
+    appendAlert(paths, r);
+    const got = readAlerts(paths);
+    assert.equal(got.length, 1, `one record for ${label}`);
+    assert.equal(got[0].count, want, `count for ${label}`);
+    assert.equal(typeof got[0].count, 'number', `count stays a number for ${label}`);
+  }
+});
+
+test('alerts: a count above MAX_COUNT is clamped to MAX_COUNT (AC-2, C3)', () => {
+  const { paths } = setup();
+  appendAlert(paths, { ...rec('dream', '2026-08-30T03:30:00.000Z', 'exited 1'), count: MAX_COUNT + 12345 });
+  assert.equal(readAlerts(paths)[0].count, MAX_COUNT, 'clamped, not passed through');
+  assert.equal(MAX_COUNT, 1000000, 'the value the launcher duplicates as a literal (C3)');
+});
+
+test('alerts: every record appendAlert writes carries count 1 — the app-side writer never collapses', () => {
+  const { paths } = setup();
+  appendAlert(paths, rec('dream', '2026-08-30T03:30:00.000Z', 'exited 1'));
+  appendAlert(paths, rec('dream', '2026-08-30T04:30:00.000Z', 'exited 1')); // identical (job, reason)
+  const raw = fs.readFileSync(path.join(paths.state, ALERTS_FILE), 'utf8').trim().split('\n');
+  assert.equal(raw.length, 2, 'two rows — appendAlert does not collapse');
+  for (const line of raw) assert.equal(JSON.parse(line).count, 1);
+});
+
+test('alerts: a pre-WP alerts.jsonl with no count field reads as count 1 and renders unchanged (AC-12, C13)', () => {
+  const { paths } = setup();
+  fs.mkdirSync(paths.state, { recursive: true });
+  // Hand-written in the OLD four-field shape — no migration step exists or is needed.
+  fs.writeFileSync(
+    path.join(paths.state, ALERTS_FILE),
+    JSON.stringify({ job: 'dream', at: '2026-08-30T03:30:00.000Z', reason: 'exited 1', log_hint: 'logs/dream/' }) + '\n'
+  );
+  const got = readAlerts(paths);
+  assert.equal(got.length, 1);
+  assert.equal(got[0].count, 1, 'absent count reads as 1');
+  const out = renderDigest(FIXTURE, undefined, { alerts: got });
+  assert.ok(out.includes('the "dream" job has failed. Latest error: exited 1.'), out.split('\n')[0]);
+});
+
+test('alerts: count survives a readAlerts → clearAlerts round-trip for the surviving job', () => {
+  const { paths } = setup();
+  appendAlert(paths, { ...rec('dream', '2026-08-30T03:30:00.000Z', 'exited 1'), count: 7 });
+  appendAlert(paths, rec('digest', '2026-08-30T07:00:00.000Z', 'exited 2'));
+  clearAlerts(paths, 'digest');
+  const got = readAlerts(paths);
+  assert.equal(got.length, 1);
+  assert.deepEqual([got[0].job, got[0].count], ['dream', 7], 'the rewrite preserves count');
 });

--- a/tests/unit/digest.test.js
+++ b/tests/unit/digest.test.js
@@ -14,6 +14,7 @@ const {
   readNoteBounded,
 } = require('../../src/core/digest');
 const { allowAll } = require('../../src/core/safety-profile');
+const { MAX_COUNT } = require('../../src/core/alerts');
 const { approvalsFromVault } = require('../../src/core/identity-approvals');
 const { defaultLayout } = require('../../src/core/layout');
 
@@ -813,4 +814,76 @@ test('insecureModes: a positive count renders the fixed banner in the prefix; 0/
   assert.ok(bannerLine && !/[/\\]/.test(bannerLine.replace('`wienerdog sync`', '').replace('`wienerdog doctor`', '')), 'no paths in the banner line');
   assert.equal(renderDigest(FIXTURE, undefined, { identityApprovals: approvals(FIXTURE), insecureModes: 0, profile: BLOCKED }), golden);
   assert.equal(renderDigest(FIXTURE, undefined, { identityApprovals: approvals(FIXTURE), profile: BLOCKED }), golden);
+});
+
+// -------------------------------------------------------------------------
+// formatAlerts sums `count` (WP-launcher-alert-bound, Table C12 / AC-3…AC-6)
+// -------------------------------------------------------------------------
+
+/** The alert banner line only (the digest prefix's first block). */
+function alertBanner(alerts) {
+  return renderDigest(FIXTURE, undefined, { alerts, identityApprovals: approvals(FIXTURE), profile: BLOCKED }).split('\n')[0];
+}
+
+test('digest: formatAlerts sums count across rows — 1 + 5 renders "has failed 6 times since" the EARLIEST at (AC-3, C12/C7)', () => {
+  const alerts = [
+    { job: 'dream', at: '2026-08-01T03:30:00.000Z', reason: 'integrity mismatch', log_hint: 'logs/dream/', count: 5 },
+    { job: 'dream', at: '2026-08-30T03:30:00.000Z', reason: 'integrity mismatch', log_hint: 'logs/dream/', count: 1 },
+  ];
+  const line = alertBanner(alerts);
+  assert.ok(
+    line.includes('the "dream" job has failed 6 times since 2026-08-01T03:30:00.000Z.'),
+    `summed count + onset timestamp: ${line}`
+  );
+});
+
+test('digest: a single row with count 1 still renders "has failed" with no number (AC-4, C12)', () => {
+  const line = alertBanner([{ job: 'dream', at: '2026-08-30T03:30:00.000Z', reason: 'boom', log_hint: 'logs/dream/', count: 1 }]);
+  assert.ok(line.includes('the "dream" job has failed. Latest error: boom.'), line);
+  assert.ok(!line.includes('times since'), 'wording unchanged from before the count field');
+});
+
+test('digest: a single COLLAPSED row with count 4 renders the real streak, not "has failed" (C12)', () => {
+  const line = alertBanner([{ job: 'dream', at: '2026-08-27T03:30:00.000Z', reason: 'boom', log_hint: 'logs/dream/', count: 4 }]);
+  assert.ok(line.includes('the "dream" job has failed 4 times since 2026-08-27T03:30:00.000Z.'), line);
+});
+
+test('digest: a summed total over MAX_COUNT is clamped, never rendered as an unsafe integer (AC-5)', () => {
+  const alerts = [
+    { job: 'dream', at: '2026-08-01T03:30:00.000Z', reason: 'boom', log_hint: 'logs/dream/', count: MAX_COUNT },
+    { job: 'dream', at: '2026-08-02T03:30:00.000Z', reason: 'boom', log_hint: 'logs/dream/', count: MAX_COUNT },
+    { job: 'dream', at: '2026-08-03T03:30:00.000Z', reason: 'boom', log_hint: 'logs/dream/', count: MAX_COUNT },
+  ];
+  const line = alertBanner(alerts);
+  assert.ok(line.includes(`has failed ${MAX_COUNT} times since`), line);
+  assert.ok(!line.includes('e+'), 'no exponential/unsafe number reaches the banner');
+});
+
+test('digest: a hostile or absent count contributes exactly 1 — the banner never shows NaN/Infinity (C2/C13)', () => {
+  const hostile = [
+    { job: 'dream', at: '2026-08-01T03:30:00.000Z', reason: 'boom', log_hint: 'logs/dream/' }, // pre-WP row, no count
+    { job: 'dream', at: '2026-08-02T03:30:00.000Z', reason: 'boom', log_hint: 'logs/dream/', count: NaN },
+    { job: 'dream', at: '2026-08-03T03:30:00.000Z', reason: 'boom', log_hint: 'logs/dream/', count: Infinity },
+    { job: 'dream', at: '2026-08-04T03:30:00.000Z', reason: 'boom', log_hint: 'logs/dream/', count: -1 },
+    { job: 'dream', at: '2026-08-05T03:30:00.000Z', reason: 'boom', log_hint: 'logs/dream/', count: '9'.repeat(400) },
+  ];
+  const line = alertBanner(hostile);
+  assert.ok(line.includes('has failed 5 times since 2026-08-01T03:30:00.000Z.'), line);
+  assert.ok(!/NaN|Infinity/.test(line), 'no NaN/Infinity in the banner');
+});
+
+test('digest: counts are summed per job, not across jobs (C12)', () => {
+  const alerts = [
+    { job: 'dream', at: '2026-08-01T03:30:00.000Z', reason: 'boom', log_hint: 'logs/dream/', count: 3 },
+    { job: 'digest', at: '2026-08-02T07:00:00.000Z', reason: 'bang', log_hint: 'logs/digest/', count: 1 },
+  ];
+  const out = renderDigest(FIXTURE, undefined, { alerts, identityApprovals: approvals(FIXTURE), profile: BLOCKED });
+  assert.ok(out.includes('the "dream" job has failed 3 times since 2026-08-01T03:30:00.000Z.'), out.split('\n')[0]);
+  assert.ok(out.includes('the "digest" job has failed. Latest error: bang.'), out.split('\n')[1]);
+});
+
+test('digest: the golden with no alerts is byte-identical — the count field changes nothing (AC-6)', () => {
+  const golden = fs.readFileSync(GOLDEN, 'utf8');
+  const out = renderDigest(FIXTURE, undefined, { alerts: [], identityApprovals: approvals(FIXTURE), profile: BLOCKED });
+  assert.equal(out, golden, 'no alerts → the frozen golden, unchanged');
 });

--- a/tests/unit/launcher.test.js
+++ b/tests/unit/launcher.test.js
@@ -821,3 +821,213 @@ test('remedy: an INHERITED remedy does not select the sync tail (ownership)', ()
     delete Object.prototype.remedy;
   }
 });
+
+// -------------------------------------------------------------------------
+// appendRefuseAlert: collapse + bound (WP-launcher-alert-bound, Table C)
+// -------------------------------------------------------------------------
+
+const ALERT_MAX_RECORDS = 200; // mirrors the launcher's literal / MAX_ALERTS (C4)
+const ALERT_MAX_FILE_BYTES = 512 * 1024; // mirrors the launcher's literal / MAX_FILE_BYTES (C5)
+
+/** A bare temp state dir — the only thing appendRefuseAlert needs (it writes
+ *  alerts.jsonl there and requires nothing from the app tree, C11). */
+function alertState() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-launch-alert-'));
+  const state = path.join(root, 'state');
+  return { root, p: { state }, file: path.join(state, 'alerts.jsonl') };
+}
+
+/** Parse alerts.jsonl into records, oldest-first. */
+function readRows(file) {
+  return fs
+    .readFileSync(file, 'utf8')
+    .split('\n')
+    .filter((l) => l.trim() !== '')
+    .map((l) => JSON.parse(l));
+}
+
+test('launcher: two identical (job, reason) refusals collapse into ONE record with count 2 (AC-7, C6/C7)', () => {
+  const { p, file } = alertState();
+  launcher.appendRefuseAlert(p, 'dream', 'refusing to run: integrity mismatch');
+  const firstAt = readRows(file)[0].at;
+  launcher.appendRefuseAlert(p, 'dream', 'refusing to run: integrity mismatch');
+
+  const rows = readRows(file);
+  assert.equal(rows.length, 1, 'the repeat collapsed — the file did not grow');
+  assert.equal(rows[0].count, 2, 'the streak length is carried, not discarded');
+  assert.equal(rows[0].at, firstAt, 'at keeps the FIRST occurrence — the banner onset stays truthful');
+  assert.equal(rows[0].job, 'dream');
+  assert.equal(rows[0].log_hint, '');
+});
+
+test('launcher: a repeat collapses into a hand-seeded PRIOR record and keeps its old timestamp (AC-7, C7)', () => {
+  const { p, file } = alertState();
+  fs.mkdirSync(p.state, { recursive: true, mode: 0o700 });
+  const reason = 'refusing to run: integrity mismatch';
+  fs.writeFileSync(file, JSON.stringify({ job: 'dream', at: '2026-08-01T03:30:00.000Z', reason, log_hint: '', count: 118 }) + '\n');
+
+  launcher.appendRefuseAlert(p, 'dream', reason);
+
+  const rows = readRows(file);
+  assert.equal(rows.length, 1, 'still one record');
+  assert.equal(rows[0].count, 119, 'the 2026-08-01 logbook streak advances by exactly one');
+  assert.equal(rows[0].at, '2026-08-01T03:30:00.000Z', 'the onset timestamp is NOT overwritten');
+});
+
+test('launcher: a hundred identical refusals leave one record with count 100 — the growth defect is cured', () => {
+  const { p, file } = alertState();
+  for (let i = 0; i < 100; i += 1) launcher.appendRefuseAlert(p, 'dream', 'refusing to run: integrity mismatch');
+  const rows = readRows(file);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].count, 100);
+  assert.ok(fs.statSync(file).size < 500, `the file stays tiny: ${fs.statSync(file).size} bytes`);
+});
+
+test('launcher: two DIFFERENT reasons leave two records, each count 1 (AC-8, C6)', () => {
+  const { p, file } = alertState();
+  launcher.appendRefuseAlert(p, 'dream', 'refusing to run: integrity mismatch');
+  launcher.appendRefuseAlert(p, 'dream', 'refusing to run: stance mismatch');
+  const rows = readRows(file);
+  assert.equal(rows.length, 2, 'a different reason is a different failure — no collapse');
+  assert.deepEqual(rows.map((r) => r.count), [1, 1]);
+});
+
+test('launcher: the same reason under a DIFFERENT job does not collapse (AC-8, C6)', () => {
+  const { p, file } = alertState();
+  launcher.appendRefuseAlert(p, 'dream', 'refusing to run: integrity mismatch');
+  launcher.appendRefuseAlert(p, 'digest', 'refusing to run: integrity mismatch');
+  const rows = readRows(file);
+  assert.equal(rows.length, 2, 'the collapse key is the PAIR (job, reason)');
+  assert.deepEqual(rows.map((r) => r.job), ['dream', 'digest']);
+});
+
+test('launcher: a match against a NON-LAST record appends instead of collapsing (AC-9, C6)', () => {
+  const { p, file } = alertState();
+  launcher.appendRefuseAlert(p, 'dream', 'reason A');
+  launcher.appendRefuseAlert(p, 'dream', 'reason B'); // now the last record
+  launcher.appendRefuseAlert(p, 'dream', 'reason A'); // matches record 1, which is NOT last
+
+  const rows = readRows(file);
+  assert.equal(rows.length, 3, 'no non-adjacent merge — the oldest-first order is preserved');
+  assert.deepEqual(rows.map((r) => r.reason), ['reason A', 'reason B', 'reason A']);
+  assert.deepEqual(rows.map((r) => r.count), [1, 1, 1]);
+});
+
+test('launcher: a prefix of the last reason is not a match — the compare is exact (C6)', () => {
+  const { p, file } = alertState();
+  launcher.appendRefuseAlert(p, 'dream', 'refusing to run: integrity mismatch');
+  launcher.appendRefuseAlert(p, 'dream', 'refusing to run: integrity mismatch (again)');
+  assert.equal(readRows(file).length, 2, 'no prefix/fuzzy matching');
+});
+
+test('launcher: beyond MAX_ALERTS distinct records the log holds exactly MAX_ALERTS, newest kept (AC-10, C4/C10)', () => {
+  const { p, file } = alertState();
+  const total = ALERT_MAX_RECORDS + 25;
+  for (let i = 0; i < total; i += 1) launcher.appendRefuseAlert(p, 'dream', `refusing to run: distinct reason ${i}`);
+
+  const rows = readRows(file);
+  assert.equal(rows.length, ALERT_MAX_RECORDS, 'the launcher now has the bound the app-side writer has');
+  assert.equal(rows[rows.length - 1].reason, `refusing to run: distinct reason ${total - 1}`, 'newest kept');
+  assert.equal(rows[0].reason, `refusing to run: distinct reason ${total - ALERT_MAX_RECORDS}`, 'oldest dropped');
+});
+
+test('launcher: a log already over MAX_FILE_BYTES is reduced below it, keeping the newest record (AC-11, C5/C10)', () => {
+  const { p, file } = alertState();
+  fs.mkdirSync(p.state, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(file, 'x'.repeat(ALERT_MAX_FILE_BYTES + 1000) + '\n'); // one huge malformed line
+  assert.ok(fs.statSync(file).size > ALERT_MAX_FILE_BYTES, 'precondition: already over the byte bound');
+
+  launcher.appendRefuseAlert(p, 'dream', 'refusing to run: fresh failure');
+
+  assert.ok(fs.statSync(file).size <= ALERT_MAX_FILE_BYTES, 'brought back under the byte bound');
+  const rows = readRows(file);
+  assert.equal(rows.length, 1, 'at least — and here exactly — the newest record survives');
+  assert.equal(rows[0].reason, 'refusing to run: fresh failure');
+});
+
+test('launcher: a pre-WP record with no count collapses correctly — no migration step (C13)', () => {
+  const { p, file } = alertState();
+  fs.mkdirSync(p.state, { recursive: true, mode: 0o700 });
+  const reason = 'refusing to run: integrity mismatch';
+  // The OLD four-field shape, exactly as an installed 0.13.0 log holds it.
+  fs.writeFileSync(file, JSON.stringify({ job: 'dream', at: '2026-08-01T03:30:00.000Z', reason, log_hint: '' }) + '\n');
+
+  launcher.appendRefuseAlert(p, 'dream', reason);
+
+  const rows = readRows(file);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].count, 2, 'the countless record read as 1, then incremented');
+});
+
+test('launcher: an unreadable-but-appendable log keeps the just-appended record (C8/C9 durability)', { skip: process.platform === 'win32' }, () => {
+  const { p, file } = alertState();
+  launcher.appendRefuseAlert(p, 'dream', 'refusing to run: first failure');
+  fs.chmodSync(file, 0o200); // write-only: the read-back fails, the append does not
+  try {
+    assert.doesNotThrow(() => launcher.appendRefuseAlert(p, 'dream', 'refusing to run: second failure'));
+  } finally {
+    fs.chmodSync(file, 0o600);
+  }
+  const rows = readRows(file);
+  assert.equal(rows.length, 2, 'the empty read-back skipped the rewrite instead of erasing the log');
+  assert.equal(rows[1].reason, 'refusing to run: second failure', 'the newest fail-loud record is durable');
+});
+
+test('launcher: alerts.jsonl is 0600 after a collapse rewrite as well as after a plain append', { skip: process.platform === 'win32' }, () => {
+  const { p, file } = alertState();
+  launcher.appendRefuseAlert(p, 'dream', 'refusing to run: integrity mismatch');
+  assert.equal(fs.statSync(file).mode & 0o777, 0o600, 'first append leaves 0600');
+  assert.equal(fs.statSync(p.state).mode & 0o777, 0o700, 'state dir is 0700');
+  launcher.appendRefuseAlert(p, 'dream', 'refusing to run: integrity mismatch'); // collapse → rewrite
+  assert.equal(fs.statSync(file).mode & 0o777, 0o600, 'the temp+rename rewrite leaves 0600');
+  assert.equal(readRows(file).length, 1, 'and it did collapse');
+});
+
+test('launcher: appendRefuseAlert swallows an unwritable state dir and leaves no temp file behind (AC-13)', { skip: process.platform === 'win32' }, () => {
+  const { p } = alertState();
+  fs.mkdirSync(p.state, { recursive: true, mode: 0o700 });
+  fs.chmodSync(p.state, 0o500); // readable, not writable
+  try {
+    assert.doesNotThrow(() => launcher.appendRefuseAlert(p, 'dream', 'refusing to run: integrity mismatch'));
+    assert.deepEqual(fs.readdirSync(p.state), [], 'nothing — not even a .tmp — was left behind');
+  } finally {
+    fs.chmodSync(p.state, 0o700);
+  }
+});
+
+test('launcher: with state/ unwritable the refusal STILL exits non-zero and spawns nothing (AC-13)', { skip: process.platform === 'win32' }, () => {
+  const { env, descriptorPath, digest, paths } = setupProd();
+  jobsLib.saveJob(paths, { ...DREAM_JOB, run: 'skill:wienerdog-weekly-review' }); // drift
+  let spawned = false;
+  let code = null;
+  const origErr = process.stderr.write;
+  process.stderr.write = () => true;
+  fs.chmodSync(paths.state, 0o500); // the alert cannot land
+  try {
+    code = launcher.main(['dream', '--descriptor', descriptorPath, '--expect-digest', digest], {
+      env,
+      core: paths.core,
+      platform: process.platform,
+      spawn: () => {
+        spawned = true;
+        return { status: 0 };
+      },
+      exit: () => {},
+    });
+  } finally {
+    process.stderr.write = origErr;
+    fs.chmodSync(paths.state, 0o700);
+  }
+  assert.equal(code, 1, 'the refusal stands on its exit code, not on the alert landing');
+  assert.equal(spawned, false, 'ZERO spawn');
+});
+
+test('launcher: every literal require in launcher.js is a Node builtin (AC-14, C11)', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'scheduler', 'launcher.js'), 'utf8');
+  const literals = [...src.matchAll(/require\((['"])([^'"]+)\1\)/g)].map((m) => m[2]);
+  assert.ok(literals.length >= 4, 'it does require builtins');
+  for (const r of literals) {
+    assert.ok(r.startsWith('node:'), `launcher.js may require builtins only, found: ${r}`);
+  }
+  assert.equal(/require\((['"])\.\.?\/[^'"]*src/.test(src), false, 'no static app-tree require');
+});


### PR DESCRIPTION
Spec: docs/specs/WP-launcher-alert-bound.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

Files changed (6 deliverables + the allowed spec status flip):

| File | What changed |
|------|--------------|
| `src/core/alerts.js` | new exported `MAX_COUNT`; `sanitizeAlert` returns a fail-closed `count`; `Alert` typedef |
| `src/core/digest.js` | `formatAlerts` sums `count` (fail-closed coercion + clamped sum) |
| `src/scheduler/launcher.js` | `appendRefuseAlert` collapse + bound; new `readAlertRecords` helper; the three duplicated literals; `appendRefuseAlert` exported for tests |
| `tests/unit/alerts.test.js` | `count` coercion/clamp/round-trip/backward-compat; two pre-existing `deepEqual` shape assertions updated for the new field |
| `tests/unit/digest.test.js` | `formatAlerts` summing, single-record wording, clamp, per-job sums, golden byte-identity |
| `tests/unit/launcher.test.js` | collapse, non-collapse, bounds, durability, failure swallowing, builtin-only requires |
| `docs/specs/WP-launcher-alert-bound.md` | `status: Draft` → `In-Review` |

`tests/golden/digest-default.md` is untouched (AC-6).

## Verification output

```
$ npm test -- --test-name-pattern alerts
ℹ tests 132
ℹ suites 0
ℹ pass 132
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1912.753667

$ npm test -- --test-name-pattern digest
ℹ tests 152
ℹ suites 0
ℹ pass 152
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1952.759958

$ npm test -- --test-name-pattern launcher
ℹ tests 156
ℹ suites 0
ℹ pass 156
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1907.550208

$ npm test
ℹ tests 1969
ℹ suites 0
ℹ pass 1960
ℹ fail 0
ℹ cancelled 0
ℹ skipped 9
ℹ todo 0
ℹ duration_ms 45948.513417

$ npm run lint

> wienerdog@0.13.0 lint
> node scripts/lint.js

--- markdownlint ---
markdownlint-cli2 v0.23.0 (markdownlint v0.41.0)
Finding: docs/**/*.md skills/**/*.md templates/**/*.md tests/**/*.md *.md
Linting: 402 file(s)
Summary: 0 error(s)
--- shellcheck ---
--- PSScriptAnalyzer ---
--- frontmatter check ---
frontmatter check passed: 221 spec(s), 4 agent(s)

lint passed

# C11 — the launcher still requires no app-tree code (expect NO output):
$ grep -n "require(['\"]\.\./src\|require(['\"]\.\./\.\./src" src/scheduler/launcher.js
(no output)

# C3/C4/C5 — the duplicated bounds are present in both places:
$ grep -n "MAX_ALERTS\|MAX_FILE_BYTES\|MAX_COUNT" src/core/alerts.js
28:const MAX_ALERTS = 200; // keep only the most-recent N records
30:const MAX_FILE_BYTES = 512 * 1024; // hard byte bound on the log file / the read
33:// it reaches the digest banner's arithmetic. MAX_ALERTS, MAX_FILE_BYTES and
34:// MAX_COUNT are duplicated as literals in src/scheduler/launcher.js, which cannot
36:const MAX_COUNT = 1000000;
57: *  MAX_COUNT, so a hand-edited alerts.jsonl cannot push a nonsense or memory-hostile
68:  const count = Number.isSafeInteger(n) && n >= 1 ? Math.min(n, MAX_COUNT) : 1;
73: *  Compacts to `MAX_ALERTS` records / `MAX_FILE_BYTES` bytes when either bound
126:  if (all.length > MAX_ALERTS || size > MAX_FILE_BYTES) {
128:    let kept = all.slice(Math.max(0, all.length - MAX_ALERTS)); // newest N (append order = chronological)
132:    // well under MAX_FILE_BYTES (4 fields × MAX_FIELD_CHARS ≈ 8 KiB + JSON overhead).
133:    while (kept.length > 1 && Buffer.byteLength(text) > MAX_FILE_BYTES) {
145: *  Byte-bounds its read (tail window of `MAX_FILE_BYTES` for oversized files) and
163:    if (st.size > MAX_FILE_BYTES) {
164:      // Read the trailing MAX_FILE_BYTES (newest records) PLUS one preceding byte, so
167:      const readStart = st.size - MAX_FILE_BYTES - 1; // >= 0 since st.size > MAX_FILE_BYTES
236:  MAX_ALERTS,
238:  MAX_FILE_BYTES,
239:  MAX_COUNT,

$ grep -n "200\|512 \* 1024\|1000000\|1_000_000" src/scheduler/launcher.js
173:const ALERT_MAX_RECORDS = 200; // twin: MAX_ALERTS in src/core/alerts.js
174:const ALERT_MAX_FILE_BYTES = 512 * 1024; // twin: MAX_FILE_BYTES in src/core/alerts.js
175:const ALERT_MAX_COUNT = 1000000; // twin: MAX_COUNT in src/core/alerts.js
243: *  newest-200 compaction. Two repairs, together because either alone is lossy:

# AC-6 — the frozen golden is untouched (expect NO output):
$ git diff --stat -- tests/golden/digest-default.md
(no output)
```

## Known open finding (C8 race — flagged by the Codex design review, NOT fixed here)

The Codex review of the spec set flagged Table C row C8 (append-then-rewrite
compaction) as racy across two concurrent launcher processes:

> P1 appends + reads snapshot A, P2 appends + reads snapshot B and renames,
> then P1 renames its older snapshot A over the file and B is lost.

What this branch's write path does in that interleaving, stated plainly:
`appendRefuseAlert` appends its own record atomically first (so P1's record is
in both snapshots by the time either rename lands), reads the file back, and
then renames its snapshot over the log with **no** compare-and-retry and no
cross-process lock. So in the interleaving above P2's record is indeed lost —
P1's older snapshot A wins, and P2's alert is gone even though P2's own
`process.exit(1)` and zero-spawn refusal still stand.

This is the same residual `appendAlert` has carried since it was written (its
own comment: *"A compaction by one run-job can still drop a record a DIFFERENT
run-job appended in the same window; that residual is accepted — full
cross-process locking is out of scope per ADR-0004"*), so this WP does not
widen it — but it does not narrow it either, and the launcher's failure mode
(scheduled jobs that can fire concurrently) makes the window more reachable
than the app side's. The spec may be revised (cross-process lock, or
compare-and-retry before the rename) before this merges; I implemented C8
exactly as it stands today and did not redesign. **Draft PR for that reason.**

## Decisions made

1. **`appendRefuseAlert` is now exported** from `src/scheduler/launcher.js`.
   The bound and collapse behaviour (AC-7 … AC-11, AC-13) cannot be exercised
   through `main()` at reasonable cost — AC-10 alone needs 225 refusals, each
   of which would otherwise require a full drifted `setupProd` install. The
   export is test-only surface and changes no verification logic.
2. **The collapse is implemented as "compare the just-appended last record
   against its immediate predecessor, then drop the appended row and increment
   the predecessor's `count`."** C7 is written from the pre-append point of
   view ("increment that last record's count"), but C8 mandates appending
   first; the two are reconciled the only way that preserves both — the
   predecessor keeps its original `at` (C7) and the file never loses a record
   it did not just write (C8).
3. **The launcher's read-back drops the first line whenever its tail window
   starts mid-file**, rather than duplicating `readAlerts`' preceding-byte
   check to tell a boundary-aligned window from a split one. The simpler rule
   can discard at most one *oldest* record, which the byte bound (C10) was
   about to drop anyway. The reader stays a ~40-line self-contained twin
   instead of a ~60-line one.
4. **`formatAlerts` is more than the "exactly one line" the spec's Exact
   contracts predicted.** The security checklist and AC-5 require the summed
   total to be clamped, and callers legitimately pass records that never went
   through `sanitizeAlert` (every existing `digest.test.js` alert literal does
   — none of them has a `count`). A local fail-closed `countOf` mirroring C2
   is therefore applied before the arithmetic; without it those records would
   sum to `NaN`. Wording, `first`/`lastReason`/`hint` handling and the
   single-record output are all unchanged.
5. **Two pre-existing assertions in `tests/unit/alerts.test.js` were updated**
   (`deepEqual(got[0], {job, at, reason, log_hint})` → the same object plus
   `count: 1`). They pin `sanitizeAlert`'s exact output shape, which C1
   changes by design; the file is in the Deliverables table.
6. **The launcher's constants are named `ALERT_MAX_RECORDS` /
   `ALERT_MAX_FILE_BYTES` / `ALERT_MAX_COUNT`**, not the app-side names, so a
   reader cannot mistake them for imports. Each carries a `// twin: <name> in
   src/core/alerts.js` comment as C3–C5 require.
7. **`appendAlert` is unchanged apart from its JSDoc.** It writes `count: 1`
   for free, because `sanitizeAlert` supplies it — no collapse was added to
   the app-side writer (explicitly out of scope).

## Discovered issues (out of scope, not fixed)

1. **`clearAlerts` does not re-`chmod` after its rename.** `appendAlert` calls
   `chmodAlerts` after its compaction rename and `clearAlerts` writes its temp
   file with the default mode and no `{ mode: 0o600 }`, so a `clearAlerts`
   rewrite can leave `alerts.jsonl` at the umask default rather than 0600.
   Pre-existing, unrelated to this WP, not touched.
2. **The byte-budget loop in both writers is O(n²)** — it re-serializes every
   surviving record on each drop. Harmless at `MAX_ALERTS = 200`; noted only
   because this WP copies the shape into a second place.
3. **`appendAlert`'s comment says "4 fields × MAX_FIELD_CHARS ≈ 8 KiB"**,
   which is still true of the string fields after this WP (`count` adds ~12
   bytes), so it was left alone rather than churned.

## Lessons

- WP-launcher-alert-bound: the spec's "changes exactly one line" prediction for
  `formatAlerts` conflicted with its own security checklist (clamp the sum) and
  with the existing tests, which pass alert literals that never see
  `sanitizeAlert`. Trust the acceptance criteria and the checklist over a
  prose estimate of diff size — and check what the *existing* tests feed a
  function before assuming every caller is the sanitized path.
- WP-launcher-alert-bound: C7 ("increment the last record's count") and C8
  ("append first, then rewrite") describe the same operation from opposite
  sides of the append. Reading either alone yields a different implementation;
  the reconciliation (drop the appended row, increment the predecessor) is
  worth stating in a spec that mandates both.
- WP-launcher-alert-bound: a duplicated-constant rule (C3–C5, ADR-0031) is much
  easier to keep honest when the copies are *deliberately named differently*
  and each carries a `// twin:` comment — the grep in the spec's verification
  block then reads as a real cross-check rather than a coincidence of literals.
- WP-launcher-alert-bound: testing a best-effort writer's failure swallowing
  needs two different unwritable shapes — a `0o500` state dir (the append never
  lands) and a `0o200` log file (the append lands but the read-back fails, the
  C9 guard). Only the second one proves the empty-read guard is doing anything.

---
Generated-by: claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9LjCEYVM481sJirm1HDY1
