### PR TITLE
fix(run-job): keep the durable record when a state write fails (WP-failloud-survives-state-write-failure)

### DIFF
--- a/docs/specs/WP-failloud-survives-state-write-failure.md
+++ b/docs/specs/WP-failloud-survives-state-write-failure.md
@@ -243,7 +243,10 @@ values, and `failLoud` derives everything from it internally.
 | Fact / rule | Value |
 |-------------|-------|
 | Closed set | those three values and nothing else. The caller passes only the discriminant |
-| Derived inside `failLoud` | the canonical reason wording, the email subject, and the append policy. Callers may pass the job-specific detail the reason interpolates, but **never** a subject and **never** a skip boolean — there is no caller-supplied way to suppress an append |
+| Derived inside `failLoud` | the email subject and the append policy. Callers may pass the job-specific detail the reason interpolates, but **never** a subject and **never** a skip boolean — there is no caller-supplied way to suppress an append |
+| **One source for each canonical string** (amended 2026-09-01) | Table B `:173` requires `runJob` to **throw** a `WienerdogError` carrying the site's distinct reason, and this table requires `failLoud` to persist and email that same wording. A reason derived *only* inside `failLoud` cannot reach the caller's throw, so the earlier "derived inside `failLoud`" phrasing made the two rows unsatisfiable together. The resolution: each outcome's reason and subject come from **one shared module-level template**, called by `runJob` for the throw and by `failLoud` for what it records. The template is the string's single source; neither caller nor callee may compose its own variant, and the verbatim-string assertions test the template's output on both paths |
+| **`failLoud` self-derives the reason for the non-default outcomes** | for `success-marker-refused` and `alert-cleanup-refused`, `failLoud` derives the reason it persists and emails **from the outcome**, via that template — it does **not** trust the `reason` argument it was handed. A stale or wrong caller string would otherwise misreport replay: measured on this branch, `failLoud(paths, name, 'x', { outcome: 'alert-cleanup-refused' })` skips the append and emails body `x`, so the operator is told nothing true about which state operation was refused. **The outcome decides the reason, the subject and the append policy — all three.** The `reason` parameter is honored **only** for `job-failure`, which keeps HEAD semantics for the three failure sites and the catch-up refusals |
+| **The outcome channel is separate from the forwarded `opts`** | the discriminant must **not** be inheritable from the generic `opts` object `runJob` forwards to its ordinary `failLoud` calls. Those sites pass their caller's `opts` straight through, so an `outcome` riding that object reaches them too — and `alert-cleanup-refused` sets the append-skip, which is precisely the "suppression capability any caller could aim at the primary reporting channel" this table's preamble exists to deny. Contract: the three failure sites (`:797`, `:872`, `:1096`) and the catch-up refusals pass **no** outcome, or explicitly force `job-failure`; **only** `:1060` and `:1061` carry one, and it cannot arrive from caller-supplied `opts`. **The observable is the contract, the mechanism is the implementer's:** an outcome injected into `runJob`'s `opts` leaves every ordinary failure path's reporting — append attempted, subject, reason, return value — unchanged |
 | Unknown value | **refuse the call loudly** — throw rather than fall back to any behavior. Silently degrading an unrecognized discriminant to `job-failure` would append through a refused artifact; silently degrading it to a skip would suppress the record. Neither is acceptable, so an unknown value is a programming error surfaced at once. Note this is the ONE place `failLoud` may throw; it is unreachable from the five sites, which pass literals |
 | Absent input | byte-identical to HEAD on every observable: the append is attempted, the subject is `` `job ${name} failed` ``, and the return is the existing `persisted` boolean |
 | Canonical strings | each of the three values has exactly one reason template and exactly one subject template, asserted verbatim by the tests. "Must say" prose is not a contract; the strings are |
@@ -281,6 +284,12 @@ values, and `failLoud` derives everything from it internally.
 - [ ] **Table E's enum** — its three values appear in the Deliverables row, the
       Exact contracts paragraph, the acceptance criteria and the Security
       checklist; adding or renaming a value moves all four
+- [ ] **The outcome→reason derivation (amended 2026-09-01)** — Table E's three
+      amended rows (one shared template; `failLoud` self-derives for the
+      non-default outcomes; the outcome channel is separate from the forwarded
+      `opts`) are mirrored by Table B `:173`'s throw requirement and by the
+      poison-reason / poison-outcome / one-template acceptance criteria. A change
+      to which side owns the string moves all of them together
 - [ ] **Reachability of every acceptance precondition** — B1 both-unwritable is
       reachable, B2 both-unwritable is not and is explicitly excluded; any new
       criterion must be walked against the call graph before it is added
@@ -393,6 +402,22 @@ values, and `failLoud` derives everything from it internally.
       their **exact canonical** reason and subject strings, asserted verbatim.
       `alert-cleanup-refused` skips the append and returns **`false`**. An
       unknown discriminant throws rather than degrading to either behavior.
+- [ ] **Poison reason:** calling `failLoud` with a wrong or stale `reason`
+      argument and a `success-marker-refused` or `alert-cleanup-refused` outcome
+      persists and emails the **canonical** string for that outcome — the
+      caller's string appears nowhere in the record or the email. For
+      `job-failure` the caller's `reason` is still used verbatim, as on HEAD.
+- [ ] **Poison outcome:** a `success-marker-refused` or `alert-cleanup-refused`
+      value injected into `runJob`'s caller-supplied `opts` leaves the ordinary
+      failure paths (`:797`, `:872`, `:1096`, and the catch-up refusals)
+      reporting exactly as they do without it — the append is still attempted,
+      the subject is still `` `job <name> failed` ``, the reason is still the
+      caller's original, and the return value is unchanged. In particular the
+      injected `alert-cleanup-refused` must **not** skip the append.
+- [ ] **One template, both paths:** for each success-path outcome, the reason
+      string `runJob` throws and the reason string `failLoud` persists are
+      produced by the same shared template and are byte-identical to each other
+      and to the canonical string the enum tests assert.
 - [ ] **`persisted` honors an explicit `false`:** when `appendAlert` returns
       exactly `false`, `failLoud` returns `false` and `:1106-1107` **retains**
       the reap token pidfiles. When `appendAlert` returns `undefined` — every

--- a/docs/specs/WP-failloud-survives-state-write-failure.md
+++ b/docs/specs/WP-failloud-survives-state-write-failure.md
@@ -1,7 +1,7 @@
 ---
 id: WP-failloud-survives-state-write-failure
 title: A failed state write must never suppress a job's durable record, on any path
-status: Ready
+status: In-Review
 model: sonnet
 size: S
 depends_on: []

--- a/docs/specs/WP-failloud-survives-state-write-failure.md
+++ b/docs/specs/WP-failloud-survives-state-write-failure.md
@@ -123,7 +123,7 @@ RETAINED as the sole recovery breadcrumb. This WP must not change that.
 
 | Action | Path | Notes |
 |--------|------|-------|
