### PR TITLE
fix(scripts): refuse the install smoke run against a live scheduler domain (WP-smoke-live-scheduler-preflight)

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -39,4 +39,12 @@ jobs:
           brew unlink git || true
           command -v git && git --version
       - name: Install lifecycle smoke
+        env:
+          # Linux CI runners have no user D-Bus session, so the live-scheduler
+          # preflight's systemctl probe cannot answer (NOT-PROBEABLE) and it
+          # would otherwise abort every run on this leg. macOS gets no
+          # override (empty string, which the preflight's exact-value rule
+          # treats as unset): if its launchd probe ever stops answering
+          # CLEAN, this job goes red rather than silently skipping the check.
+          WIENERDOG_SMOKE_ALLOW_UNPROBEABLE: ${{ runner.os == 'Linux' && '1' || '' }}
         run: bash scripts/smoke-install.sh

--- a/docs/specs/WP-smoke-live-scheduler-preflight.md
+++ b/docs/specs/WP-smoke-live-scheduler-preflight.md
@@ -1,7 +1,7 @@
 ---
 id: WP-smoke-live-scheduler-preflight
 title: Refuse to run the install smoke script while this user has live Wienerdog scheduler registrations
-status: Ready
+status: In-Review
 model: sonnet
 size: S
 depends_on: []

--- a/scripts/live-scheduler-probe.sh
+++ b/scripts/live-scheduler-probe.sh
@@ -26,7 +26,7 @@ LAUNCHCTL_PATH="/bin/launchctl"
 PREFIX="${1:-ai.wienerdog.}"
 
 not_probeable() {
-  printf 'not-probeable: %s\n' "$1"
+  printf 'not-probeable: %s\n' "$1" >&2
   exit 2
 }
 
@@ -62,9 +62,20 @@ Linux)
   ;;
 esac
 
-MATCHES="$(printf '%s\n' "$OUT" | grep -F "$PREFIX" || true)"
-if [ -n "$MATCHES" ]; then
+# -- terminates option parsing so a prefix that looks like a flag (e.g. "-e")
+# is matched as a literal string, never interpreted as a grep option.
+if MATCHES="$(printf '%s\n' "$OUT" | grep -F -- "$PREFIX")"; then
+  GREP_RC=0
+else
+  GREP_RC=$?
+fi
+if [ "$GREP_RC" -eq 0 ]; then
   printf '%s\n' "$MATCHES"
   exit 1
+elif [ "$GREP_RC" -eq 1 ]; then
+  # No match: CLEAN input, not a failure.
+  exit 0
 fi
-exit 0
+# grep exited >=2: a real failure (bad pattern, I/O error, ...), not "no
+# match" — an absence of evidence, not evidence of absence.
+not_probeable "grep exited $GREP_RC matching the prefix"

--- a/scripts/live-scheduler-probe.sh
+++ b/scripts/live-scheduler-probe.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# live-scheduler-probe.sh — read-only probe for a live Wienerdog scheduler
+# registration in this OS user's real scheduler domain (launchd on macOS,
+# systemd --user on Linux). WP-smoke-live-scheduler-preflight / issue #169.
+#
+# It reads the scheduler; it never writes one, never spawns the Wienerdog
+# CLI, and creates no files. Three outcomes, three exit codes:
+#   0  CLEAN          the client answered and nothing matched the prefix.
+#   1  LIVE            the client answered and something matched; the
+#                       matching line(s) are printed.
+#   2  NOT-PROBEABLE   the client is absent, failed, or this platform has no
+#                       supported query. Never collapsed into 0 — an
+#                       unanswerable scheduler is an absence of evidence, not
+#                       evidence of absence.
+#
+# Usage: scripts/live-scheduler-probe.sh [prefix]   (prefix defaults to
+# "ai.wienerdog."; matched as a fixed string, never a regex or a path.)
+set -euo pipefail
+
+# Absolute by contract: a bare-name `launchctl` lookup could resolve through a
+# shimmed PATH and make the probe observe its own machinery instead of the OS
+# (the same reasoning as tests/scenarios/scheduler-guard.js:42).
+LAUNCHCTL_PATH="/bin/launchctl"
+
+PREFIX="${1:-ai.wienerdog.}"
+
+not_probeable() {
+  printf 'not-probeable: %s\n' "$1"
+  exit 2
+}
+
+case "$(uname -s)" in
+Darwin)
+  if [ ! -x "$LAUNCHCTL_PATH" ]; then
+    not_probeable "launchctl client absent at $LAUNCHCTL_PATH"
+  fi
+  if OUT="$("$LAUNCHCTL_PATH" print "gui/$(id -u)" 2>/dev/null)"; then
+    RC=0
+  else
+    RC=$?
+  fi
+  if [ "$RC" -ne 0 ]; then
+    not_probeable "launchctl print gui/$(id -u) exited $RC"
+  fi
+  ;;
+Linux)
+  if ! command -v systemctl >/dev/null 2>&1; then
+    not_probeable "systemctl client absent"
+  fi
+  if OUT="$(systemctl --user list-units --all --no-legend 2>/dev/null)"; then
+    RC=0
+  else
+    RC=$?
+  fi
+  if [ "$RC" -ne 0 ]; then
+    not_probeable "systemctl --user list-units exited $RC"
+  fi
+  ;;
+*)
+  not_probeable "no supported scheduler query on $(uname -s)"
+  ;;
+esac
+
+MATCHES="$(printf '%s\n' "$OUT" | grep -F "$PREFIX" || true)"
+if [ -n "$MATCHES" ]; then
+  printf '%s\n' "$MATCHES"
+  exit 1
+fi
+exit 0