-| modify | src/cli/run-job.js | (a) the five state-write sites at `:797`, `:872`, `:1096`, `:1060`, `:1061`, per Tables A, B1 and B2; (b) `failLoud` (`:611-634`) gains the **closed outcome enum** of Table E — three values, canonical reason/subject/append-policy derived inside, unknown value refused, absent input byte-identical to HEAD; (c) `failLoud`'s `persisted` honors an explicit `false` from `appendAlert` (Table E, and see Implementation notes — `undefined` keeps today's meaning). Do NOT change the `appendAlert` call at `:840`, the reap logic at `:1106-1108`, `defaultSendAlert`, or any existing failure-path `reason` string |
+| modify | src/cli/run-job.js | (a) the five state-write sites at `:797`, `:872`, `:1096`, `:1060`, `:1061`, per Tables A, B1 and B2; (b) `failLoud` (`:611-634`) gains the **closed outcome enum** of Table E — three values; one shared template per outcome as the canonical reason and subject's single source, called by both `runJob` (for its throw) and `failLoud`; `failLoud` self-derives reason, subject and append policy from the outcome for the two non-default values, honoring the `reason` argument only for `job-failure`; the outcome carried on a channel the forwarded `opts` cannot supply; unknown value refused; absent input byte-identical to HEAD; (c) `failLoud`'s `persisted` honors an explicit `false` from `appendAlert` (Table E, and see Implementation notes — `undefined` keeps today's meaning). Do NOT change the `appendAlert` call at `:840`, the reap logic at `:1106-1108`, `defaultSendAlert`, or any existing failure-path `reason` string |
 | modify | tests/unit/scheduler-runjob.test.js | cover the acceptance criteria below; the implementer designs the cases |
 
 ### Exact contracts
@@ -243,7 +243,7 @@ values, and `failLoud` derives everything from it internally.
 | Fact / rule | Value |
 |-------------|-------|
 | Closed set | those three values and nothing else. The caller passes only the discriminant |
-| Derived inside `failLoud` | the email subject and the append policy. Callers may pass the job-specific detail the reason interpolates, but **never** a subject and **never** a skip boolean — there is no caller-supplied way to suppress an append |
+| Derived inside `failLoud` | the email subject and the append policy, for every outcome. A caller **never** passes a subject and **never** passes a skip boolean — there is no caller-supplied way to suppress an append. A caller-supplied reason is honored **only** for `job-failure`; for the two non-default outcomes the reason is derived too — see the *"`failLoud` self-derives the reason"* row below — so the job-specific detail that reason interpolates comes from the template's own inputs, not from a string the caller composed |
 | **One source for each canonical string** (amended 2026-09-01) | Table B `:173` requires `runJob` to **throw** a `WienerdogError` carrying the site's distinct reason, and this table requires `failLoud` to persist and email that same wording. A reason derived *only* inside `failLoud` cannot reach the caller's throw, so the earlier "derived inside `failLoud`" phrasing made the two rows unsatisfiable together. The resolution: each outcome's reason and subject come from **one shared module-level template**, called by `runJob` for the throw and by `failLoud` for what it records. The template is the string's single source; neither caller nor callee may compose its own variant, and the verbatim-string assertions test the template's output on both paths |
 | **`failLoud` self-derives the reason for the non-default outcomes** | for `success-marker-refused` and `alert-cleanup-refused`, `failLoud` derives the reason it persists and emails **from the outcome**, via that template — it does **not** trust the `reason` argument it was handed. A stale or wrong caller string would otherwise misreport replay: measured on this branch, `failLoud(paths, name, 'x', { outcome: 'alert-cleanup-refused' })` skips the append and emails body `x`, so the operator is told nothing true about which state operation was refused. **The outcome decides the reason, the subject and the append policy — all three.** The `reason` parameter is honored **only** for `job-failure`, which keeps HEAD semantics for the three failure sites and the catch-up refusals |
 | **The outcome channel is separate from the forwarded `opts`** | the discriminant must **not** be inheritable from the generic `opts` object `runJob` forwards to its ordinary `failLoud` calls. Those sites pass their caller's `opts` straight through, so an `outcome` riding that object reaches them too — and `alert-cleanup-refused` sets the append-skip, which is precisely the "suppression capability any caller could aim at the primary reporting channel" this table's preamble exists to deny. Contract: the three failure sites (`:797`, `:872`, `:1096`) and the catch-up refusals pass **no** outcome, or explicitly force `job-failure`; **only** `:1060` and `:1061` carry one, and it cannot arrive from caller-supplied `opts`. **The observable is the contract, the mechanism is the implementer's:** an outcome injected into `runJob`'s `opts` leaves every ordinary failure path's reporting — append attempted, subject, reason, return value — unchanged |
@@ -300,8 +300,15 @@ values, and `failLoud` derives everything from it internally.
 ## Implementation notes & constraints
 
 - Zero new dependencies; plain Node ≥ 18; JSDoc types; no build step (CLAUDE.md).
-- The change is local to five call sites. Do not introduce a wrapper helper, do
-  not re-order the paths, and do not touch the reap/token logic at `:1106-1108`.
+- The change is local to five call sites. Do not re-order the paths, and do not
+  touch the reap/token logic at `:1106-1108`. **"No wrapper helper" means no
+  helper that wraps the state-write + `failLoud` SEQUENCE** — each site keeps its
+  own visible try/attempt/report shape, so a reader sees at the site what happens
+  when the write fails, and no single helper accretes the five sites' differing
+  policies. It does **not** forbid the shared reason/subject templates Table E
+  mandates: those are pure string builders with no control flow, and they exist
+  precisely so one string cannot drift between `runJob`'s throw and `failLoud`'s
+  record.
 - Do not make the state writers themselves non-throwing in
   `src/scheduler/jobs.js` or `src/core/alerts.js`: other callers rely on their
   errors, and `WP-private-state-writers-mode-pin` changes both for an unrelated
@@ -351,6 +358,20 @@ values, and `failLoud` derives everything from it internally.
       (Table E): no call site can request a skipped append, an unknown
       discriminant is refused rather than silently degraded, and a skipped
       append returns `false` so `:1106-1108` still treats it as unrecorded.
+- [ ] **Flagged for a future architect pass, NOT this WP** (wd-reviewer, PR #185
+      round 2): `opts.appendAlert` — the test seam this spec blesses in the
+      `persisted`-honors-`false` criterion — is **inheritable at the ordinary
+      sites the way `outcome` used to be**, since those sites forward the
+      caller's `opts` verbatim. It is production-unreachable today
+      (`bin/wienerdog.js:74` invokes `run(rest)` with no `opts`), and it is a
+      test-only seam by this spec's own contract, so nothing here is a live
+      defect. But it is a strictly **larger** capability than the `opts.sendAlert`
+      precedent it was modelled on — `sendAlert` can only redirect the email,
+      whereas `appendAlert` can replace the durable-record writer itself. If the
+      seam family is ever revisited, it warrants the same channel-separation
+      treatment Table E now gives `outcome`. Recorded so the next reader inherits
+      the observation rather than re-deriving it; changing it is out of scope
+      here.
 - [ ] Residual, named and measured: with GWS unconfigured, a B2 refusal has no
       durable Wienerdog-side notification — the job log is not open at any of
       the five sites and doctor does not inspect `alerts.jsonl` (Table C's

--- a/src/cli/run-job.js
+++ b/src/cli/run-job.js
@@ -583,6 +583,43 @@ function defaultSendAlert(paths, name, subject, body) {
   return { status: r.status == null ? 1 : r.status };
 }
 
+/** Table E (WP-failloud-survives-state-write-failure) — B1's canonical reason
+ *  (`:1060`): the job's work completed, but the `last_success` watermark — the
+ *  catch-up replay guard (`:1244-1245`) — could not be saved, so the job will
+ *  be re-run at every catch-up until the fault is repaired.
+ *  @param {string} name @returns {string} */
+function successMarkerRefusedReason(name) {
+  return (
+    `job "${name}" finished its work, but the record of that success ("last_success" in ` +
+    `state/schedule.json) could not be saved. Because that record is what tells Wienerdog the ` +
+    `job already ran, the job will be re-run at every future catch-up until this is fixed. To ` +
+    `stop the repeats: repair or remove state/schedule.json, or disable the job.`
+  );
+}
+
+/** @param {string} name @returns {string} */
+function successMarkerRefusedSubject(name) {
+  return `job ${name} succeeded, but its record could not be saved`;
+}
+
+/** Table E — B2's canonical reason (`:1061`): the job's work completed AND the
+ *  success marker was saved — only clearing the previous run's stale alerts
+ *  failed. No replay: `last_success` was written, so `catchUp` sees the job as
+ *  current.
+ *  @param {string} name @returns {string} */
+function alertCleanupRefusedReason(name) {
+  return (
+    `job "${name}" finished its work and its success was recorded, but Wienerdog could not clear ` +
+    `its previous alert(s) in state/alerts.jsonl. The job is up to date; the earlier alert(s) will ` +
+    `keep showing until this is fixed.`
+  );
+}
+
+/** @param {string} name @returns {string} */
+function alertCleanupRefusedSubject(name) {
+  return `job ${name} succeeded, but its alert cleanup failed`;
+}
+
 /**
  * Fail loud: append a DURABLE alert to state/alerts.jsonl (re-rendered into the
  * digest until the job next succeeds — ADR-0012 part 3), then attempt the
@@ -603,24 +640,61 @@ function defaultSendAlert(paths, name, subject, body) {
  * compaction rewrite also yields `false` (the atomic append already put the
  * record on disk, but we err toward RETAINING the pidfile — a false-negative
  * keeps the recovery identity, a false-positive would lose it).
+ *
+ * WP-failloud-survives-state-write-failure (Table E): `opts.outcome` is a
+ * CLOSED discriminated enum — `'job-failure'` (default, byte-identical to
+ * HEAD), `'success-marker-refused'` (Table B1) or `'alert-cleanup-refused'`
+ * (Table B2 — the append is POLICY-SKIPPED, never attempted, because the
+ * refused artifact IS alerts.jsonl and the recovery path must never write
+ * through the artifact it just refused, Table C). The subject and the append
+ * policy are derived HERE from the discriminant only — callers pass no subject
+ * and no skip flag, so there is no caller-supplied way to suppress an append.
+ * An unrecognized discriminant throws (the one place failLoud may throw; it is
+ * unreachable from the five call sites, which all pass literals) rather than
+ * silently degrading to either behavior.
+ * `persisted` now also honors an explicit `false` return from the append
+ * (`opts.appendAlert`, a test-only seam mirroring `opts.sendAlert` — production
+ * always uses the real `appendAlert`, which returns `undefined` on every path
+ * today, so this is a no-op there); `undefined` keeps today's
+ * absence-of-throw meaning.
  * @param {import('../core/paths').WienerdogPaths} paths
  * @param {string} name @param {string} reason
- * @param {{sendAlert?: typeof defaultSendAlert}} opts
- * @returns {Promise<boolean>} true iff the durable alert append succeeded
+ * @param {{sendAlert?: typeof defaultSendAlert, appendAlert?: typeof appendAlert,
+ *          outcome?: 'job-failure'|'success-marker-refused'|'alert-cleanup-refused'}} [opts]
+ * @returns {Promise<boolean>} true iff the durable alert append persisted
  */
 async function failLoud(paths, name, reason, opts = {}) {
+  const outcome = opts.outcome === undefined ? 'job-failure' : opts.outcome;
+  let subject;
+  let appendSkipped = false;
+  if (outcome === 'job-failure') {
+    subject = `job ${name} failed`;
+  } else if (outcome === 'success-marker-refused') {
+    subject = successMarkerRefusedSubject(name);
+  } else if (outcome === 'alert-cleanup-refused') {
+    subject = alertCleanupRefusedSubject(name);
+    appendSkipped = true; // Table C: never write through the artifact just refused
+  } else {
+    throw new WienerdogError(`failLoud: unrecognized outcome "${outcome}"`);
+  }
+
   let persisted = false;
   try {
     const logHint = `${tilde(paths.home, path.join(paths.logs, name))}/`;
-    appendAlert(paths, {
-      job: name,
-      at: nowIso(),
-      reason,
-      log_hint: logHint,
-    });
-    persisted = true; // the durable append returned without throwing
+    if (!appendSkipped) {
+      const appendFn = opts.appendAlert || appendAlert;
+      const appendResult = appendFn(paths, {
+        job: name,
+        at: nowIso(),
+        reason,
+        log_hint: logHint,
+      });
+      // Explicit `false` (WP-private-state-writers-mode-pin's F10 case) means
+      // the record was NOT persisted; `undefined` (every path today) keeps
+      // meaning "no throw" — persisted.
+      persisted = appendResult !== false;
+    }
     const send = opts.sendAlert || defaultSendAlert;
-    const subject = `job ${name} failed`;
     const body = `${reason}\n\nDetails: ${logHint}`.trim();
     try {
       send(paths, name, subject, body);
@@ -794,7 +868,17 @@ async function runJob(paths, job, opts = {}) {
     const reason =
       `refused: ${g.offending} is under a macOS protected folder (${g.prefix}) — ` +
       'move the vault to ~/wienerdog';
-    jobsLib.writeScheduleState(paths, name, { last_status: 'error', last_error_at: nowIso() });
+    // Table A (WP-failloud-survives-state-write-failure): a throw from the
+    // watermark write must never suppress the failLoud call that follows —
+    // surfaced once on stderr (a non-alert channel), never a second
+    // alerts.jsonl record; the alert below still reports the ORIGINAL reason.
+    try {
+      jobsLib.writeScheduleState(paths, name, { last_status: 'error', last_error_at: nowIso() });
+    } catch (werr) {
+      process.stderr.write(
+        `wienerdog: job "${name}" error watermark could not be saved: ${(werr && werr.message) || werr}\n`
+      );
+    }
     await failLoud(paths, name, reason, opts);
     throw new WienerdogError(`job "${name}" ${reason}`);
   }
@@ -869,7 +953,15 @@ async function runJob(paths, job, opts = {}) {
       const reason =
         `routine "${name}" halted: pre-routine containment self-check ${probe.outcome} on claude ` +
         `${probe.claudeVersion} — ${probe.reason}. The routine did not run. Re-run after updating/checking Claude.`;
-      jobsLib.writeScheduleState(paths, name, { last_status: 'error', last_error_at: nowIso() });
+      // Table A: same coupling break as :797 — the watermark throw must not
+      // suppress this failLoud call, and the alert still reports `reason`.
+      try {
+        jobsLib.writeScheduleState(paths, name, { last_status: 'error', last_error_at: nowIso() });
+      } catch (werr) {
+        process.stderr.write(
+          `wienerdog: job "${name}" error watermark could not be saved: ${(werr && werr.message) || werr}\n`
+        );
+      }
       await failLoud(paths, name, reason, opts);
       throw new WienerdogError(reason);
     }
@@ -1057,8 +1149,38 @@ async function runJob(paths, job, opts = {}) {
   //    user-invoked registration (sync/schedule add/init/adopt). Here we do at most
   //    a READ-ONLY "catch-up entry missing" notice — never write, never load.
   if (!failure && code === 0 && !reapFailure && !logStreamFailed) {
-    jobsLib.writeScheduleState(paths, name, { last_success: nowIso(), last_status: 'ok' });
-    clearAlerts(paths, name);
+    // B1 (`:1060`, Table B/B1): the job's work succeeded, but persisting the
+    // success marker — `last_success`, the catch-up replay guard — can itself
+    // throw (ENOSPC/EROFS/EDQUOT, or a refused writeFilePrivate once
+    // WP-private-state-writers-mode-pin lands). A throw here must not be
+    // certified clean: exactly one failLoud attempt, then throw carrying the
+    // site's distinct reason — never reaching clearAlerts below.
+    try {
+      jobsLib.writeScheduleState(paths, name, { last_success: nowIso(), last_status: 'ok' });
+    } catch (werr) {
+      process.stderr.write(
+        `wienerdog: job "${name}" succeeded, but its success record could not be saved: ${(werr && werr.message) || werr}\n`
+      );
+      const b1reason = successMarkerRefusedReason(name);
+      await failLoud(paths, name, b1reason, { ...opts, outcome: 'success-marker-refused' });
+      throw new WienerdogError(b1reason);
+    }
+
+    // B2 (`:1061`, Table B/B2): the marker WAS saved — only clearing the
+    // previous run's alerts can throw. No replay consequence. The refused
+    // artifact IS alerts.jsonl, so the recovery path must not attempt to
+    // write through it (Table C) — the alert-cleanup-refused outcome skips
+    // the append.
+    try {
+      clearAlerts(paths, name);
+    } catch (werr) {
+      process.stderr.write(
+        `wienerdog: job "${name}" succeeded, but clearing its previous alerts failed: ${(werr && werr.message) || werr}\n`
+      );
+      const b2reason = alertCleanupRefusedReason(name);
+      await failLoud(paths, name, b2reason, { ...opts, outcome: 'alert-cleanup-refused' });
+      throw new WienerdogError(b2reason);
+    }
     if (platform === 'darwin' || platform === 'win32') {
       try {
         noticeIfCatchupMissing(paths, platform);
@@ -1091,9 +1213,18 @@ async function runJob(paths, job, opts = {}) {
     reason += ` — and it ${reapFailure.reason}`;
   }
   // The mechanicsRootUntrusted entry gate (top of run()) refuses an anomalous
-  // core before any dispatch, so runJob only ever runs on a trusted core — the
-  // failure path writes the watermark + fail-loud alert normally.
-  jobsLib.writeScheduleState(paths, name, { last_status: 'error', last_error_at: nowIso() });
+  // core before any dispatch, so runJob only ever runs on a trusted core — but
+  // a trusted core's watermark write can still throw for an unrelated reason
+  // (ENOSPC/EROFS/EDQUOT, an unwritable state/). Table A: that throw must
+  // never suppress the failLoud call that follows, and the alert still
+  // reports the ORIGINAL `reason`, never the watermark's I/O error.
+  try {
+    jobsLib.writeScheduleState(paths, name, { last_status: 'error', last_error_at: nowIso() });
+  } catch (werr) {
+    process.stderr.write(
+      `wienerdog: job "${name}" error watermark could not be saved: ${(werr && werr.message) || werr}\n`
+    );
+  }
   const alertPersisted = await failLoud(paths, name, reason, opts);
   // F3 + G2 (WP-a10-reap fix-pass): the durable alert IS the record of the
   // un-reapable group, so release the still-retained token pidfile(s) — but

--- a/src/cli/run-job.js
+++ b/src/cli/run-job.js
@@ -621,6 +621,22 @@ function alertCleanupRefusedSubject(name) {
 }
 
 /**
+ * WP-failloud-survives-state-write-failure, Table E ("the outcome channel is
+ * separate from the forwarded opts"): every ORDINARY `failLoud` call site
+ * (the three failure sites `:797`/`:872`/`:1096` and the catch-up refusals)
+ * forwards its caller's `opts` verbatim. Without this, an `outcome` riding
+ * that object — e.g. `alert-cleanup-refused`, which sets the append-skip —
+ * would reach them too: exactly the "suppression capability any caller could
+ * aim at the primary reporting channel" Table E's preamble exists to deny.
+ * This FORCES `job-failure`, overriding anything `opts.outcome` carries, so
+ * only `:1060`/`:1061` (which build their own outcome-bearing opts object,
+ * never derived from this function) can select a different outcome.
+ * @param {object} opts @returns {object} */
+function ordinaryFailLoudOpts(opts) {
+  return { ...opts, outcome: 'job-failure' };
+}
+
+/**
  * Fail loud: append a DURABLE alert to state/alerts.jsonl (re-rendered into the
  * digest until the job next succeeds — ADR-0012 part 3), then attempt the
  * best-effort email. The durable record is independent of email delivery.
@@ -652,13 +668,23 @@ function alertCleanupRefusedSubject(name) {
  * An unrecognized discriminant throws (the one place failLoud may throw; it is
  * unreachable from the five call sites, which all pass literals) rather than
  * silently degrading to either behavior.
+ * Amended 2026-09-01: for the two success-path outcomes `failLoud` ALSO
+ * self-derives the `reason` it persists and emails from the SAME shared
+ * template `runJob` uses for its throw (`successMarkerRefusedReason` /
+ * `alertCleanupRefusedReason`) — the `reason` argument is honored only for
+ * `job-failure`. This keeps a stale/wrong caller string from ever reaching
+ * the durable record: the template is the string's single source, called by
+ * both `runJob` (for the throw) and `failLoud` (for what it records), so the
+ * two are always byte-identical.
  * `persisted` now also honors an explicit `false` return from the append
  * (`opts.appendAlert`, a test-only seam mirroring `opts.sendAlert` — production
  * always uses the real `appendAlert`, which returns `undefined` on every path
  * today, so this is a no-op there); `undefined` keeps today's
  * absence-of-throw meaning.
  * @param {import('../core/paths').WienerdogPaths} paths
- * @param {string} name @param {string} reason
+ * @param {string} name @param {string} reason honored ONLY for the default
+ *   `job-failure` outcome — ignored (and self-derived instead) for the two
+ *   success-path outcomes
  * @param {{sendAlert?: typeof defaultSendAlert, appendAlert?: typeof appendAlert,
  *          outcome?: 'job-failure'|'success-marker-refused'|'alert-cleanup-refused'}} [opts]
  * @returns {Promise<boolean>} true iff the durable alert append persisted
@@ -667,12 +693,15 @@ async function failLoud(paths, name, reason, opts = {}) {
   const outcome = opts.outcome === undefined ? 'job-failure' : opts.outcome;
   let subject;
   let appendSkipped = false;
+  let effectiveReason = reason;
   if (outcome === 'job-failure') {
     subject = `job ${name} failed`;
   } else if (outcome === 'success-marker-refused') {
     subject = successMarkerRefusedSubject(name);
+    effectiveReason = successMarkerRefusedReason(name); // self-derived — never the caller's reason
   } else if (outcome === 'alert-cleanup-refused') {
     subject = alertCleanupRefusedSubject(name);
+    effectiveReason = alertCleanupRefusedReason(name); // self-derived — never the caller's reason
     appendSkipped = true; // Table C: never write through the artifact just refused
   } else {
     throw new WienerdogError(`failLoud: unrecognized outcome "${outcome}"`);
@@ -686,7 +715,7 @@ async function failLoud(paths, name, reason, opts = {}) {
       const appendResult = appendFn(paths, {
         job: name,
         at: nowIso(),
-        reason,
+        reason: effectiveReason,
         log_hint: logHint,
       });
       // Explicit `false` (WP-private-state-writers-mode-pin's F10 case) means
@@ -695,7 +724,7 @@ async function failLoud(paths, name, reason, opts = {}) {
       persisted = appendResult !== false;
     }
     const send = opts.sendAlert || defaultSendAlert;
-    const body = `${reason}\n\nDetails: ${logHint}`.trim();
+    const body = `${effectiveReason}\n\nDetails: ${logHint}`.trim();
     try {
       send(paths, name, subject, body);
     } catch {
@@ -879,7 +908,7 @@ async function runJob(paths, job, opts = {}) {
         `wienerdog: job "${name}" error watermark could not be saved: ${(werr && werr.message) || werr}\n`
       );
     }
-    await failLoud(paths, name, reason, opts);
+    await failLoud(paths, name, reason, ordinaryFailLoudOpts(opts));
     throw new WienerdogError(`job "${name}" ${reason}`);
   }
 
@@ -962,7 +991,7 @@ async function runJob(paths, job, opts = {}) {
           `wienerdog: job "${name}" error watermark could not be saved: ${(werr && werr.message) || werr}\n`
         );
       }
-      await failLoud(paths, name, reason, opts);
+      await failLoud(paths, name, reason, ordinaryFailLoudOpts(opts));
       throw new WienerdogError(reason);
     }
   }
@@ -1225,7 +1254,7 @@ async function runJob(paths, job, opts = {}) {
       `wienerdog: job "${name}" error watermark could not be saved: ${(werr && werr.message) || werr}\n`
     );
   }
-  const alertPersisted = await failLoud(paths, name, reason, opts);
+  const alertPersisted = await failLoud(paths, name, reason, ordinaryFailLoudOpts(opts));
   // F3 + G2 (WP-a10-reap fix-pass): the durable alert IS the record of the
   // un-reapable group, so release the still-retained token pidfile(s) — but
   // ONLY when that alert actually persisted (G2). If alerts.jsonl could not be
@@ -1325,7 +1354,7 @@ async function catchUp(paths, opts = {}) {
         paths,
         'catchup',
         `wienerdog: catch-up refused — the bound job-authorization map is unreadable (${decoded.reason}); no jobs were run. Run 'wienerdog sync' to re-bind it.`,
-        opts
+        ordinaryFailLoudOpts(opts)
       );
       process.stdout.write('wienerdog: catch-up refused — unreadable authorization map; nothing run.\n');
       return;
@@ -1352,11 +1381,11 @@ async function catchUp(paths, opts = {}) {
         live = undefined;
       }
       if (bound === undefined) {
-        await failLoud(paths, name, `wienerdog: catch-up refused "${name}" — it is not in the authorized job map (added since the last 'wienerdog sync'); it was NOT run.`, opts);
+        await failLoud(paths, name, `wienerdog: catch-up refused "${name}" — it is not in the authorized job map (added since the last 'wienerdog sync'); it was NOT run.`, ordinaryFailLoudOpts(opts));
       } else if (live === undefined) {
-        await failLoud(paths, name, `wienerdog: catch-up refused "${name}" — it is authorized but no longer in your config (removed since the last 'wienerdog sync'); it was NOT run.`, opts);
+        await failLoud(paths, name, `wienerdog: catch-up refused "${name}" — it is authorized but no longer in your config (removed since the last 'wienerdog sync'); it was NOT run.`, ordinaryFailLoudOpts(opts));
       } else if (live !== bound) {
-        await failLoud(paths, name, `wienerdog: catch-up refused "${name}" — its descriptor changed since it was scheduled (run/model/at/… drift); run 'wienerdog sync' to re-authorize it. It was NOT run.`, opts);
+        await failLoud(paths, name, `wienerdog: catch-up refused "${name}" — its descriptor changed since it was scheduled (run/model/at/… drift); run 'wienerdog sync' to re-authorize it. It was NOT run.`, ordinaryFailLoudOpts(opts));
       } else {
         authorized.push({ name, job });
       }

--- a/tests/unit/scheduler-runjob.test.js
+++ b/tests/unit/scheduler-runjob.test.js
@@ -2367,3 +2367,418 @@ test('scheduler-runjob: WP-151 T10 — a clean exit whose log stream errored is 
     assert.match(bodies[0], /ran but its log could not be written/, 'email carries the row-4 reason');
   }
 });
+
+// -------------------------------------------------------------------------
+// WP-failloud-survives-state-write-failure: a failed state write must never
+// suppress a job's durable record, on any of the five sites. Tables A/B/C/E.
+// -------------------------------------------------------------------------
+
+/** Capture process.stderr.write for the duration of `fn`, restoring after
+ *  (mirrors the pattern already used across this repo's test suite). */
+async function captureStderr(fn) {
+  const orig = process.stderr.write;
+  let out = '';
+  process.stderr.write = (chunk) => {
+    out += chunk.toString();
+    return true;
+  };
+  try {
+    await fn();
+  } finally {
+    process.stderr.write = orig;
+  }
+  return out;
+}
+
+// ---- Table A: the three failure-path sites (:797, :872, :1096) ----------
+
+test('scheduler-runjob: Table A :797 — a watermark write throw does not suppress the TCC-refusal alert', async () => {
+  const { env, paths } = setup(path.join('Documents', 'vault'));
+  jobsLib.saveJob(paths, { name: 'digest', at: '07:00', run: 'skill:wienerdog-daily-digest', timeoutMinutes: 15 });
+  fs.mkdirSync(path.join(paths.state, 'schedule.json')); // forces writeScheduleState to throw EISDIR
+  /** @type {any[]} */ const alerts = [];
+  const sendAlert = (_p, _n, subject, body) => (alerts.push({ subject, body }), { status: 0 });
+
+  const stderr = await captureStderr(() =>
+    assert.rejects(
+      withRun(env, {}, ['digest'], { platform: 'darwin', sendAlert, loader: noopLoader }),
+      /macOS protected folder \(Documents\)/
+    )
+  );
+
+  assert.match(stderr, /error watermark could not be saved/, 'watermark failure surfaced once on stderr (non-alert channel)');
+  assert.equal(alerts.length, 1, 'exactly one failLoud attempt');
+  assert.equal(alerts[0].subject, 'job digest failed', 'job-failure subject unchanged');
+  assert.match(alerts[0].body, /macOS protected folder \(Documents\)/, 'reports the ORIGINAL failure, not the watermark I/O error');
+  const durable = readAlerts(paths);
+  assert.equal(durable.length, 1, 'one durable alert recorded — never a second');
+  assert.match(durable[0].reason, /macOS protected folder \(Documents\)/);
+});
+
+test('scheduler-runjob: Table A :797 both-writes-fail — zero alert records, one diagnostic, original reason still thrown', async () => {
+  const { env, paths } = setup(path.join('Documents', 'vault'));
+  jobsLib.saveJob(paths, { name: 'digest', at: '07:00', run: 'skill:wienerdog-daily-digest', timeoutMinutes: 15 });
+  fs.mkdirSync(path.join(paths.state, 'schedule.json'));
+  fs.mkdirSync(path.join(paths.state, 'alerts.jsonl'));
+  /** @type {any[]} */ const alerts = [];
+  const sendAlert = (_p, _n, subject, body) => (alerts.push({ subject, body }), { status: 0 });
+
+  const stderr = await captureStderr(() =>
+    assert.rejects(
+      withRun(env, {}, ['digest'], { platform: 'darwin', sendAlert, loader: noopLoader }),
+      /macOS protected folder \(Documents\)/
+    )
+  );
+
+  assert.match(stderr, /error watermark could not be saved/, 'exactly one non-alert persistence diagnostic');
+  // failLoud's append and email send share one try (unchanged, out of scope
+  // here): when appendAlert itself throws (the same fault also breaks
+  // alerts.jsonl), the throw skips the email send too — this is HEAD's
+  // existing best-effort behavior, not something this WP alters.
+  assert.equal(alerts.length, 0, 'the append throw also skipped the email attempt (pre-existing failLoud behavior)');
+  assert.equal(readAlerts(paths).length, 0, 'zero alert records — alerts.jsonl itself could not be written either');
+});
+
+test('scheduler-runjob: Table A :872 — a watermark write throw does not suppress the containment-halt alert', async () => {
+  const { root, env, paths } = setup();
+  jobsLib.saveJob(paths, { name: 'digest', at: '07:00', run: 'skill:wienerdog-daily-digest', timeoutMinutes: 15 });
+  const brain = writeScript(root, 'brain.sh', ['#!/bin/sh', 'exit 0']);
+  fs.mkdirSync(path.join(paths.state, 'schedule.json'));
+  /** @type {any[]} */ const alerts = [];
+
+  const stderr = await captureStderr(() =>
+    assert.rejects(
+      withRun(env, {}, ['digest'], routineOpts({
+        resolveCommand: fakeResolve(brain),
+        probeCmd: writeProbeFake(root, 'fail'),
+        sendAlert: (_p, _n, subject, body) => (alerts.push({ subject, body }), { status: 0 }),
+      })),
+      /pre-routine containment self-check fail/
+    )
+  );
+
+  assert.match(stderr, /error watermark could not be saved/);
+  assert.equal(alerts.length, 1);
+  assert.equal(alerts[0].subject, 'job digest failed');
+  assert.match(alerts[0].body, /pre-routine containment self-check fail/);
+  assert.equal(readAlerts(paths).length, 1, 'one durable alert recorded');
+});
+
+test('scheduler-runjob: Table A :872 both-writes-fail — zero alert records, one diagnostic, original reason still thrown', async () => {
+  const { root, env, paths } = setup();
+  jobsLib.saveJob(paths, { name: 'digest', at: '07:00', run: 'skill:wienerdog-daily-digest', timeoutMinutes: 15 });
+  const brain = writeScript(root, 'brain.sh', ['#!/bin/sh', 'exit 0']);
+  fs.mkdirSync(path.join(paths.state, 'schedule.json'));
+  fs.mkdirSync(path.join(paths.state, 'alerts.jsonl'));
+  /** @type {any[]} */ const alerts = [];
+
+  const stderr = await captureStderr(() =>
+    assert.rejects(
+      withRun(env, {}, ['digest'], routineOpts({
+        resolveCommand: fakeResolve(brain),
+        probeCmd: writeProbeFake(root, 'fail'),
+        sendAlert: (_p, _n, subject, body) => (alerts.push({ subject, body }), { status: 0 }),
+      })),
+      /pre-routine containment self-check fail/
+    )
+  );
+
+  assert.match(stderr, /error watermark could not be saved/);
+  assert.equal(alerts.length, 0, 'the append throw also skipped the email attempt (pre-existing failLoud behavior)');
+  assert.equal(readAlerts(paths).length, 0, 'zero alert records');
+});
+
+test('scheduler-runjob: Table A :1096 — a watermark write throw does not suppress the general-failure alert', async () => {
+  const { root, env, paths } = setup();
+  jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+  const fake = writeScript(root, 'fail.sh', ['#!/bin/sh', 'exit 3']);
+  fs.mkdirSync(path.join(paths.state, 'schedule.json'));
+  /** @type {any[]} */ const alerts = [];
+  const sendAlert = (_p, _n, subject, body) => (alerts.push({ subject, body }), { status: 0 });
+
+  const stderr = await captureStderr(() =>
+    assert.rejects(
+      withRun(env, {}, ['dream'], { resolveCommand: fakeResolve(fake), sendAlert, loader: noopLoader }),
+      /exited 3/
+    )
+  );
+
+  assert.match(stderr, /error watermark could not be saved/);
+  assert.equal(alerts.length, 1);
+  assert.equal(alerts[0].subject, 'job dream failed');
+  assert.match(alerts[0].body, /exited 3/);
+  const durable = readAlerts(paths);
+  assert.equal(durable.length, 1);
+  assert.equal(durable[0].reason, 'job "dream" exited 3');
+  assert.equal(jobsLib.readScheduleState(paths).dream, undefined, 'the watermark write never landed');
+});
+
+test('scheduler-runjob: Table A :1096 both-writes-fail — zero alert records, one diagnostic, retained pidfile n/a, original reason still thrown', async () => {
+  const { root, env, paths } = setup();
+  jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+  const fake = writeScript(root, 'fail.sh', ['#!/bin/sh', 'exit 3']);
+  fs.mkdirSync(path.join(paths.state, 'schedule.json'));
+  fs.mkdirSync(path.join(paths.state, 'alerts.jsonl'));
+  /** @type {any[]} */ const alerts = [];
+  const sendAlert = (_p, _n, subject, body) => (alerts.push({ subject, body }), { status: 0 });
+
+  const stderr = await captureStderr(() =>
+    assert.rejects(
+      withRun(env, {}, ['dream'], { resolveCommand: fakeResolve(fake), sendAlert, loader: noopLoader }),
+      /exited 3/
+    )
+  );
+
+  assert.match(stderr, /error watermark could not be saved/);
+  assert.equal(alerts.length, 0, 'the append throw also skipped the email attempt (pre-existing failLoud behavior)');
+  assert.equal(readAlerts(paths).length, 0);
+});
+
+// ---- Table B: the two success-path sites (:1060, :1061) -----------------
+
+test('scheduler-runjob: Table B1 :1060 — the success-marker write throws: one failLoud attempt, replay-guard reason, not-clean throw', async () => {
+  const { root, env, paths } = setup();
+  jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+  const fake = writeScript(root, 'ok.sh', ['#!/bin/sh', 'exit 0']);
+  fs.mkdirSync(path.join(paths.state, 'schedule.json')); // forces writeScheduleState to throw at :1060
+  /** @type {any[]} */ const alerts = [];
+  const sendAlert = (_p, _n, subject, body) => (alerts.push({ subject, body }), { status: 0 });
+
+  await assert.rejects(
+    withRun(env, {}, ['dream'], { resolveCommand: fakeResolve(fake), sendAlert, loader: noopLoader }),
+    (e) => {
+      assert.match(e.message, /last_success/);
+      assert.match(e.message, /could not be saved/);
+      assert.match(e.message, /re-run/);
+      assert.match(e.message, /repair or remove state\/schedule\.json/);
+      return true;
+    }
+  );
+
+  assert.equal(alerts.length, 1, 'exactly one failLoud attempt for the run');
+  assert.notEqual(alerts[0].subject, 'job dream failed', 'the work completed — not the generic failure subject');
+  assert.match(alerts[0].subject, /succeeded/);
+  assert.match(alerts[0].body, /schedule\.json/, 'names the refused state operation');
+  const durable = readAlerts(paths);
+  assert.equal(durable.length, 1, 'the append is attempted — alerts.jsonl is not the refused artifact here (B1)');
+  assert.match(durable[0].reason, /re-run/);
+  assert.equal(jobsLib.readScheduleState(paths).dream, undefined, 'last_success never landed — the next run treats this as overdue');
+});
+
+test('scheduler-runjob: Table B1 both-writes-fail — zero alert records, one diagnostic, B1 reason still thrown', async () => {
+  const { root, env, paths } = setup();
+  jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+  const fake = writeScript(root, 'ok.sh', ['#!/bin/sh', 'exit 0']);
+  fs.mkdirSync(path.join(paths.state, 'schedule.json'));
+  fs.mkdirSync(path.join(paths.state, 'alerts.jsonl'));
+  /** @type {any[]} */ const alerts = [];
+  const sendAlert = (_p, _n, subject, body) => (alerts.push({ subject, body }), { status: 0 });
+
+  const stderr = await captureStderr(() =>
+    assert.rejects(
+      withRun(env, {}, ['dream'], { resolveCommand: fakeResolve(fake), sendAlert, loader: noopLoader }),
+      /last_success|re-run/
+    )
+  );
+
+  assert.match(stderr, /success record could not be saved/, 'one non-alert persistence diagnostic');
+  assert.equal(alerts.length, 0, 'the append throw also skipped the email attempt (pre-existing failLoud behavior)');
+  assert.equal(readAlerts(paths).length, 0, 'zero alert records — alerts.jsonl itself could not be written either');
+});
+
+test('scheduler-runjob: Table B2 :1061 — clearAlerts throws AFTER :1060 succeeded: no replay claim, only one failLoud attempt for the run', async () => {
+  const { root, env, paths } = setup();
+  jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+  const fake = writeScript(root, 'ok.sh', ['#!/bin/sh', 'exit 0']);
+  // A pre-existing alert for a DIFFERENT job so clearAlerts's rewrite branch is
+  // reached (remaining.length > 0) rather than its rmSync branch.
+  const alertsFile = path.join(paths.state, ALERTS_FILE);
+  fs.writeFileSync(
+    alertsFile,
+    `${JSON.stringify({ job: 'other', at: new Date().toISOString(), reason: 'x', log_hint: 'y' })}\n`
+  );
+  // clearAlerts runs IN THIS PROCESS (no subprocess), so its own temp filename
+  // (alerts.jsonl.<pid>.tmp) is deterministic — block just that write.
+  fs.mkdirSync(`${alertsFile}.${process.pid}.tmp`);
+  /** @type {any[]} */ const alerts = [];
+  const sendAlert = (_p, _n, subject, body) => (alerts.push({ subject, body }), { status: 0 });
+
+  await assert.rejects(
+    withRun(env, {}, ['dream'], { resolveCommand: fakeResolve(fake), sendAlert, loader: noopLoader }),
+    (e) => {
+      assert.match(e.message, /recorded/);
+      assert.match(e.message, /could not/);
+      assert.doesNotMatch(e.message, /re-run|replay/i, 'B2 must NOT make a replay claim');
+      return true;
+    }
+  );
+
+  const state = jobsLib.readScheduleState(paths).dream;
+  assert.equal(state.last_status, 'ok', 'the success marker WAS saved at :1060 — no replay');
+  assert.ok(state.last_success, 'last_success recorded');
+  assert.equal(alerts.length, 1, 'exactly one failLoud attempt — the :1060 site did not ALSO fire');
+  assert.notEqual(alerts[0].subject, 'job dream failed');
+  assert.match(alerts[0].subject, /succeeded/);
+  assert.match(alerts[0].body, /alerts\.jsonl/, 'names the refused state operation');
+  const rawOutside = fs.readFileSync(alertsFile, 'utf8');
+  assert.ok(!rawOutside.includes('"job":"dream"'), 'the recovery path never wrote through the refused artifact (Table C)');
+});
+
+// ---- Table C: the :1061 recovery path never writes through alerts.jsonl -
+
+test('scheduler-runjob: Table C — a :1061 refusal on a SYMLINKED alerts.jsonl adds no write through the refusal handling', async () => {
+  const { root, env, paths } = setup();
+  jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+  const fake = writeScript(root, 'ok.sh', ['#!/bin/sh', 'exit 0']);
+  const outside = path.join(root, 'OUTSIDE');
+  const alertsFile = path.join(paths.state, ALERTS_FILE);
+  fs.writeFileSync(
+    outside,
+    `${JSON.stringify({ job: 'other', at: new Date().toISOString(), reason: 'x', log_hint: 'y' })}\n`
+  );
+  fs.symlinkSync(outside, alertsFile);
+  fs.mkdirSync(`${alertsFile}.${process.pid}.tmp`); // forces clearAlerts's rewrite to throw
+  /** @type {any[]} */ const alerts = [];
+  const sendAlert = (_p, _n, subject, body) => (alerts.push({ subject, body }), { status: 0 });
+
+  const stderr = await captureStderr(() =>
+    assert.rejects(
+      withRun(env, {}, ['dream'], { resolveCommand: fakeResolve(fake), sendAlert, loader: noopLoader }),
+      /recorded/
+    )
+  );
+
+  assert.match(stderr, /clearing its previous alerts failed/, 'the non-alert diagnostic still happens');
+  assert.equal(alerts.length, 1, 'the best-effort email attempt still happens');
+  assert.ok(fs.lstatSync(alertsFile).isSymbolicLink(), 'alerts.jsonl is STILL a symlink — the refusal handling added no write');
+  const rawOutside = fs.readFileSync(outside, 'utf8');
+  assert.ok(!rawOutside.includes('"job":"dream"'), "the symlink's target gained no record from the refusal handling");
+});
+
+// ---- Table E: failLoud's closed outcome enum -----------------------------
+
+test('scheduler-runjob: Table E — failLoud with no outcome is byte-identical to HEAD', async () => {
+  const { paths } = setup();
+  /** @type {any[]} */ const calls = [];
+  const persisted = await runjob.failLoud(paths, 'dream', 'brain exploded', {
+    sendAlert: (_p, _n, subject, body) => (calls.push({ subject, body }), { status: 0 }),
+  });
+  assert.equal(persisted, true);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].subject, 'job dream failed');
+  const alerts = readAlerts(paths);
+  assert.equal(alerts.length, 1);
+  assert.equal(alerts[0].reason, 'brain exploded');
+});
+
+test('scheduler-runjob: Table E — success-marker-refused: append attempted, canonical subject/reason, true iff persisted', async () => {
+  const { paths } = setup();
+  /** @type {any[]} */ const calls = [];
+  const reason =
+    'job "dream" finished its work, but the record of that success ("last_success" in ' +
+    'state/schedule.json) could not be saved. Because that record is what tells Wienerdog the ' +
+    'job already ran, the job will be re-run at every future catch-up until this is fixed. To ' +
+    'stop the repeats: repair or remove state/schedule.json, or disable the job.';
+  const persisted = await runjob.failLoud(paths, 'dream', reason, {
+    outcome: 'success-marker-refused',
+    sendAlert: (_p, _n, subject, body) => (calls.push({ subject, body }), { status: 0 }),
+  });
+  assert.equal(persisted, true, 'the append is attempted — alerts.jsonl is not the refused artifact');
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].subject, 'job dream succeeded, but its record could not be saved');
+  assert.match(calls[0].body, /^job "dream" finished its work, but the record of that success/);
+  const alerts = readAlerts(paths);
+  assert.equal(alerts.length, 1);
+  assert.equal(alerts[0].reason, reason);
+});
+
+test('scheduler-runjob: Table E — alert-cleanup-refused: append POLICY-SKIPPED, returns false always, canonical subject/reason', async () => {
+  const { paths } = setup();
+  /** @type {any[]} */ const calls = [];
+  const reason =
+    'job "dream" finished its work and its success was recorded, but Wienerdog could not clear ' +
+    'its previous alert(s) in state/alerts.jsonl. The job is up to date; the earlier alert(s) will ' +
+    'keep showing until this is fixed.';
+  const persisted = await runjob.failLoud(paths, 'dream', reason, {
+    outcome: 'alert-cleanup-refused',
+    sendAlert: (_p, _n, subject, body) => (calls.push({ subject, body }), { status: 0 }),
+  });
+  assert.equal(persisted, false, 'a skipped append never reports as persisted');
+  assert.equal(calls.length, 1, 'the email is still attempted');
+  assert.equal(calls[0].subject, 'job dream succeeded, but its alert cleanup failed');
+  assert.match(calls[0].body, /^job "dream" finished its work and its success was recorded/);
+  assert.deepEqual(readAlerts(paths), [], 'the append was never attempted — no write through the refused artifact');
+});
+
+test('scheduler-runjob: Table E — alert-cleanup-refused returns false even when the email send itself SUCCEEDS', async () => {
+  const { paths } = setup();
+  const persisted = await runjob.failLoud(paths, 'dream', 'x', {
+    outcome: 'alert-cleanup-refused',
+    sendAlert: () => ({ status: 0 }),
+  });
+  assert.equal(persisted, false);
+});
+
+test('scheduler-runjob: Table E — an unknown outcome discriminant throws rather than degrading to either behavior', async () => {
+  const { paths } = setup();
+  await assert.rejects(
+    runjob.failLoud(paths, 'dream', 'x', { outcome: 'bogus-outcome' }),
+    /unrecognized outcome/
+  );
+  assert.deepEqual(readAlerts(paths), [], 'no append happened either');
+});
+
+// ---- Table E: `persisted` honors an explicit `false` from appendAlert ----
+
+test('scheduler-runjob: Table E — persisted honors an explicit `false` from appendAlert (test-only seam)', async () => {
+  const { paths } = setup();
+  /** @type {any[]} */ const calls = [];
+  const persisted = await runjob.failLoud(paths, 'dream', 'brain exploded', {
+    appendAlert: () => false,
+    sendAlert: (_p, _n, subject, body) => (calls.push({ subject, body }), { status: 0 }),
+  });
+  assert.equal(persisted, false, 'an explicit false from appendAlert means NOT persisted');
+  assert.equal(calls.length, 1, 'the email is still attempted');
+  assert.deepEqual(readAlerts(paths), [], 'the injected seam never actually wrote to disk');
+});
+
+test('scheduler-runjob: Table E — appendAlert returning undefined (every path on HEAD) keeps HEAD semantics', async () => {
+  const { paths } = setup();
+  const persisted = await runjob.failLoud(paths, 'dream', 'brain exploded', {
+    appendAlert: () => undefined,
+    sendAlert: () => ({ status: 0 }),
+  });
+  assert.equal(persisted, true, 'absence-of-throw with an undefined return still means persisted');
+});
+
+test(
+  'scheduler-runjob: Table E — an explicit `false` from appendAlert (not a throw) still RETAINS the survivor pidfile via :1106-1108',
+  { skip: REAP_SKIP_WIN32 },
+  async () => {
+    const { root, env, paths } = setup();
+    jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+    const fake = writeScript(root, 'mid.sh', [
+      '#!/bin/sh',
+      'printf \'{"pid": 55555, "pgid": 55555}\' > "$WIENERDOG_HOME/state/dream-brain.$WIENERDOG_DREAM_RUN_TOKEN.pid"',
+      'exit 0',
+    ]);
+    const seams = reapSeams([{ reaped: false }, { reaped: false }, { reaped: false }, { reaped: false }]);
+    await assert.rejects(
+      withRun(env, {}, ['dream'], {
+        resolveCommand: fakeResolve(fake),
+        sendAlert: () => ({ status: 0 }),
+        // The new WP-private-state-writers-mode-pin F10 shape: loses the record
+        // WITHOUT throwing. failLoud must still report persisted === false.
+        appendAlert: () => false,
+        loader: noopLoader,
+        reapTree: seams.reapTree,
+        reapGroup: seams.reapGroup,
+      }),
+      /could not be reaped/
+    );
+    assert.equal(jobsLib.readScheduleState(paths).dream.last_status, 'error', 'error watermark still written');
+    assert.deepEqual(readAlerts(paths), [], 'the injected seam never actually wrote a record');
+    const leftover = fs.readdirSync(paths.state).filter((f) => f.startsWith('dream-brain.') && f.endsWith('.pid'));
+    assert.equal(leftover.length, 1, 'the survivor pidfile is RETAINED — an explicit false composes with :1106-1108 exactly like a throw does');
+  }
+);

--- a/tests/unit/scheduler-runjob.test.js
+++ b/tests/unit/scheduler-runjob.test.js
@@ -12,7 +12,7 @@ const { getPaths } = require('../../src/core/paths');
 const manifestLib = require('../../src/core/manifest');
 const jobsLib = require('../../src/scheduler/jobs');
 const runjob = require('../../src/cli/run-job');
-const { readAlerts, ALERTS_FILE } = require('../../src/core/alerts');
+const { readAlerts, ALERTS_FILE, appendAlert } = require('../../src/core/alerts');
 const { allowAll } = require('../../src/core/safety-profile');
 
 // A fully-blocked profile (the pre-0.10.0 frozen shape). The released profile now
@@ -2390,6 +2390,38 @@ async function captureStderr(fn) {
   return out;
 }
 
+/** Shadow finding F2: a both-writes-fail test that only checks the final
+ *  record count is vacuous about whether `failLoud`'s append was ever
+ *  ATTEMPTED — removing the production `failLoud` call entirely would still
+ *  pass it. Wrap the REAL `appendAlert` with a call counter that still
+ *  DELEGATES to it (so a directory-fixture throw still happens exactly as it
+ *  would in production); `.calls` proves the attempt count directly.
+ *  @returns {((paths:object, record:object)=>*) & {calls: object[]}} */
+function countingAppendAlert() {
+  const calls = [];
+  const fn = (paths, record) => {
+    calls.push(record);
+    return appendAlert(paths, record);
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+// The canonical B1/B2 reason templates — the single source `runJob` (for its
+// throw) and `failLoud` (for what it persists/emails) both derive from
+// (Table E, amended 2026-09-01). Defined once here and reused by both the
+// Table B and the Table E "one template, both paths" / "poison reason" tests
+// so a drift between two hand-typed copies can't hide a real bug.
+const CANONICAL_B1_REASON =
+  'job "dream" finished its work, but the record of that success ("last_success" in ' +
+  'state/schedule.json) could not be saved. Because that record is what tells Wienerdog the ' +
+  'job already ran, the job will be re-run at every future catch-up until this is fixed. To ' +
+  'stop the repeats: repair or remove state/schedule.json, or disable the job.';
+const CANONICAL_B2_REASON =
+  'job "dream" finished its work and its success was recorded, but Wienerdog could not clear ' +
+  'its previous alert(s) in state/alerts.jsonl. The job is up to date; the earlier alert(s) will ' +
+  'keep showing until this is fixed.';
+
 // ---- Table A: the three failure-path sites (:797, :872, :1096) ----------
 
 test('scheduler-runjob: Table A :797 — a watermark write throw does not suppress the TCC-refusal alert', async () => {
@@ -2420,17 +2452,19 @@ test('scheduler-runjob: Table A :797 both-writes-fail — zero alert records, on
   jobsLib.saveJob(paths, { name: 'digest', at: '07:00', run: 'skill:wienerdog-daily-digest', timeoutMinutes: 15 });
   fs.mkdirSync(path.join(paths.state, 'schedule.json'));
   fs.mkdirSync(path.join(paths.state, 'alerts.jsonl'));
+  const counted = countingAppendAlert();
   /** @type {any[]} */ const alerts = [];
   const sendAlert = (_p, _n, subject, body) => (alerts.push({ subject, body }), { status: 0 });
 
   const stderr = await captureStderr(() =>
     assert.rejects(
-      withRun(env, {}, ['digest'], { platform: 'darwin', sendAlert, loader: noopLoader }),
+      withRun(env, {}, ['digest'], { platform: 'darwin', sendAlert, appendAlert: counted, loader: noopLoader }),
       /macOS protected folder \(Documents\)/
     )
   );
 
   assert.match(stderr, /error watermark could not be saved/, 'exactly one non-alert persistence diagnostic');
+  assert.equal(counted.calls.length, 1, 'failLoud actually ATTEMPTED the append exactly once (F2)');
   // failLoud's append and email send share one try (unchanged, out of scope
   // here): when appendAlert itself throws (the same fault also breaks
   // alerts.jsonl), the throw skips the email send too — this is HEAD's
@@ -2470,6 +2504,7 @@ test('scheduler-runjob: Table A :872 both-writes-fail — zero alert records, on
   const brain = writeScript(root, 'brain.sh', ['#!/bin/sh', 'exit 0']);
   fs.mkdirSync(path.join(paths.state, 'schedule.json'));
   fs.mkdirSync(path.join(paths.state, 'alerts.jsonl'));
+  const counted = countingAppendAlert();
   /** @type {any[]} */ const alerts = [];
 
   const stderr = await captureStderr(() =>
@@ -2478,12 +2513,14 @@ test('scheduler-runjob: Table A :872 both-writes-fail — zero alert records, on
         resolveCommand: fakeResolve(brain),
         probeCmd: writeProbeFake(root, 'fail'),
         sendAlert: (_p, _n, subject, body) => (alerts.push({ subject, body }), { status: 0 }),
+        appendAlert: counted,
       })),
       /pre-routine containment self-check fail/
     )
   );
 
   assert.match(stderr, /error watermark could not be saved/);
+  assert.equal(counted.calls.length, 1, 'failLoud actually ATTEMPTED the append exactly once (F2)');
   assert.equal(alerts.length, 0, 'the append throw also skipped the email attempt (pre-existing failLoud behavior)');
   assert.equal(readAlerts(paths).length, 0, 'zero alert records');
 });
@@ -2513,26 +2550,53 @@ test('scheduler-runjob: Table A :1096 — a watermark write throw does not suppr
   assert.equal(jobsLib.readScheduleState(paths).dream, undefined, 'the watermark write never landed');
 });
 
-test('scheduler-runjob: Table A :1096 both-writes-fail — zero alert records, one diagnostic, retained pidfile n/a, original reason still thrown', async () => {
-  const { root, env, paths } = setup();
-  jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
-  const fake = writeScript(root, 'fail.sh', ['#!/bin/sh', 'exit 3']);
-  fs.mkdirSync(path.join(paths.state, 'schedule.json'));
-  fs.mkdirSync(path.join(paths.state, 'alerts.jsonl'));
-  /** @type {any[]} */ const alerts = [];
-  const sendAlert = (_p, _n, subject, body) => (alerts.push({ subject, body }), { status: 0 });
+test(
+  'scheduler-runjob: Table A :1096 both-writes-fail — zero alert records, one diagnostic, retained pidfile, original reason still thrown',
+  { skip: REAP_SKIP_WIN32 },
+  async () => {
+    const { root, env, paths } = setup();
+    jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+    // F4: a builtin:dream run that mints a per-token brain pidfile AND hits an
+    // un-reapable settle-path group, so the :1106-1108 pidfile-retention logic
+    // is actually exercised (not merely "n/a" for this site).
+    const fake = writeScript(root, 'mid.sh', [
+      '#!/bin/sh',
+      'printf \'{"pid": 55555, "pgid": 55555}\' > "$WIENERDOG_HOME/state/dream-brain.$WIENERDOG_DREAM_RUN_TOKEN.pid"',
+      'exit 0',
+    ]);
+    fs.mkdirSync(path.join(paths.state, 'schedule.json'));
+    fs.mkdirSync(path.join(paths.state, 'alerts.jsonl'));
+    const seams = reapSeams([{ reaped: false }, { reaped: false }, { reaped: false }, { reaped: false }]);
+    const counted = countingAppendAlert();
+    /** @type {any[]} */ const alerts = [];
+    const sendAlert = (_p, _n, subject, body) => (alerts.push({ subject, body }), { status: 0 });
 
-  const stderr = await captureStderr(() =>
-    assert.rejects(
-      withRun(env, {}, ['dream'], { resolveCommand: fakeResolve(fake), sendAlert, loader: noopLoader }),
-      /exited 3/
-    )
-  );
+    const stderr = await captureStderr(() =>
+      assert.rejects(
+        withRun(env, {}, ['dream'], {
+          resolveCommand: fakeResolve(fake),
+          sendAlert,
+          appendAlert: counted,
+          loader: noopLoader,
+          reapTree: seams.reapTree,
+          reapGroup: seams.reapGroup,
+        }),
+        /could not be reaped/
+      )
+    );
 
-  assert.match(stderr, /error watermark could not be saved/);
-  assert.equal(alerts.length, 0, 'the append throw also skipped the email attempt (pre-existing failLoud behavior)');
-  assert.equal(readAlerts(paths).length, 0);
-});
+    assert.match(stderr, /error watermark could not be saved/, 'exactly one non-alert persistence diagnostic');
+    assert.equal(counted.calls.length, 1, 'failLoud actually ATTEMPTED the append exactly once (F2)');
+    assert.equal(alerts.length, 0, 'the append throw also skipped the email attempt (pre-existing failLoud behavior)');
+    assert.equal(readAlerts(paths).length, 0, 'zero alert records');
+    const leftover = fs.readdirSync(paths.state).filter((f) => f.startsWith('dream-brain.') && f.endsWith('.pid'));
+    assert.equal(
+      leftover.length,
+      1,
+      'the survivor pidfile is RETAINED (F4) — alertPersisted is false since alerts.jsonl itself could not be written either'
+    );
+  }
+);
 
 // ---- Table B: the two success-path sites (:1060, :1061) -----------------
 
@@ -2544,24 +2608,30 @@ test('scheduler-runjob: Table B1 :1060 — the success-marker write throws: one 
   /** @type {any[]} */ const alerts = [];
   const sendAlert = (_p, _n, subject, body) => (alerts.push({ subject, body }), { status: 0 });
 
-  await assert.rejects(
-    withRun(env, {}, ['dream'], { resolveCommand: fakeResolve(fake), sendAlert, loader: noopLoader }),
-    (e) => {
-      assert.match(e.message, /last_success/);
-      assert.match(e.message, /could not be saved/);
-      assert.match(e.message, /re-run/);
-      assert.match(e.message, /repair or remove state\/schedule\.json/);
-      return true;
-    }
+  const stderr = await captureStderr(() =>
+    assert.rejects(
+      withRun(env, {}, ['dream'], { resolveCommand: fakeResolve(fake), sendAlert, loader: noopLoader }),
+      (e) => {
+        // One template, both paths: the THROWN reason is byte-identical to the
+        // canonical template (asserted again below on the PERSISTED reason).
+        assert.equal(e.message, CANONICAL_B1_REASON);
+        return true;
+      }
+    )
   );
 
+  assert.equal(
+    (stderr.match(/success record could not be saved/g) || []).length,
+    1,
+    'exactly one non-alert persistence diagnostic (F5)'
+  );
   assert.equal(alerts.length, 1, 'exactly one failLoud attempt for the run');
   assert.notEqual(alerts[0].subject, 'job dream failed', 'the work completed — not the generic failure subject');
-  assert.match(alerts[0].subject, /succeeded/);
-  assert.match(alerts[0].body, /schedule\.json/, 'names the refused state operation');
+  assert.equal(alerts[0].subject, 'job dream succeeded, but its record could not be saved');
+  assert.ok(alerts[0].body.startsWith(CANONICAL_B1_REASON), 'the EMAILED reason is the same canonical template');
   const durable = readAlerts(paths);
   assert.equal(durable.length, 1, 'the append is attempted — alerts.jsonl is not the refused artifact here (B1)');
-  assert.match(durable[0].reason, /re-run/);
+  assert.equal(durable[0].reason, CANONICAL_B1_REASON, 'the PERSISTED reason is byte-identical to the THROWN one');
   assert.equal(jobsLib.readScheduleState(paths).dream, undefined, 'last_success never landed — the next run treats this as overdue');
 });
 
@@ -2571,17 +2641,19 @@ test('scheduler-runjob: Table B1 both-writes-fail — zero alert records, one di
   const fake = writeScript(root, 'ok.sh', ['#!/bin/sh', 'exit 0']);
   fs.mkdirSync(path.join(paths.state, 'schedule.json'));
   fs.mkdirSync(path.join(paths.state, 'alerts.jsonl'));
+  const counted = countingAppendAlert();
   /** @type {any[]} */ const alerts = [];
   const sendAlert = (_p, _n, subject, body) => (alerts.push({ subject, body }), { status: 0 });
 
   const stderr = await captureStderr(() =>
     assert.rejects(
-      withRun(env, {}, ['dream'], { resolveCommand: fakeResolve(fake), sendAlert, loader: noopLoader }),
-      /last_success|re-run/
+      withRun(env, {}, ['dream'], { resolveCommand: fakeResolve(fake), sendAlert, appendAlert: counted, loader: noopLoader }),
+      (e) => e.message === CANONICAL_B1_REASON
     )
   );
 
   assert.match(stderr, /success record could not be saved/, 'one non-alert persistence diagnostic');
+  assert.equal(counted.calls.length, 1, 'failLoud actually ATTEMPTED the append exactly once (F2)');
   assert.equal(alerts.length, 0, 'the append throw also skipped the email attempt (pre-existing failLoud behavior)');
   assert.equal(readAlerts(paths).length, 0, 'zero alert records — alerts.jsonl itself could not be written either');
 });
@@ -2603,25 +2675,63 @@ test('scheduler-runjob: Table B2 :1061 — clearAlerts throws AFTER :1060 succee
   /** @type {any[]} */ const alerts = [];
   const sendAlert = (_p, _n, subject, body) => (alerts.push({ subject, body }), { status: 0 });
 
-  await assert.rejects(
-    withRun(env, {}, ['dream'], { resolveCommand: fakeResolve(fake), sendAlert, loader: noopLoader }),
-    (e) => {
-      assert.match(e.message, /recorded/);
-      assert.match(e.message, /could not/);
-      assert.doesNotMatch(e.message, /re-run|replay/i, 'B2 must NOT make a replay claim');
-      return true;
-    }
+  const stderr = await captureStderr(() =>
+    assert.rejects(
+      withRun(env, {}, ['dream'], { resolveCommand: fakeResolve(fake), sendAlert, loader: noopLoader }),
+      (e) => {
+        assert.doesNotMatch(e.message, /re-run|replay/i, 'B2 must NOT make a replay claim');
+        // One template, both paths: byte-identical to the canonical template.
+        assert.equal(e.message, CANONICAL_B2_REASON);
+        return true;
+      }
+    )
   );
 
+  assert.equal(
+    (stderr.match(/clearing its previous alerts failed/g) || []).length,
+    1,
+    'exactly one non-alert persistence diagnostic (F5)'
+  );
   const state = jobsLib.readScheduleState(paths).dream;
   assert.equal(state.last_status, 'ok', 'the success marker WAS saved at :1060 — no replay');
   assert.ok(state.last_success, 'last_success recorded');
   assert.equal(alerts.length, 1, 'exactly one failLoud attempt — the :1060 site did not ALSO fire');
-  assert.notEqual(alerts[0].subject, 'job dream failed');
-  assert.match(alerts[0].subject, /succeeded/);
-  assert.match(alerts[0].body, /alerts\.jsonl/, 'names the refused state operation');
+  assert.equal(alerts[0].subject, 'job dream succeeded, but its alert cleanup failed');
+  assert.ok(alerts[0].body.startsWith(CANONICAL_B2_REASON), 'the EMAILED reason is the same canonical template');
   const rawOutside = fs.readFileSync(alertsFile, 'utf8');
   assert.ok(!rawOutside.includes('"job":"dream"'), 'the recovery path never wrote through the refused artifact (Table C)');
+});
+
+test('scheduler-runjob: Table C — GWS unconfigured (sendAlert throws): B2 still emits the diagnostic, no alert record, and rejects with the B2 reason', async () => {
+  const { root, env, paths } = setup();
+  jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+  const fake = writeScript(root, 'ok.sh', ['#!/bin/sh', 'exit 0']);
+  // A pre-existing EMPTY DIRECTORY at alerts.jsonl: readAlerts()'s read fails
+  // EISDIR and its own catch resiliently returns [], so clearAlerts's
+  // `remaining` is [] and it takes the rmSync branch — rmSync on a directory
+  // without recursive:true also throws (verified: ERR_FS_EISDIR).
+  fs.mkdirSync(path.join(paths.state, ALERTS_FILE));
+  // Simulates GWS not being configured: the real defaultSendAlert's subprocess
+  // would fail; a throwing stub is the hermetic equivalent (failLoud's email
+  // try/catch swallows it either way).
+  const sendAlert = () => {
+    throw new Error('wienerdog gws _alert: GWS is not configured');
+  };
+
+  const stderr = await captureStderr(() =>
+    assert.rejects(
+      withRun(env, {}, ['dream'], { resolveCommand: fakeResolve(fake), sendAlert, loader: noopLoader }),
+      (e) => {
+        assert.equal(e.message, CANONICAL_B2_REASON);
+        return true;
+      }
+    )
+  );
+
+  assert.match(stderr, /clearing its previous alerts failed/, 'the non-alert diagnostic still appears even though the email itself failed');
+  assert.deepEqual(readAlerts(paths), [], 'readAlerts is empty — GWS being unconfigured creates no alert record either');
+  const state = jobsLib.readScheduleState(paths).dream;
+  assert.equal(state.last_status, 'ok', 'the success marker WAS saved — no replay');
 });
 
 // ---- Table C: the :1061 recovery path never writes through alerts.jsonl -
@@ -2674,12 +2784,7 @@ test('scheduler-runjob: Table E — failLoud with no outcome is byte-identical t
 test('scheduler-runjob: Table E — success-marker-refused: append attempted, canonical subject/reason, true iff persisted', async () => {
   const { paths } = setup();
   /** @type {any[]} */ const calls = [];
-  const reason =
-    'job "dream" finished its work, but the record of that success ("last_success" in ' +
-    'state/schedule.json) could not be saved. Because that record is what tells Wienerdog the ' +
-    'job already ran, the job will be re-run at every future catch-up until this is fixed. To ' +
-    'stop the repeats: repair or remove state/schedule.json, or disable the job.';
-  const persisted = await runjob.failLoud(paths, 'dream', reason, {
+  const persisted = await runjob.failLoud(paths, 'dream', CANONICAL_B1_REASON, {
     outcome: 'success-marker-refused',
     sendAlert: (_p, _n, subject, body) => (calls.push({ subject, body }), { status: 0 }),
   });
@@ -2689,17 +2794,13 @@ test('scheduler-runjob: Table E — success-marker-refused: append attempted, ca
   assert.match(calls[0].body, /^job "dream" finished its work, but the record of that success/);
   const alerts = readAlerts(paths);
   assert.equal(alerts.length, 1);
-  assert.equal(alerts[0].reason, reason);
+  assert.equal(alerts[0].reason, CANONICAL_B1_REASON);
 });
 
 test('scheduler-runjob: Table E — alert-cleanup-refused: append POLICY-SKIPPED, returns false always, canonical subject/reason', async () => {
   const { paths } = setup();
   /** @type {any[]} */ const calls = [];
-  const reason =
-    'job "dream" finished its work and its success was recorded, but Wienerdog could not clear ' +
-    'its previous alert(s) in state/alerts.jsonl. The job is up to date; the earlier alert(s) will ' +
-    'keep showing until this is fixed.';
-  const persisted = await runjob.failLoud(paths, 'dream', reason, {
+  const persisted = await runjob.failLoud(paths, 'dream', CANONICAL_B2_REASON, {
     outcome: 'alert-cleanup-refused',
     sendAlert: (_p, _n, subject, body) => (calls.push({ subject, body }), { status: 0 }),
   });
@@ -2717,6 +2818,142 @@ test('scheduler-runjob: Table E — alert-cleanup-refused returns false even whe
     sendAlert: () => ({ status: 0 }),
   });
   assert.equal(persisted, false);
+});
+
+// ---- Table E (amended 2026-09-01): the outcome decides the reason, and is
+// not inheritable from runJob's forwarded opts. Poison-reason, poison-outcome
+// and one-template-both-paths acceptance criteria. ------------------------
+
+test('scheduler-runjob: Table E — poison reason: success-marker-refused ignores a wrong/stale caller reason and self-derives the canonical string', async () => {
+  const { paths } = setup();
+  /** @type {any[]} */ const calls = [];
+  const persisted = await runjob.failLoud(paths, 'dream', 'WRONG STALE TEXT', {
+    outcome: 'success-marker-refused',
+    sendAlert: (_p, _n, subject, body) => (calls.push({ subject, body }), { status: 0 }),
+  });
+  assert.equal(persisted, true);
+  const durable = readAlerts(paths);
+  assert.equal(durable.length, 1);
+  assert.equal(durable[0].reason, CANONICAL_B1_REASON, 'the canonical string is persisted, not the caller reason');
+  assert.ok(!durable[0].reason.includes('WRONG STALE TEXT'));
+  assert.ok(calls[0].body.startsWith(CANONICAL_B1_REASON), 'the canonical string is emailed too');
+  assert.ok(!calls[0].body.includes('WRONG STALE TEXT'));
+});
+
+test('scheduler-runjob: Table E — poison reason: alert-cleanup-refused ignores a wrong/stale caller reason and self-derives the canonical string', async () => {
+  const { paths } = setup();
+  /** @type {any[]} */ const calls = [];
+  const persisted = await runjob.failLoud(paths, 'dream', 'WRONG STALE TEXT', {
+    outcome: 'alert-cleanup-refused',
+    sendAlert: (_p, _n, subject, body) => (calls.push({ subject, body }), { status: 0 }),
+  });
+  assert.equal(persisted, false);
+  assert.deepEqual(readAlerts(paths), [], 'the append is skipped for this outcome regardless');
+  assert.ok(calls[0].body.startsWith(CANONICAL_B2_REASON), 'the canonical string is emailed, not the caller reason');
+  assert.ok(!calls[0].body.includes('WRONG STALE TEXT'));
+});
+
+test('scheduler-runjob: Table E — job-failure still honors the caller reason verbatim (HEAD semantics preserved)', async () => {
+  const { paths } = setup();
+  const persisted = await runjob.failLoud(paths, 'dream', 'the callers exact text', {
+    outcome: 'job-failure',
+    sendAlert: () => ({ status: 0 }),
+  });
+  assert.equal(persisted, true);
+  assert.equal(readAlerts(paths)[0].reason, 'the callers exact text');
+});
+
+test('scheduler-runjob: Table E — poison outcome via runJob opts does not affect :797 (TCC refusal reports normally)', async () => {
+  const { env, paths } = setup(path.join('Documents', 'vault'));
+  jobsLib.saveJob(paths, { name: 'digest', at: '07:00', run: 'skill:wienerdog-daily-digest', timeoutMinutes: 15 });
+  /** @type {any[]} */ const alerts = [];
+  const sendAlert = (_p, _n, subject, body) => (alerts.push({ subject, body }), { status: 0 });
+
+  await assert.rejects(
+    withRun(env, {}, ['digest'], {
+      platform: 'darwin',
+      sendAlert,
+      loader: noopLoader,
+      outcome: 'alert-cleanup-refused', // POISON: injected via opts, must not reach failLoud
+    }),
+    /macOS protected folder \(Documents\)/
+  );
+
+  assert.equal(alerts.length, 1, 'the append is still attempted — NOT skipped by the poisoned outcome');
+  assert.equal(alerts[0].subject, 'job digest failed', 'subject unaffected by the poisoned outcome');
+  assert.match(alerts[0].body, /macOS protected folder \(Documents\)/, 'reason unaffected — still the caller original');
+  const durable = readAlerts(paths);
+  assert.equal(durable.length, 1, 'the append was NOT skipped despite the poisoned alert-cleanup-refused outcome');
+  assert.match(durable[0].reason, /macOS protected folder \(Documents\)/);
+});
+
+test('scheduler-runjob: Table E — poison outcome via runJob opts does not affect :872 (containment-halt reports normally)', async () => {
+  const { root, env, paths } = setup();
+  jobsLib.saveJob(paths, { name: 'digest', at: '07:00', run: 'skill:wienerdog-daily-digest', timeoutMinutes: 15 });
+  const brain = writeScript(root, 'brain.sh', ['#!/bin/sh', 'exit 0']);
+  /** @type {any[]} */ const alerts = [];
+
+  await assert.rejects(
+    withRun(env, {}, ['digest'], routineOpts({
+      resolveCommand: fakeResolve(brain),
+      probeCmd: writeProbeFake(root, 'fail'),
+      sendAlert: (_p, _n, subject, body) => (alerts.push({ subject, body }), { status: 0 }),
+      outcome: 'alert-cleanup-refused', // POISON
+    })),
+    /pre-routine containment self-check fail/
+  );
+
+  assert.equal(alerts.length, 1, 'the append is still attempted — NOT skipped by the poisoned outcome');
+  assert.equal(alerts[0].subject, 'job digest failed');
+  assert.match(alerts[0].body, /pre-routine containment self-check fail/);
+  assert.equal(readAlerts(paths).length, 1, 'the append was NOT skipped');
+});
+
+test('scheduler-runjob: Table E — poison outcome via runJob opts does not affect :1096 (general failure reports normally)', async () => {
+  const { root, env, paths } = setup();
+  jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+  const fake = writeScript(root, 'fail.sh', ['#!/bin/sh', 'exit 3']);
+  /** @type {any[]} */ const alerts = [];
+  const sendAlert = (_p, _n, subject, body) => (alerts.push({ subject, body }), { status: 0 });
+
+  await assert.rejects(
+    withRun(env, {}, ['dream'], {
+      resolveCommand: fakeResolve(fake),
+      sendAlert,
+      loader: noopLoader,
+      outcome: 'alert-cleanup-refused', // POISON
+    }),
+    /exited 3/
+  );
+
+  assert.equal(alerts.length, 1, 'the append is still attempted — NOT skipped by the poisoned outcome');
+  assert.equal(alerts[0].subject, 'job dream failed');
+  assert.match(alerts[0].body, /exited 3/);
+  const durable = readAlerts(paths);
+  assert.equal(durable.length, 1, 'the append was NOT skipped');
+  assert.equal(durable[0].reason, 'job "dream" exited 3');
+});
+
+test('scheduler-runjob: Table E — poison outcome via runJob opts does not affect a catch-up refusal', async () => {
+  const gen = require('../../src/scheduler/generators');
+  const { env, paths } = setup();
+  jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
+  /** @type {any[]} */ const alerts = [];
+  const sendAlert = (_p, _n, subject, body) => (alerts.push({ subject, body }), { status: 0 });
+
+  await withRun(env, {}, ['--catch-up'], {
+    sendAlert,
+    loader: noopLoader,
+    jobDigests: gen.encodeJobDigests({}), // 'dream' is NOT in the bound map → "added since last sync" refusal
+    outcome: 'alert-cleanup-refused', // POISON: must not reach the catch-up refusal's failLoud call
+  });
+
+  assert.equal(alerts.length, 1, 'the append is still attempted — NOT skipped by the poisoned outcome');
+  assert.equal(alerts[0].subject, 'job dream failed', 'subject unaffected by the poisoned outcome');
+  assert.match(alerts[0].body, /not in the authorized job map/);
+  const durable = readAlerts(paths);
+  assert.equal(durable.length, 1, 'the append was NOT skipped despite the poisoned outcome');
+  assert.match(durable[0].reason, /not in the authorized job map/);
 });
 
 test('scheduler-runjob: Table E — an unknown outcome discriminant throws rather than degrading to either behavior', async () => {


### PR DESCRIPTION
Spec: docs/specs/WP-failloud-survives-state-write-failure.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table (`src/cli/run-job.js`, `tests/unit/scheduler-runjob.test.js`)
- [x] Spec status flipped to In-Review

## Verification output

Round 1 (commit 1273288):

```
npm test → 2384 tests, 2372 pass, 0 fail, 12 skipped (18 new tests)
npm run lint → lint passed (markdownlint 0 issues; frontmatter 264 specs)
boundary-check → exit 0
HEAD-red / branch-green pair: run-job.js reverted → 16 of 18 new tests FAIL
  (the 2 still-green test failLoud's default/unknown-outcome cases, independent
  of the call-site guards — correct); restored, full suite green reconfirmed.
Mechanism probe: writeScheduleState still throws on unwritable state/, and
  writeFilePrivate still refuses a symlinked leaf — red by construction (this
  WP guards the call sites, not the primitives).
```

Round 2 (commit 5a2c35d, on top of the Table E spec amendment 9b788ea — F1-F5
fixes from round-1 gates: wd-reviewer APPROVE-conditional, plugin 1 P2, shadow
2 findings, converging on the amended Table E derivation/isolation contract):

```
npm test -- --test-name-pattern "run-job|runjob" → 213 tests, 213 pass, 0 fail
  (26 new tests added this round: poison-reason x3, poison-outcome x4,
  GWS-unconfigured B2 x1, plus F2/F4/F5 hardening of existing both-fail/
  single-fault tests)
npm test (full) → 2392 tests, 2380 pass, 0 fail, 12 skipped
npm run lint → lint passed (markdownlint 0 issues; frontmatter 264 specs)
boundary-check → exit 0
RED-side proof for the F1 fix specifically: reverted src/cli/run-job.js to
  commit 1273288 (pre-F1) while keeping the round-2 test file → 6 of 6 new
  poison-reason/poison-outcome tests FAIL (the 2 poison-reason tests on the
  wrong-caller-reason path, and all 4 poison-outcome tests on :797/:872/
  :1096/catch-up — each shows the poisoned alert-cleanup-refused outcome
  actually reaching the ordinary site: e.g. subject
  "job digest succeeded, but its alert cleanup failed" instead of the
  expected "job digest failed"). Restored (diffed byte-identical against the
  pre-revert copy); full targeted suite (213/213) and full suite (2380 pass)
  reconfirmed green.
```

## What changed

All five state-write sites (`:797`, `:872`, `:1096`, `:1060`, `:1061`) guarded inline; a watermark/clearAlerts throw is surfaced once on stderr and never suppresses `failLoud`. `failLoud` gains the Table E closed outcome enum (`job-failure` = byte-identical HEAD default, `success-marker-refused` = B1, `alert-cleanup-refused` = B2 with the Table C append skip); unknown discriminant throws; `persisted` honors an explicit `false` from `appendAlert` (`undefined` keeps HEAD semantics — the F10 producer lands in the mode-pin WP).

## Decisions made

1. Canonical B1/B2 reason/subject strings live in two local template functions — single source for both `failLoud`'s derivation and the call sites' thrown `WienerdogError`; the subject/append-policy seam stays strictly inside `failLoud`.
2. The non-alert stderr diagnostic is emitted on any watermark/clearAlerts throw (required unconditionally for B2; applied uniformly — no criterion conflicts).
3. `opts.appendAlert` test-only seam added, mirroring the existing `opts.sendAlert` idiom (named as acceptable by the spec).
4. (Round 2, F1b) Outcome isolation is a new `ordinaryFailLoudOpts(opts)` helper (`{ ...opts, outcome: 'job-failure' }`) applied at all seven ordinary `failLoud` call sites, rather than an inline spread at each — reduces the risk of missing one of the seven and silently reopening the suppression seam.
5. (Round 2, F2) The four both-writes-fail tests now inject a call-counting wrapper around the real `appendAlert` (delegates to it, so the directory-fixture throw still fires) rather than asserting only on the absence of a record, closing the "removing the failLoud call would still pass" gap shadow flagged.
6. (Round 2, F3) The GWS-unconfigured B2 test uses a pre-existing EMPTY DIRECTORY at `alerts.jsonl` (not the pid-tmp-dir + other-job-alert fixture used elsewhere) — `readAlerts()`'s own EISDIR catch resiliently returns `[]`, so `clearAlerts` takes its `rmSync` branch, which also throws without `recursive:true`. This gives a literal `readAlerts(paths) === []` as the acceptance criterion asked for.

## Discovered issues (out of scope, not fixed)

- `mkdirPrivate`'s `chmodIfNeeded` auto-heals a `chmod 0500` state/ before `appendAlert` writes, defeating that technique for both-writes-fail simulation (tests use pre-created directories instead — EISDIR). Relevant to the mode-pin WP's tests.
- Pre-existing: `failLoud`'s append and email share one `try`, so an appendAlert *throw* (vs return false) skips the email too — Table A's both-writes-fail case gets zero email attempts. HEAD behavior, out of scope here.
- Stale comment in `catchUp` (`// doRun already recorded the error watermark and failed loud.`, originally at commit 1273288's `:1383` on the per-job `catch` block): its claim that the watermark is always "recorded" is no longer exact after this WP — the watermark write can throw and NOT persist while `failLoud` is still attempted. Flagged by wd-reviewer C in round 1; dispositioned as out of scope for this WP (no spec instruction to touch it), noted here rather than fixed.

## Review gates

Runs recorded in comments below (wd-reviewer + Codex plugin on the same tip).

## Lessons (for memory/lessons/inbox.md)

- WP-failloud-survives-state-write-failure: `chmod(state/, 0o500)` is not a durable both-writes-fail simulation — `mkdirPrivate` heals it before the append; pre-created directories at the target paths (EISDIR) are portable and unhealed.
- WP-failloud-survives-state-write-failure: `renameSync(tmp, dest)` replaces a symlinked dest rather than following it, so a symlinked `alerts.jsonl` alone doesn't make the pre-mode-pin rewrite throw; a directory planted at the deterministic `${file}.${pid}.tmp` name does.
- WP-failloud-survives-state-write-failure: `failLoud`'s shared try means an appendAlert throw skips the email send — easy to assume email is always attempted; it isn't.
- WP-failloud-survives-state-write-failure: a spec that says a value is "derived inside" a function but also requires the caller to throw the SAME string is unsatisfiable as written — the fix is a shared module-level template called from both sides, not a choice of which side "owns" it. Worth stating explicitly in a future spec rather than leaving it for review to catch.
- WP-failloud-survives-state-write-failure: a generic `opts` object threaded through a whole call chain (test seams, forwarded caller opts) is also a channel an attacker-shaped test/caller can use to inject an unintended key (here, `outcome`) into an unrelated call site — worth an explicit "which sites forward opts verbatim vs. construct their own" note in specs that introduce a new discriminant riding an existing opts bag.
- WP-failloud-survives-state-write-failure: a pre-existing EMPTY DIRECTORY at a target path is a cleaner way to force `readAlerts()` to literally return `[]` (its own read fails EISDIR and is caught) than pre-populating a file and blocking a rename — useful whenever a test needs "the reader sees nothing" rather than "the reader sees something it can't act on."

---
Generated-by: Claude Sonnet 5 (implementer) / Claude Fable 5 (orchestrator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCXat1SiCGPBaijqCCkAjG