--- a/scripts/smoke-install.sh
+++ b/scripts/smoke-install.sh
@@ -44,7 +44,10 @@ for PREFLIGHT_PREFIX in "ai.wienerdog." "wienerdog-"; do
     PREFLIGHT_STATE="live"
     PREFLIGHT_MATCHES="$PREFLIGHT_MATCHES$PREFLIGHT_OUT
 "
-  elif [ "$PREFLIGHT_RC" -eq 2 ] && [ "$PREFLIGHT_STATE" != "live" ]; then
+  elif [ "$PREFLIGHT_RC" -ne 0 ] && [ "$PREFLIGHT_STATE" != "live" ]; then
+    # Any non-0, non-1 probe status (2, or an unexpected 127/126/3/...) is
+    # NOT-PROBEABLE, not CLEAN: a deleted, non-executable, or crashing probe
+    # must never be read as "the domain is safe".
     PREFLIGHT_STATE="not-probeable"
   fi
 done

--- a/scripts/smoke-install.sh
+++ b/scripts/smoke-install.sh
@@ -20,6 +20,52 @@ set -euo pipefail
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 WD() { node "$REPO/bin/wienerdog.js" "$@"; }
 
+# Live-scheduler preflight (issue #169, WP-smoke-live-scheduler-preflight).
+# The lifecycle below (catch-up teardown + `uninstall`) removes every
+# Wienerdog scheduler entry it finds, and those OS identifiers are
+# per-user-global, not $HOME-scoped — a throwaway HOME does not protect them
+# (docs/adr/0018-windows-scheduled-dreaming.md Decision 2). Refuse to proceed
+# while this user has a live registration.
+#
+# Two overrides, both exact-value (only the literal string "1" counts), each
+# applying to its own outcome only:
+#   WIENERDOG_SMOKE_I_KNOW=1            — proceed past a LIVE result.
+#   WIENERDOG_SMOKE_ALLOW_UNPROBEABLE=1 — proceed past a NOT-PROBEABLE result.
+PROBE="$REPO/scripts/live-scheduler-probe.sh"
+PREFLIGHT_STATE="clean"
+PREFLIGHT_MATCHES=""
+for PREFLIGHT_PREFIX in "ai.wienerdog." "wienerdog-"; do
+  if PREFLIGHT_OUT="$("$PROBE" "$PREFLIGHT_PREFIX")"; then
+    PREFLIGHT_RC=0
+  else
+    PREFLIGHT_RC=$?
+  fi
+  if [ "$PREFLIGHT_RC" -eq 1 ]; then
+    PREFLIGHT_STATE="live"
+    PREFLIGHT_MATCHES="$PREFLIGHT_MATCHES$PREFLIGHT_OUT
+"
+  elif [ "$PREFLIGHT_RC" -eq 2 ] && [ "$PREFLIGHT_STATE" != "live" ]; then
+    PREFLIGHT_STATE="not-probeable"
+  fi
+done
+case "$PREFLIGHT_STATE" in
+live)
+  if [ "${WIENERDOG_SMOKE_I_KNOW:-}" != "1" ]; then
+    printf 'ABORT (issue #169): a live Wienerdog scheduler registration exists.\n' >&2
+    printf 'This run would remove it:\n%s' "$PREFLIGHT_MATCHES" >&2
+    printf 'Set WIENERDOG_SMOKE_I_KNOW=1 to proceed anyway.\n' >&2
+    exit 1
+  fi
+  ;;
+not-probeable)
+  if [ "${WIENERDOG_SMOKE_ALLOW_UNPROBEABLE:-}" != "1" ]; then
+    printf 'ABORT (issue #169): this machine'"'"'s live scheduler domain could not be queried.\n' >&2
+    printf 'Set WIENERDOG_SMOKE_ALLOW_UNPROBEABLE=1 to proceed anyway.\n' >&2
+    exit 1
+  fi
+  ;;
+esac
+
 SB="$(mktemp -d "${TMPDIR:-/tmp}/wd-smoke.XXXXXX")"
 trap 'rm -rf "$SB"' EXIT
 


### PR DESCRIPTION
Spec: docs/specs/WP-smoke-live-scheduler-preflight.md

Successor to #181, which was auto-closed when its base branch (`docs/issue-169-specs`, merged as #180) was deleted — same branch, same tip (`6a1ff0e`), identical diff, now against main. **All review-gate records live on #181**: round 1 (REQUEST-CHANGES, one severity-A + three C, all three reviewers converging) and round 2 (**wd-reviewer APPROVE + Codex plugin clean** on this tip). Verification output, decisions and lessons are in #181's description.

Merge authorized by the maintainer 2026-09-01 ("Merge 180 and 181 for me").

---
Generated-by: Claude Sonnet 5 (implementer) / Claude Fable 5 (orchestrator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCXat1SiCGPBaijqCCkAjG