### PR TITLE
fix(state): write every private-listed state file through the private writer (WP-private-state-writers-mode-pin)

### DIFF
--- a/docs/specs/WP-private-state-writers-mode-pin.md
+++ b/docs/specs/WP-private-state-writers-mode-pin.md
@@ -186,6 +186,7 @@ repair cannot hold a file that a scheduled job rewrites nightly.
 | modify | src/core/alerts.js | two functions: (a) `clearAlerts` — replace lines 206-208 per Table B, thread `{ core: paths.core }`; (b) `appendAlert`'s **compaction branch** — replace lines 117-120 per Table D (migrate + local try/catch, must not throw). Do NOT touch the atomic append at `:89-90`, the empty-read guard at `:105`, the compaction trigger at `:106`, or `chmodAlerts` itself |
 | modify | src/core/private-fs.js | **comment text PLUS one tagged throw** (this row was "comment-only" in earlier rounds; it is not any more). (a) Correct the two now-false mirrors of the 2026-07-19 decision at lines 20-22 and 129-134 (the `A9_PRIVATE_STATE_FILES` JSDoc) so they no longer claim these writers are unchanged. The array literal it documents, lines 135-141, is CODE and is NOT edited — its membership is correct and 3 of its 5 entries were never part of that decision. The `A9_PRIVATE_CORE_FILES` comment at lines 143-148 also stays TRUE and is NOT edited. (b) Add `code = 'WD_F10_POST_RENAME'` to the single throw at lines 361-365, per Table D2 — the ONLY code change permitted in this file |
 | create | tests/unit/private-writer-modes.test.js | cover the acceptance criteria below; the implementer designs the cases |
+| modify | tests/unit/scheduler-runjob.test.js | **ONLY the `:2661` fixture**, whose failure-injection technique — a directory pre-created at the predictable temp path `${alertsFile}.${process.pid}.tmp` (`:2674`) — this WP's own fix retires, so it no longer intercepts anything and `clearAlerts` succeeds. Replace it with a post-mode-pin refusal trigger (e.g. symlink `alertsFile` itself, per the `:2739` sibling). **No other change to the file** — see "A test that the fix retired" below |
 
 ### Exact contracts
 
@@ -442,6 +443,39 @@ every surface below in one pass:
       fact; both stay
 
 ## Implementation notes & constraints
+
+### A test that this WP's fix retired (why `scheduler-runjob.test.js` is a Deliverable)
+
+`tests/unit/scheduler-runjob.test.js` is not a file this WP set out to touch. It
+is in the Deliverables because an **intervening dependency's test used the very
+hazard this WP closes as its failure-injection fixture**, and closing the hazard
+disarmed the fixture.
+
+`WP-failloud-survives-state-write-failure` landed first (this WP's `depends_on`).
+Its Table B2 test at `:2661` needed `clearAlerts` to throw, and at the time the
+cheapest way to force that was to pre-create a **directory** at `clearAlerts`'
+deterministic temp path — `` fs.mkdirSync(`${alertsFile}.${process.pid}.tmp`) ``
+(`:2674`), with a comment noting the filename is predictable because
+`clearAlerts` runs in-process. That predictability **is** the hazard Table B
+retires: `writeFilePrivate` uses a crypto-random `O_EXCL|O_NOFOLLOW` temp, so the
+planted directory is never opened, the rewrite succeeds, and the test's premise
+evaporates. Measured on this branch: `:2661` is the **only** failing test in the
+suite (2405 tests, 2392 pass, 1 fail).
+
+The fix is to re-arm the test against the post-mode-pin refusal shape rather than
+to weaken it. Its sibling at `:2739` already shows the shape and still passes —
+note **why**: `:2739` symlinks `alertsFile` itself, so its refusal comes from
+`writeFilePrivate`'s destination check (F16), not from the temp fixture. Its own
+`` fs.mkdirSync(`${alertsFile}.${process.pid}.tmp`) `` at `:2750` is now
+vestigial but harmless, and is **out of scope** — do not tidy it up; this row
+permits the `:2661` fixture and nothing else.
+
+**The class was predicted.** `WP-failloud-survives-state-write-failure`'s own
+lessons flagged that a test injecting failure through a mechanism a *later* WP is
+chartered to remove will go green-then-stale exactly when that WP lands. This is
+that prediction arriving. The general rule it argues for — inject failure through
+a seam the roadmap is not about to close, or expect to re-arm the test — belongs
+in the dogfood lessons, not in this spec; report it in the PR body.
 
 - Zero new dependencies; plain Node ≥ 18; JSDoc types; no build step (CLAUDE.md).
 - Each of the three edits is a **replacement, not an addition**: delete the

--- a/docs/specs/WP-private-state-writers-mode-pin.md
+++ b/docs/specs/WP-private-state-writers-mode-pin.md
@@ -333,7 +333,7 @@ and `:113`, `core/dream/scratch.js:215`, `core/exec-identity.js:410`,
 | Call | `writeFilePrivate(dest, data, opts)` — `src/core/private-fs.js:280` |
 | Why not `{mode:0o600}` + `chmod` | the create mode is umask-masked (measured `0000` under `umask 0777`) and is **ignored on an existing path**, so a stale temp keeps its loose mode while private bytes are written into it; and a symlink at the predictable temp name is followed out of the core (both measured, Current state) |
 | How it avoids all three | crypto-random temp name + `O_WRONLY\|O_CREAT\|O_EXCL\|O_NOFOLLOW`, so a pre-existing file or symlink at the temp name cannot be written through; `fchmod(fd, 0o600)` on the descriptor, so the mode is umask-independent and fixed **before** the rename |
-| Core threading | pass `{ core: paths.core }` where the writer has `paths` (`writeScheduleState`, `clearAlerts`) so the ancestry check uses the caller's verified core |
+| Core threading | pass `{ core: paths.core }` where the writer has `paths` (`writeScheduleState`, `clearAlerts`, and `appendAlert`'s compaction branch — Table D) so the ancestry check uses the caller's verified core. This row governs **every** `writeFilePrivate` call this WP adds; Table D's Change cell shows the same argument rather than a different instruction |
 | No-override case | `writeWatermarks(stateDir, …)` has no `paths`; call it without `opts` and `assertInCoreAncestry` resolves the core via `getPaths()` (`:193-196`). Verified: writing to a state dir outside the resolved core is out of that guard's scope and proceeds, so the existing `stateDir`-based callers keep working |
 | Added refusals (the behavior change) | a pre-existing symlink or non-regular file at `dest` (F16, `:297-303`); a symlinked in-core ancestor or a symlink/non-dir at the parent (`mkdirPrivate`); a post-rename inode mismatch (F10, `:358-366`). Each throws `WienerdogError` instead of silently writing through — fail-closed, and the reason this WP depends on `WP-failloud-survives-state-write-failure`. A symlinked **leaf** is not caught by the `mechanicsRootUntrusted` entry gate, which classifies directories only (`:1001-1007`, measured), so these refusals are reachable on the success path as well as the failure paths — which is why that dependency covers all five sites |
 | Directory creation | `writeFilePrivate` calls `mkdirPrivate` itself, so the writers' own `fs.mkdirSync` calls are removed rather than kept alongside |
@@ -357,7 +357,7 @@ and `:113`, `core/dream/scratch.js:215`, `core/exec-identity.js:410`,
 
 | Fact / rule | Value |
 |-------------|-------|
-| Change | `src/core/alerts.js:117-120` — replace the predictable-temp `writeFileSync`/`renameSync`/`chmodAlerts` sequence with `writeFilePrivate(file, text)`, wrapped in a **local `try`/`catch`** |
+| Change | `src/core/alerts.js:117-120` — replace the predictable-temp `writeFileSync`/`renameSync`/`chmodAlerts` sequence with `writeFilePrivate(file, text, { core: paths.core })`, wrapped in a **local `try`/`catch`**. The `core` is threaded per Table B's core-threading row: `appendAlert` has `paths`, so it passes it like the other two `paths`-carrying writers |
 | Must not throw | compaction failure never propagates out of `appendAlert` — in **either** case below. On catch: emit one non-alert diagnostic and return. Refusals split into two cases with **different durability outcomes**, and the return value distinguishes them |
 | **Case 1 — PRE-rename refusal** (temp creation/write/`fchmod`, symlinked ancestor, symlinked dest) | nothing was installed. `alerts.jsonl` is untouched and still holds the record appended at `:89`. The record **is** durable; `appendAlert` returns as it does on success |
 | **Case 2 — POST-rename F10 integrity failure** (`private-fs.js:358-366`) | the `renameSync` at `:354` **already completed**, and what it installed is the entry a concurrent process substituted — not the file we wrote. So the compacted content is NOT at `dest` (its inode was unlinked), **and** the rename replaced the pre-compaction `alerts.jsonl` that held the `:89` record. **The record is LOST.** Make no claim about `dest`'s contents: they are whatever was installed. `appendAlert` must therefore signal **not-persisted** (next row) so no downstream consumer treats the alert as recorded |
@@ -396,11 +396,16 @@ every surface below in one pass:
 - [ ] The Table C verification gate under Verification steps
 - [ ] Current-state (the measured probe output, the mode-argument measurements,
       the three mechanism citations, and the `writeWatermarks` caveat)
-- [ ] The out-of-scope justification for Table A rows 13-14, and the **three**
-      named residuals (row 2's create window; deletion-recreation; the parent
-      directory) — the count appears in the Security checklist, the residual
-      prose and Out of scope, and the three move together. Row 3 is a FIX
-      (Table D), not a residual, on every surface
+- [ ] The out-of-scope justification for Table A rows 13-14, and the **five**
+      named residuals — (1) row 2's create window, (2) the destination-symlink
+      append, (3) unbounded growth under persistent compaction refusal,
+      (4) deletion-recreation of the in-place-written files and `state/` itself,
+      (5) the parent directory. The **total of five** appears in the Security
+      checklist and must agree with this bullet. A **subset count of three** also
+      appears deliberately — the three that sit on `alerts.jsonl` (residuals 1-3),
+      in the residual prose and Out of scope; that is a subset, not a stale
+      total, and must not be "corrected" to five. Row 3's compaction rewrite is a
+      FIX (Table D), not a residual, on every surface
 - [ ] The **applicable-cell count (10)** — it appears in Table C's two rows, the
       acceptance criteria, the gate script's comment header, its `cells !== 10`
       assertion and its success message; all five must agree. The count covers
@@ -411,6 +416,20 @@ every surface below in one pass:
       `WP-failloud-survives-state-write-failure`, and the backward-compatibility
       rule (`undefined` keeps HEAD semantics, only explicit `false` signals) is
       stated in both. All three surfaces move together
+- [ ] **KNOWN-STALE (registered, not fixed here): `src/cli/run-job.js`'s
+      `failLoud` JSDoc, `:655-658` and `:681-683`.** Both restate this wire from
+      the consumer side and both went stale the moment the producer landed in
+      this WP. `:655-658` says "a throw from the post-append compaction rewrite
+      also yields `false`" — compaction no longer throws (Table D wraps it in a
+      local `try`/`catch`), so the stated mechanism is gone even though a `false`
+      still arrives, by a different route and only for Case 2. `:681-683` says
+      the real `appendAlert` "returns `undefined` on every path today, so this is
+      a no-op" in production — no longer true: it returns `false` on Case 2
+      (`src/core/alerts.js:140`). **Disposition:** outside this WP's Deliverables
+      boundary, so it is NOT corrected here; fix it via a comment-only follow-up
+      or in the next WP that legitimately touches `run-job.js`. Registered so the
+      drift is on the books rather than silent, and so the next editor of that
+      JSDoc knows what it must end up saying
 - [ ] **The 2026-07-19 waiver's status** — its lift (DATED OWNER DECISION
       2026-09-01) is recorded under Current state and mirrored in
       Definition-of-done item 0(b) and the design-gate round record's Outcome;

--- a/docs/specs/WP-private-state-writers-mode-pin.md
+++ b/docs/specs/WP-private-state-writers-mode-pin.md
@@ -1,7 +1,7 @@
 ---
 id: WP-private-state-writers-mode-pin
 title: Write every private-listed state file through the private writer, so no rewrite can loosen it
-status: Ready
+status: In-Review
 model: sonnet
 size: S
 depends_on: [WP-failloud-survives-state-write-failure]

--- a/src/core/alerts.js
+++ b/src/core/alerts.js
@@ -4,7 +4,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const { redactOnly } = require('./secret-scan');
-const { mkdirPrivate } = require('./private-fs');
+const { mkdirPrivate, writeFilePrivate } = require('./private-fs');
 const { pruneAcksForJob } = require('./alert-ack');
 
 /** Best-effort 0600 on the alerts file (audit A5, WP-126): a first append
@@ -114,10 +114,32 @@ function appendAlert(paths, record) {
       kept = kept.slice(1); // drop oldest
       text = serialize(kept);
     }
-    const tmp = `${file}.${process.pid}.tmp`;
-    fs.writeFileSync(tmp, text, { mode: 0o600 });
-    fs.renameSync(tmp, file); // atomic replace (mirrors clearAlerts)
-    chmodAlerts(file);
+    // Table D (WP-private-state-writers-mode-pin): migrated onto the audited
+    // private-write primitive (crypto-random O_EXCL|O_NOFOLLOW temp + fchmod
+    // before rename) so this rewrite can no longer be hijacked through a
+    // stale or symlinked predictable temp name. Wrapped in a local try/catch —
+    // this is housekeeping running AFTER the durable append at :89, so its
+    // failure must never propagate (the :840 caller's "WARN + PROCEED, no
+    // throw" contract stays untouched).
+    try {
+      writeFilePrivate(file, text, { core: paths.core });
+    } catch (e) {
+      try {
+        process.stderr.write(
+          `wienerdog: alerts.jsonl compaction refused (${(e && e.message) || e}); leaving the log over budget until this is fixed\n`
+        );
+      } catch {
+        /* best-effort diagnostic — never mask the append result */
+      }
+      // Case 2 (F10 post-rename substitution): the rename already completed and
+      // replaced the pre-compaction file that held the :89 record — the record
+      // may be lost, so signal not-persisted rather than let the caller infer
+      // success from the absence of a throw. Every other refusal (Case 1) is
+      // pre-rename: alerts.jsonl is untouched and the :89 record is still
+      // durable, so this falls through to the same `undefined` return as success.
+      if (e && e.code === 'WD_F10_POST_RENAME') return false;
+      return;
+    }
   }
 }
 
@@ -203,9 +225,7 @@ function clearAlerts(paths, job) {
     fs.rmSync(file, { force: true });
     return;
   }
-  const tmp = `${file}.${process.pid}.tmp`;
-  fs.writeFileSync(tmp, remaining.map((a) => JSON.stringify(a)).join('\n') + '\n');
-  fs.renameSync(tmp, file);
+  writeFilePrivate(file, remaining.map((a) => JSON.stringify(a)).join('\n') + '\n', { core: paths.core });
 }
 
 module.exports = {

--- a/src/core/dream/watermarks.js
+++ b/src/core/dream/watermarks.js
@@ -2,6 +2,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { writeFilePrivate } = require('../private-fs');
 
 /** @param {string} stateDir @returns {string} */
 function watermarksPath(stateDir) {
@@ -32,12 +33,9 @@ function readWatermarks(stateDir) {
  * @param {{claude:number|null, codex:number|null}} watermarks
  */
 function writeWatermarks(stateDir, { claude, codex }) {
-  fs.mkdirSync(stateDir, { recursive: true });
   const file = watermarksPath(stateDir);
-  const tmp = `${file}.tmp-${process.pid}`;
   const body = JSON.stringify({ version: 1, claude: claude ?? null, codex: codex ?? null }, null, 2);
-  fs.writeFileSync(tmp, body);
-  fs.renameSync(tmp, file);
+  writeFilePrivate(file, body);
 }
 
 module.exports = { readWatermarks, writeWatermarks };

--- a/src/core/private-fs.js
+++ b/src/core/private-fs.js
@@ -16,9 +16,12 @@ const { WienerdogError } = require('./errors');
  * dirs, digest/alerts/ledger/approvals files, per-run logs, dream scratch,
  * quarantine) UNION the A9 set (`secrets/` and every file directly inside it —
  * GWS tokens + client JSON — the grants/pins/run-evidence state files, every
- * `logs/<job>` subdirectory, and the four repair-only metadata files
- * config.yaml / install-manifest.json / schedule.json / watermarks.json,
- * whose WRITERS stay unchanged per the DATED OWNER DECISION 2026-07-19).
+ * `logs/<job>` subdirectory, and two remaining repair-only metadata files
+ * config.yaml / install-manifest.json, whose WRITERS stay unchanged per the
+ * DATED OWNER DECISION 2026-07-19. schedule.json / watermarks.json were
+ * covered by that decision too until DATED OWNER DECISION 2026-09-01
+ * (WP-private-state-writers-mode-pin) lifted it for those two: their writers
+ * now go through `writeFilePrivate` like the rest of the A9 state files).
  *
  * win32 posture (OWNER-APPROVED 2026-07-17): POSIX modes do not exist there —
  * chmod is a best-effort no-op, the scan reports {insecure: 0}, and WP-127
@@ -127,11 +130,14 @@ const A5_PRIVATE_FILE_BASENAMES = [
 const A9_PRIVATE_DIRS = (paths) => [paths.secrets];
 
 /** A9-scoped private FILES directly under state/ (0600): grants, exec pins, run
- *  evidence, plus the two metadata files schedule.json/watermarks.json
- *  (repair-only, DATED OWNER DECISION 2026-07-19 — their writers are NOT
- *  changed). (Tokens/client JSON are matched by walking secrets/ for every
- *  regular file — no fixed basename list, so a new google-token-*.json is
- *  covered automatically.) */
+ *  evidence, plus schedule.json/watermarks.json. The latter two were
+ *  repair-only under the DATED OWNER DECISION 2026-07-19; that waiver was
+ *  lifted for them by DATED OWNER DECISION 2026-09-01
+ *  (WP-private-state-writers-mode-pin), and their writers
+ *  (`writeScheduleState`, `writeWatermarks`) now write through
+ *  `writeFilePrivate` like every other file in this list. (Tokens/client
+ *  JSON are matched by walking secrets/ for every regular file — no fixed
+ *  basename list, so a new google-token-*.json is covered automatically.) */
 const A9_PRIVATE_STATE_FILES = [
   'broker-grants.json',
   'exec-pins.json',
@@ -358,11 +364,13 @@ function writeFilePrivate(dest, data, opts = {}) {
   try {
     const after = fs.lstatSync(dest);
     if (after.isSymbolicLink() || after.dev !== fdDev || after.ino !== fdIno) {
-      throw new WienerdogError(
+      const err = new WienerdogError(
         `refusing to complete write ${dest}: its temp was substituted between the private open and the ` +
           'rename (a concurrent same-owner swap — the destination is not the file we wrote); investigate ' +
           'for a same-user attacker inside your Wienerdog core.'
       );
+      err.code = 'WD_F10_POST_RENAME';
+      throw err;
     }
   } catch (e) {
     if (e instanceof WienerdogError) throw e;

--- a/src/scheduler/jobs.js
+++ b/src/scheduler/jobs.js
@@ -5,6 +5,7 @@ const path = require('node:path');
 const crypto = require('node:crypto');
 
 const manifestLib = require('../core/manifest');
+const { writeFilePrivate } = require('../core/private-fs');
 
 /**
  * Job definitions live in a managed `jobs:` section of config.yaml (stable
@@ -233,10 +234,7 @@ function writeScheduleState(paths, name, patch) {
   const state = readScheduleState(paths);
   state[name] = { ...state[name], ...patch };
   const file = scheduleStatePath(paths);
-  const tmp = `${file}.${process.pid}.tmp`;
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(tmp, `${JSON.stringify(state, null, 2)}\n`);
-  fs.renameSync(tmp, file);
+  writeFilePrivate(file, `${JSON.stringify(state, null, 2)}\n`, { core: paths.core });
 }
 
 module.exports = {

--- a/tests/unit/private-writer-modes.test.js
+++ b/tests/unit/private-writer-modes.test.js
@@ -24,6 +24,8 @@ const POSIX = process.platform !== 'win32';
 
 const PRIVATE_FS_ID = require.resolve('../../src/core/private-fs');
 const ALERTS_ID = require.resolve('../../src/core/alerts');
+const JOBS_ID = require.resolve('../../src/scheduler/jobs');
+const WATERMARKS_ID = require.resolve('../../src/core/dream/watermarks');
 
 /** @param {string} p @returns {number} */
 function modeOf(p) {
@@ -73,27 +75,37 @@ function rec(job) {
 }
 
 /** Replace private-fs's `writeFilePrivate` export with `stubFn`, then
- *  re-require alerts.js FRESH so its own destructured reference picks up the
- *  stub (mirrors the `stubCollaborators` idiom in dream-validate.test.js).
- *  The module-level `appendAlert`/`clearAlerts` this file already imported at
- *  the top are a SEPARATE, earlier-loaded instance and are unaffected — they
- *  keep using the real `writeFilePrivate` throughout.
+ *  re-require `moduleId` FRESH so its own destructured reference picks up the
+ *  stub (mirrors the `stubCollaborators` idiom in dream-validate.test.js). The
+ *  module-level references this file already imported at the top are a
+ *  SEPARATE, earlier-loaded instance and are unaffected — they keep using the
+ *  real `writeFilePrivate` throughout.
+ *  @param {string} moduleId a `require.resolve(...)`'d module path
  *  @param {Function} stubFn
- *  @returns {{alerts: object, restore: () => void}} */
-function stubAlertsWriteFilePrivate(stubFn) {
+ *  @returns {{mod: object, restore: () => void}} */
+function stubWriteFilePrivateFor(moduleId, stubFn) {
   const privateFsExports = require.cache[PRIVATE_FS_ID].exports;
   const orig = privateFsExports.writeFilePrivate;
   privateFsExports.writeFilePrivate = stubFn;
-  delete require.cache[ALERTS_ID];
+  delete require.cache[moduleId];
   // eslint-disable-next-line global-require
-  const alerts = require('../../src/core/alerts');
+  const mod = require(moduleId);
   return {
-    alerts,
+    mod,
     restore() {
       require.cache[PRIVATE_FS_ID].exports.writeFilePrivate = orig;
-      delete require.cache[ALERTS_ID];
+      delete require.cache[moduleId];
     },
   };
+}
+
+/** `stubWriteFilePrivateFor` specialized to alerts.js, keeping the `alerts`-
+ *  named return the existing Table D tests already destructure.
+ *  @param {Function} stubFn
+ *  @returns {{alerts: object, restore: () => void}} */
+function stubAlertsWriteFilePrivate(stubFn) {
+  const { mod, restore } = stubWriteFilePrivateFor(ALERTS_ID, stubFn);
+  return { alerts: mod, restore };
 }
 
 /** Capture `process.stderr.write` calls during `fn()`. @returns {number} call count */
@@ -150,6 +162,81 @@ test('private-writer-modes: clearAlerts on a destination that ends up absent sti
   appendAlert(paths, rec('only-job'));
   assert.equal(clearAlerts(paths, 'only-job'), undefined, 'return value unchanged');
   assert.equal(fs.existsSync(alertsFile(paths)), false, 'no records remain -> file removed, not rewritten');
+});
+
+// ---------------------------------------------------------------------------
+// Delegation — each fixed writer calls writeFilePrivate with the right shape.
+// Table C above observes only the FINAL mode: a regression that swapped
+// writeFilePrivate back out for a mode-less temp+chmod+rename would still pass
+// every mode cell if the chmod happened to land 0600. These spy on the call
+// itself instead, so the primitive's OWN tests (pre-rename fchmod, O_EXCL
+// temp, etc — private-fs.test.js) are what's relied on for the security
+// properties, not re-derived here.
+// ---------------------------------------------------------------------------
+
+test('private-writer-modes: writeScheduleState delegates to writeFilePrivate with the destination, body, and { core: paths.core }', () => {
+  const { paths } = freshFixture();
+  const calls = [];
+  const stub = (dest, data, opts) => calls.push([dest, data, opts]);
+  const { mod: stubbedJobs, restore } = stubWriteFilePrivateFor(JOBS_ID, stub);
+  try {
+    stubbedJobs.writeScheduleState(paths, 'dream', { last_status: 'ok' });
+  } finally {
+    restore();
+  }
+  assert.equal(calls.length, 1, 'writeFilePrivate called exactly once');
+  const [dest, data, opts] = calls[0];
+  assert.equal(dest, scheduleFile(paths), 'destination is schedule.json');
+  assert.equal(
+    data,
+    `${JSON.stringify({ dream: { last_status: 'ok' } }, null, 2)}\n`,
+    'body is the merged state, pretty-printed with a trailing newline'
+  );
+  assert.deepEqual(opts, { core: paths.core }, 'threaded with { core: paths.core } (Table B core-threading row)');
+});
+
+test('private-writer-modes: writeWatermarks delegates to writeFilePrivate with the destination, body, and NO override (Table B no-override row)', () => {
+  const { paths } = freshFixture();
+  const calls = [];
+  const stub = (dest, data, opts) => calls.push([dest, data, opts]);
+  const { mod: stubbedWm, restore } = stubWriteFilePrivateFor(WATERMARKS_ID, stub);
+  try {
+    stubbedWm.writeWatermarks(paths.state, { claude: 1, codex: 2 });
+  } finally {
+    restore();
+  }
+  assert.equal(calls.length, 1, 'writeFilePrivate called exactly once');
+  const [dest, data, opts] = calls[0];
+  assert.equal(dest, watermarksFile(paths), 'destination is watermarks.json');
+  assert.equal(
+    data,
+    JSON.stringify({ version: 1, claude: 1, codex: 2 }, null, 2),
+    'body is the watermarks payload'
+  );
+  assert.equal(opts, undefined, 'no opts argument — writeWatermarks has no paths.core to thread (Table B no-override row)');
+});
+
+test('private-writer-modes: clearAlerts delegates to writeFilePrivate with the destination, body, and { core: paths.core }', () => {
+  const { paths } = freshFixture();
+  appendAlert(paths, rec('a'));
+  appendAlert(paths, rec('b'));
+  const expectedBody = readAlerts(paths)
+    .filter((a) => a.job !== 'a')
+    .map((a) => JSON.stringify(a))
+    .join('\n') + '\n';
+  const calls = [];
+  const stub = (dest, data, opts) => calls.push([dest, data, opts]);
+  const { alerts: stubbedAlerts, restore } = stubAlertsWriteFilePrivate(stub);
+  try {
+    stubbedAlerts.clearAlerts(paths, 'a');
+  } finally {
+    restore();
+  }
+  assert.equal(calls.length, 1, 'writeFilePrivate called exactly once');
+  const [dest, data, opts] = calls[0];
+  assert.equal(dest, alertsFile(paths), 'destination is alerts.jsonl');
+  assert.equal(data, expectedBody, 'body is the surviving (non-cleared) records, one JSON line each');
+  assert.deepEqual(opts, { core: paths.core }, 'threaded with { core: paths.core } (Table B core-threading row)');
 });
 
 // ---------------------------------------------------------------------------
@@ -229,19 +316,23 @@ test('private-writer-modes: a pre-existing symlink at alerts.jsonl is refused by
 // Repeat runs (Table C repeat-runs row)
 // ---------------------------------------------------------------------------
 
-test('private-writer-modes: a second consecutive call to each fixed writer leaves the same 0600 and the same content', () => {
+test('private-writer-modes: a second consecutive call to each fixed writer leaves the same 0600 (POSIX) and the same content (cross-platform)', () => {
   const { paths } = freshFixture();
 
   jobsLib.writeScheduleState(paths, 'dream', { last_status: 'ok' });
   const c1 = fs.readFileSync(scheduleFile(paths), 'utf8');
   jobsLib.writeScheduleState(paths, 'dream', { last_status: 'ok' });
-  assert.equal(modeOf(scheduleFile(paths)), 0o600);
+  // Mode assertions are POSIX-only: writeFilePrivate takes the win32 branch
+  // (private-fs.js:283-288, a plain {mode:0o600} temp+rename) before the POSIX
+  // fchmod logic this WP's fix relies on — win32 has no POSIX mode bits to
+  // assert exactly 0600 against. Content/idempotence hold on every platform.
+  if (POSIX) assert.equal(modeOf(scheduleFile(paths)), 0o600);
   assert.equal(fs.readFileSync(scheduleFile(paths), 'utf8'), c1);
 
   wmLib.writeWatermarks(paths.state, { claude: 1, codex: 2 });
   const wc1 = fs.readFileSync(watermarksFile(paths), 'utf8');
   wmLib.writeWatermarks(paths.state, { claude: 1, codex: 2 });
-  assert.equal(modeOf(watermarksFile(paths)), 0o600);
+  if (POSIX) assert.equal(modeOf(watermarksFile(paths)), 0o600);
   assert.equal(fs.readFileSync(watermarksFile(paths), 'utf8'), wc1);
 
   appendAlert(paths, rec('a'));
@@ -249,7 +340,7 @@ test('private-writer-modes: a second consecutive call to each fixed writer leave
   clearAlerts(paths, 'a'); // present -> rewrite, leaves b
   const ac1 = fs.readFileSync(alertsFile(paths), 'utf8');
   clearAlerts(paths, 'no-such-job'); // still leaves b -> rewrites again with identical content
-  assert.equal(modeOf(alertsFile(paths)), 0o600);
+  if (POSIX) assert.equal(modeOf(alertsFile(paths)), 0o600);
   assert.equal(fs.readFileSync(alertsFile(paths), 'utf8'), ac1);
 });
 
@@ -383,11 +474,15 @@ test('private-writer-modes: Table D discrimination — a refusal carrying a DIFF
   };
   const { alerts: stubbed, restore } = stubAlertsWriteFilePrivate(stub);
   let result;
+  let stderrCalls;
   try {
-    result = stubbed.appendAlert(paths, rec('newjob'));
+    stderrCalls = countStderrWrites(() => {
+      result = stubbed.appendAlert(paths, rec('newjob'));
+    });
   } finally {
     restore();
   }
 
   assert.equal(result, undefined, 'only WD_F10_POST_RENAME triggers the not-persisted signal — any other code, even a real errno, is Case 1');
+  assert.equal(stderrCalls, 1, 'exactly one non-alert diagnostic emitted — no leak into the suite output');
 });

--- a/tests/unit/private-writer-modes.test.js
+++ b/tests/unit/private-writer-modes.test.js
@@ -1,0 +1,393 @@
+'use strict';
+
+// WP-private-state-writers-mode-pin: the three mode-dropping writers
+// (writeScheduleState, writeWatermarks, clearAlerts) now write their
+// private-listed file through `writeFilePrivate`, and appendAlert's
+// compaction branch (Table D) is migrated onto it too, wrapped so it can
+// never throw. This file exercises the REAL writers end to end (no
+// reimplementation of their logic) against the contracts in Tables B/C/D/D2.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { getPaths } = require('../../src/core/paths');
+const { insecureEntries, writeFilePrivate } = require('../../src/core/private-fs');
+const { WienerdogError } = require('../../src/core/errors');
+const jobsLib = require('../../src/scheduler/jobs');
+const wmLib = require('../../src/core/dream/watermarks');
+const { appendAlert, readAlerts, clearAlerts, MAX_FILE_BYTES } = require('../../src/core/alerts');
+
+const POSIX = process.platform !== 'win32';
+
+const PRIVATE_FS_ID = require.resolve('../../src/core/private-fs');
+const ALERTS_ID = require.resolve('../../src/core/alerts');
+
+/** @param {string} p @returns {number} */
+function modeOf(p) {
+  return fs.statSync(p).mode & 0o777;
+}
+
+/** Run `fn` under a permissive umask, restoring the previous one. */
+function withUmask(mask, fn) {
+  const prev = process.umask(mask);
+  try {
+    return fn();
+  } finally {
+    process.umask(prev);
+  }
+}
+
+/** Isolated temp core, state/ pre-created 0700. The root (and state/) are
+ *  created under a known-safe umask BEFORE the caller lowers it for its own
+ *  probe — `mkdtempSync`'s requested 0700 is itself umask-masked, so creating
+ *  it under an already-lowered umask can lock the fixture out with EACCES
+ *  before the writer under test is ever called. */
+function freshFixture() {
+  return withUmask(0o022, () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-pwm-'));
+    const paths = getPaths({ HOME: root, WIENERDOG_HOME: path.join(root, 'wd') });
+    fs.mkdirSync(paths.state, { recursive: true, mode: 0o700 });
+    return { root, paths };
+  });
+}
+
+/** @param {import('../../src/core/paths').WienerdogPaths} paths @returns {string} */
+function scheduleFile(paths) {
+  return path.join(paths.state, 'schedule.json');
+}
+/** @param {import('../../src/core/paths').WienerdogPaths} paths @returns {string} */
+function watermarksFile(paths) {
+  return path.join(paths.state, 'watermarks.json');
+}
+/** @param {import('../../src/core/paths').WienerdogPaths} paths @returns {string} */
+function alertsFile(paths) {
+  return path.join(paths.state, 'alerts.jsonl');
+}
+
+/** @param {string} job @returns {{job:string, at:string, reason:string, log_hint:string}} */
+function rec(job) {
+  return { job, at: '2026-01-01T00:00:00Z', reason: 'r', log_hint: 'h' };
+}
+
+/** Replace private-fs's `writeFilePrivate` export with `stubFn`, then
+ *  re-require alerts.js FRESH so its own destructured reference picks up the
+ *  stub (mirrors the `stubCollaborators` idiom in dream-validate.test.js).
+ *  The module-level `appendAlert`/`clearAlerts` this file already imported at
+ *  the top are a SEPARATE, earlier-loaded instance and are unaffected — they
+ *  keep using the real `writeFilePrivate` throughout.
+ *  @param {Function} stubFn
+ *  @returns {{alerts: object, restore: () => void}} */
+function stubAlertsWriteFilePrivate(stubFn) {
+  const privateFsExports = require.cache[PRIVATE_FS_ID].exports;
+  const orig = privateFsExports.writeFilePrivate;
+  privateFsExports.writeFilePrivate = stubFn;
+  delete require.cache[ALERTS_ID];
+  // eslint-disable-next-line global-require
+  const alerts = require('../../src/core/alerts');
+  return {
+    alerts,
+    restore() {
+      require.cache[PRIVATE_FS_ID].exports.writeFilePrivate = orig;
+      delete require.cache[ALERTS_ID];
+    },
+  };
+}
+
+/** Capture `process.stderr.write` calls during `fn()`. @returns {number} call count */
+function countStderrWrites(fn) {
+  const orig = process.stderr.write;
+  let calls = 0;
+  process.stderr.write = (...a) => {
+    calls += 1;
+    return true;
+  };
+  try {
+    fn();
+  } finally {
+    process.stderr.write = orig;
+  }
+  return calls;
+}
+
+// ---------------------------------------------------------------------------
+// Table C — the mode contract (10 applicable cells across both umasks)
+// ---------------------------------------------------------------------------
+
+for (const um of [0o000, 0o777]) {
+  const tag = um.toString(8).padStart(4, '0');
+
+  test(`private-writer-modes: umask ${tag} — schedule.json, watermarks.json, alerts.jsonl land exactly 0600 and the predicate agrees`, { skip: !POSIX }, () => {
+    const { paths } = freshFixture();
+    withUmask(um, () => {
+      jobsLib.writeScheduleState(paths, 'dream', { last_status: 'ok' }); // absent
+      assert.equal(modeOf(scheduleFile(paths)), 0o600, `schedule.json absent, umask ${tag}`);
+      jobsLib.writeScheduleState(paths, 'dream', { last_status: 'ok' }); // present
+      assert.equal(modeOf(scheduleFile(paths)), 0o600, `schedule.json present, umask ${tag}`);
+
+      wmLib.writeWatermarks(paths.state, { claude: 1, codex: 2 }); // absent
+      assert.equal(modeOf(watermarksFile(paths)), 0o600, `watermarks.json absent, umask ${tag}`);
+      wmLib.writeWatermarks(paths.state, { claude: 3, codex: 4 }); // present
+      assert.equal(modeOf(watermarksFile(paths)), 0o600, `watermarks.json present, umask ${tag}`);
+
+      appendAlert(paths, rec('a'));
+      appendAlert(paths, rec('b'));
+      clearAlerts(paths, 'a'); // leaves b's record -> rewrite branch (present-only)
+      assert.equal(modeOf(alertsFile(paths)), 0o600, `alerts.jsonl present, umask ${tag}`);
+
+      const flagged = insecureEntries(paths).filter((p) =>
+        ['schedule.json', 'watermarks.json', 'alerts.jsonl'].includes(path.basename(p))
+      );
+      assert.deepEqual(flagged, [], `insecureEntries reports none of the three under umask ${tag}`);
+    });
+  });
+}
+
+test('private-writer-modes: clearAlerts on a destination that ends up absent still takes the delete branch and writes no file', () => {
+  const { paths } = freshFixture();
+  appendAlert(paths, rec('only-job'));
+  assert.equal(clearAlerts(paths, 'only-job'), undefined, 'return value unchanged');
+  assert.equal(fs.existsSync(alertsFile(paths)), false, 'no records remain -> file removed, not rewritten');
+});
+
+// ---------------------------------------------------------------------------
+// Stale / symlinked predictable temp path is harmless (the old hazard closed)
+// ---------------------------------------------------------------------------
+
+test('private-writer-modes: a symlink at the OLD predictable schedule.json temp path is never opened', { skip: !POSIX }, () => {
+  const { paths } = freshFixture();
+  const file = scheduleFile(paths);
+  const predictableTemp = `${file}.${process.pid}.tmp`;
+  const external = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-pwm-ext-'));
+  const externalTarget = path.join(external, 'attacker-target');
+  fs.writeFileSync(externalTarget, 'ATTACKER', { mode: 0o644 });
+  fs.symlinkSync(externalTarget, predictableTemp);
+
+  jobsLib.writeScheduleState(paths, 'dream', { last_status: 'ok' });
+
+  assert.equal(fs.readFileSync(externalTarget, 'utf8'), 'ATTACKER', 'symlink target byte-identical — never written through');
+  assert.equal(modeOf(externalTarget), 0o644, 'symlink target mode unchanged');
+  assert.equal(modeOf(file), 0o600, 'schedule.json still lands at 0600');
+  assert.equal(jobsLib.readScheduleState(paths).dream.last_status, 'ok', 'contents unaffected');
+});
+
+// ---------------------------------------------------------------------------
+// A pre-existing symlink at the destination is refused, not written through
+// ---------------------------------------------------------------------------
+
+test('private-writer-modes: a pre-existing symlink at schedule.json is refused; the symlink and its target are unmodified', { skip: !POSIX }, () => {
+  const { paths } = freshFixture();
+  const file = scheduleFile(paths);
+  const external = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-pwm-sym-'));
+  const externalTarget = path.join(external, 'target.json');
+  fs.writeFileSync(externalTarget, '{"pwn":true}', { mode: 0o644 });
+  fs.symlinkSync(externalTarget, file);
+
+  assert.throws(() => jobsLib.writeScheduleState(paths, 'dream', { last_status: 'ok' }), WienerdogError);
+  assert.ok(fs.lstatSync(file).isSymbolicLink(), 'destination still a symlink');
+  assert.equal(fs.readFileSync(externalTarget, 'utf8'), '{"pwn":true}', 'target content unchanged');
+  assert.equal(modeOf(externalTarget), 0o644, 'target mode unchanged');
+});
+
+test('private-writer-modes: a pre-existing symlink at watermarks.json is refused; the symlink and its target are unmodified', { skip: !POSIX }, () => {
+  const { paths } = freshFixture();
+  const file = watermarksFile(paths);
+  const external = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-pwm-sym2-'));
+  const externalTarget = path.join(external, 'target.json');
+  fs.writeFileSync(externalTarget, '{"pwn":true}', { mode: 0o644 });
+  fs.symlinkSync(externalTarget, file);
+
+  assert.throws(() => wmLib.writeWatermarks(paths.state, { claude: 1, codex: 2 }), WienerdogError);
+  assert.ok(fs.lstatSync(file).isSymbolicLink(), 'destination still a symlink');
+  assert.equal(fs.readFileSync(externalTarget, 'utf8'), '{"pwn":true}', 'target content unchanged');
+  assert.equal(modeOf(externalTarget), 0o644, 'target mode unchanged');
+});
+
+test('private-writer-modes: a pre-existing symlink at alerts.jsonl is refused by clearAlerts; that call itself makes no further modification (the append already wrote through it — named residual)', { skip: !POSIX }, () => {
+  const { paths } = freshFixture();
+  const file = alertsFile(paths);
+  const external = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-pwm-sym3-'));
+  const externalTarget = path.join(external, 'alerts-target.jsonl');
+  fs.symlinkSync(externalTarget, file);
+  // appendAlert follows a DESTINATION symlink (the named residual, alerts.js:89-90) —
+  // this is what seeds the file; not asserted pristine, per the spec's bounded claim.
+  appendAlert(paths, rec('a'));
+  appendAlert(paths, rec('b'));
+  const beforeContent = fs.readFileSync(externalTarget, 'utf8');
+  const beforeMode = modeOf(externalTarget);
+
+  assert.throws(() => clearAlerts(paths, 'a'), WienerdogError);
+
+  assert.ok(fs.lstatSync(file).isSymbolicLink(), 'destination still a symlink');
+  assert.equal(fs.readFileSync(externalTarget, 'utf8'), beforeContent, 'the REFUSED clearAlerts call made no further content change');
+  assert.equal(modeOf(externalTarget), beforeMode, 'the REFUSED clearAlerts call made no further mode change');
+});
+
+// ---------------------------------------------------------------------------
+// Repeat runs (Table C repeat-runs row)
+// ---------------------------------------------------------------------------
+
+test('private-writer-modes: a second consecutive call to each fixed writer leaves the same 0600 and the same content', () => {
+  const { paths } = freshFixture();
+
+  jobsLib.writeScheduleState(paths, 'dream', { last_status: 'ok' });
+  const c1 = fs.readFileSync(scheduleFile(paths), 'utf8');
+  jobsLib.writeScheduleState(paths, 'dream', { last_status: 'ok' });
+  assert.equal(modeOf(scheduleFile(paths)), 0o600);
+  assert.equal(fs.readFileSync(scheduleFile(paths), 'utf8'), c1);
+
+  wmLib.writeWatermarks(paths.state, { claude: 1, codex: 2 });
+  const wc1 = fs.readFileSync(watermarksFile(paths), 'utf8');
+  wmLib.writeWatermarks(paths.state, { claude: 1, codex: 2 });
+  assert.equal(modeOf(watermarksFile(paths)), 0o600);
+  assert.equal(fs.readFileSync(watermarksFile(paths), 'utf8'), wc1);
+
+  appendAlert(paths, rec('a'));
+  appendAlert(paths, rec('b'));
+  clearAlerts(paths, 'a'); // present -> rewrite, leaves b
+  const ac1 = fs.readFileSync(alertsFile(paths), 'utf8');
+  clearAlerts(paths, 'no-such-job'); // still leaves b -> rewrites again with identical content
+  assert.equal(modeOf(alertsFile(paths)), 0o600);
+  assert.equal(fs.readFileSync(alertsFile(paths), 'utf8'), ac1);
+});
+
+// ---------------------------------------------------------------------------
+// Table D2 — the F10 throw carries the discriminator code
+// ---------------------------------------------------------------------------
+
+test('private-writer-modes: private-fs.js tags the F10 post-rename throw with code WD_F10_POST_RENAME (Table D2)', { skip: !POSIX }, () => {
+  const { paths } = freshFixture();
+  const external = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-pwm-f10-'));
+  const externalTarget = path.join(external, 'attacker-target');
+  fs.writeFileSync(externalTarget, 'ATTACKER', { mode: 0o644 });
+  const dest = path.join(paths.state, 'f10-probe.json');
+  const renameSync = (t, d) => {
+    try {
+      fs.rmSync(t, { force: true });
+    } catch {
+      /* our temp */
+    }
+    fs.symlinkSync(externalTarget, d); // substituted target
+  };
+
+  let caught;
+  try {
+    writeFilePrivate(dest, '{"x":1}', { core: paths.core, renameSync });
+  } catch (e) {
+    caught = e;
+  }
+  assert.ok(caught instanceof WienerdogError, 'still a WienerdogError');
+  assert.equal(caught.code, 'WD_F10_POST_RENAME', 'the post-rename detection throw carries the discriminator code');
+});
+
+// ---------------------------------------------------------------------------
+// Table D — the compaction migration: hazard closed, Case 1, Case 2, and the
+// discrimination rule (both directions).
+// ---------------------------------------------------------------------------
+
+/** Force the NEXT appendAlert call to take the compaction branch cheaply: an
+ *  oversized malformed line already puts the file over MAX_FILE_BYTES, so a
+ *  single append (no need for 200+ records) triggers `size > MAX_FILE_BYTES`.
+ *  Mirrors the existing "huge malformed line" pattern in alerts.test.js.
+ *  @param {import('../../src/core/paths').WienerdogPaths} paths @returns {string} the file path */
+function seedOversizedAlerts(paths) {
+  fs.mkdirSync(paths.state, { recursive: true, mode: 0o700 });
+  const file = alertsFile(paths);
+  fs.writeFileSync(file, `${'x'.repeat(MAX_FILE_BYTES + 1000)}\n`);
+  return file;
+}
+
+test('private-writer-modes: Table D hazard closed — a symlink at the OLD predictable compaction temp path no longer intercepts the rewrite', { skip: !POSIX }, () => {
+  const { paths } = freshFixture();
+  const file = seedOversizedAlerts(paths);
+  const predictableTemp = `${file}.${process.pid}.tmp`;
+  const external = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-pwm-ext3-'));
+  const externalTarget = path.join(external, 'attacker-target');
+  fs.writeFileSync(externalTarget, 'ATTACKER', { mode: 0o644 });
+  fs.symlinkSync(externalTarget, predictableTemp);
+
+  appendAlert(paths, rec('newjob')); // over budget -> triggers compaction
+
+  assert.equal(fs.readFileSync(externalTarget, 'utf8'), 'ATTACKER', 'symlink target byte-identical — the crypto-random temp was never opened');
+  assert.equal(modeOf(externalTarget), 0o644, 'symlink target mode unchanged');
+  assert.equal(modeOf(file), 0o600, 'alerts.jsonl at 0600 after compaction');
+  assert.ok(readAlerts(paths).some((a) => a.job === 'newjob'), 'the compacted file holds the new record');
+});
+
+test('private-writer-modes: Table D Case 1 — a pre-rename compaction refusal does not throw, is diagnosed once, and the :89 record survives', { skip: !POSIX }, () => {
+  const { paths } = freshFixture();
+  const file = seedOversizedAlerts(paths);
+  const before = fs.readFileSync(file, 'utf8');
+
+  let stubCalls = 0;
+  const stub = () => {
+    stubCalls += 1;
+    throw new WienerdogError('injected: could not create the private temp file (simulated ENOSPC)');
+  };
+  const { alerts: stubbed, restore } = stubAlertsWriteFilePrivate(stub);
+  let result;
+  let stderrCalls;
+  try {
+    stderrCalls = countStderrWrites(() => {
+      result = stubbed.appendAlert(paths, rec('newjob'));
+    });
+  } finally {
+    restore();
+  }
+
+  assert.equal(stubCalls, 1, 'the compaction rewrite was attempted exactly once');
+  assert.equal(result, undefined, 'Case 1 returns undefined — same as success, the record is durable');
+  assert.equal(stderrCalls, 1, 'exactly one non-alert diagnostic emitted');
+  const after = fs.readFileSync(file, 'utf8');
+  assert.ok(after.startsWith(before), 'alerts.jsonl is untouched by the refused rewrite — the pre-compaction bytes are unchanged');
+  assert.ok(readAlerts(paths).some((a) => a.job === 'newjob'), 'the record appended at :89 is still readable afterward');
+});
+
+test('private-writer-modes: Table D Case 2 — a post-rename F10 refusal returns false, does not throw, and is diagnosed once', { skip: !POSIX }, () => {
+  const { paths } = freshFixture();
+  seedOversizedAlerts(paths);
+
+  const stub = () => {
+    const e = new WienerdogError('injected: temp was substituted between the private open and the rename');
+    e.code = 'WD_F10_POST_RENAME';
+    throw e;
+  };
+  const { alerts: stubbed, restore } = stubAlertsWriteFilePrivate(stub);
+  let result;
+  let stderrCalls;
+  try {
+    stderrCalls = countStderrWrites(() => {
+      result = stubbed.appendAlert(paths, rec('newjob'));
+    });
+  } finally {
+    restore();
+  }
+
+  assert.equal(result, false, 'Case 2 signals not-persisted — the record may be lost');
+  assert.equal(stderrCalls, 1, 'exactly one non-alert diagnostic emitted');
+  // Deliberately no assertion on alerts.jsonl's contents here: Table D makes no
+  // claim about dest's contents on Case 2 — they are whatever a concurrent
+  // process installed.
+});
+
+test('private-writer-modes: Table D discrimination — a refusal carrying a DIFFERENT code (e.g. a real errno) is still Case 1, not Case 2', { skip: !POSIX }, () => {
+  const { paths } = freshFixture();
+  seedOversizedAlerts(paths);
+
+  const stub = () => {
+    const e = new Error('EXDEV: cross-device link not permitted');
+    e.code = 'EXDEV'; // a real Node errno — NOT the F10 discriminator
+    throw e;
+  };
+  const { alerts: stubbed, restore } = stubAlertsWriteFilePrivate(stub);
+  let result;
+  try {
+    result = stubbed.appendAlert(paths, rec('newjob'));
+  } finally {
+    restore();
+  }
+
+  assert.equal(result, undefined, 'only WD_F10_POST_RENAME triggers the not-persisted signal — any other code, even a real errno, is Case 1');
+});

--- a/tests/unit/scheduler-runjob.test.js
+++ b/tests/unit/scheduler-runjob.test.js
@@ -2663,15 +2663,20 @@ test('scheduler-runjob: Table B2 :1061 — clearAlerts throws AFTER :1060 succee
   jobsLib.saveJob(paths, { name: 'dream', at: '03:30', run: 'builtin:dream', timeoutMinutes: 20 });
   const fake = writeScript(root, 'ok.sh', ['#!/bin/sh', 'exit 0']);
   // A pre-existing alert for a DIFFERENT job so clearAlerts's rewrite branch is
-  // reached (remaining.length > 0) rather than its rmSync branch.
+  // reached (remaining.length > 0) rather than its rmSync branch. alertsFile is
+  // a SYMLINK to that record (not a regular file): writeFilePrivate's F16
+  // destination check refuses a pre-existing symlink, forcing the rewrite to
+  // throw. (The old fixture — a directory pre-created at clearAlerts'
+  // deterministic temp path — is retired by this WP's own fix: writeFilePrivate's
+  // crypto-random temp never opens it, so the rewrite would just succeed. See
+  // the :2739 sibling below and "A test that this WP's fix retired" in the spec.)
   const alertsFile = path.join(paths.state, ALERTS_FILE);
+  const outside = path.join(root, 'OUTSIDE');
   fs.writeFileSync(
-    alertsFile,
+    outside,
     `${JSON.stringify({ job: 'other', at: new Date().toISOString(), reason: 'x', log_hint: 'y' })}\n`
   );
-  // clearAlerts runs IN THIS PROCESS (no subprocess), so its own temp filename
-  // (alerts.jsonl.<pid>.tmp) is deterministic — block just that write.
-  fs.mkdirSync(`${alertsFile}.${process.pid}.tmp`);
+  fs.symlinkSync(outside, alertsFile);
   /** @type {any[]} */ const alerts = [];
   const sendAlert = (_p, _n, subject, body) => (alerts.push({ subject, body }), { status: 0 });
 


### PR DESCRIPTION
Spec: docs/specs/WP-private-state-writers-mode-pin.md

Closes issue #168's defect: `writeScheduleState`, `writeWatermarks` and `clearAlerts` move onto `writeFilePrivate` (exact 0600 under any umask, both destination states, no loose-mode window, no stale/symlinked-temp write-through); `appendAlert`'s compaction branch migrates inside a non-throwing local try/catch (Table D); `private-fs.js`'s F10 post-rename throw gains `err.code = 'WD_F10_POST_RENAME'` (Table D2) — completing the producer side of the persisted-false wire whose consumer landed with the failloud WP; the two stale waiver-comment mirrors corrected per the lifted 2026-09-01 owner decision.

## Deliverables checklist

- [x] Every changed file listed in the (amended) Deliverables table — incl. `tests/unit/scheduler-runjob.test.js`, added by wd-architect for exactly one fixture: the `:2661` failure-injection used the predictable-temp hazard this WP retires; re-armed against the post-mode-pin refusal shape (F16 destination symlink, mirroring `:2739`)
- [x] Spec status flipped to In-Review

## Verification output

```
Table C gate GREEN: 10/10 applicable mode cells exactly 0600 (umask 000 + 0777 ×
  absent/present; clearAlerts present-only with its delete branch asserted)
Table C gate RED on unfixed HEAD (exit 1): 0666 under umask 000, 0000 under 0777, all three writers
Table C gate RED on mode-argument-only fix (exit 1): fails exactly at umask 0777 — the cell a
  single-umask gate cannot catch
M2 red side: writeScheduleState temporarily re-pointed at a hand-rolled temp+rename → its
  delegation spy fails (0 !== 1, "writeFilePrivate called exactly once"); restored, spy green again
New unit tests: 16/16 (mode cells, delegation spies × 3, stale/symlinked temp, F16 refusal + no
  side effects, idempotence, D2 tag, Table D cases + both discrimination directions)
npm test → 2408 tests, 2396 pass, 0 fail, 12 skipped
npm run lint → clean; boundary-check → exit 0
```

## Decisions made

1. Table D Case 1/2 failure injection via the codebase's `stubCollaborators` require-cache-swap idiom — no test-only parameter added to `appendAlert`'s production signature. Round 1 generalized this into `stubWriteFilePrivateFor(moduleId, stubFn)` and reused it for the three new delegation-spy tests (M2).
2. Compaction-refusal diagnostic on `process.stderr` per the file-wide convention.
3. The `:2739` sibling test's vestigial `mkdirSync` left untouched per the amended Deliverables scope.
4. Round 1, M1(b): checked how `:2739` (the reference sibling for the re-armed `:2661` fixture) handles win32 — it carries **no** explicit platform skip guard, and neither does the rest of its Table A/B/C section; those tests are implicitly POSIX-only because `writeScript` writes a `#!/bin/sh`-shebang fake job executable, unusable on win32 regardless of the symlink. Matching that existing, unguarded convention was the smaller change, so `:2661`'s re-armed fixture also carries no new explicit guard — see Discovered issues.

## Discovered issues (out of scope, not fixed)

- Table A rows 13–14 (`config.yaml`, `install-manifest.json`) creation-path residual — named in the spec.
- `appendAlert`'s own append at `:89-90` (create window, destination-symlink write-through, growth) — named follow-up owner in the spec.
- `src/cli/run-job.js`'s `failLoud` JSDoc (`:655-658`, the G2 paragraph, and `:681-683`) is now stale: it still describes "a throw from the post-append compaction rewrite also yields `false`" and "`appendAlert`... returns `undefined` on every path today" — both were true before this WP and are superseded by Table D, which wraps compaction in a non-throwing local try/catch and adds the explicit `false` return on Case 2. `run-job.js` is outside this WP's Deliverables boundary; flagging for whoever next touches that file's JSDoc.
- Table A/B/C section of `tests/unit/scheduler-runjob.test.js` (including the re-armed `:2661` and its `:2739` sibling) has no explicit win32 skip guard; it is implicitly POSIX-only via `writeScript`'s shebang fake-job mechanism. Not introduced by this WP, not fixed here (outside Deliverables boundary beyond the one permitted `:2661` fixture edit).

## Review gates

Runs recorded in comments below (wd-reviewer + Codex plugin on the same tip). Round 1 findings applied in this round: M1 (plugin P2 + shadow #2, Windows guards on the repeat-run mode assertions and a check of the re-armed `:2661` fixture's platform handling), M2 (shadow #1, delegation spies for all three writers), M3 (wd-reviewer finding 3, stderr-leak guard on the EXDEV discrimination test).

## Lessons (for memory/lessons/inbox.md)

- WP-private-state-writers-mode-pin: a WP that closes a "predictable temp path" hazard breaks any earlier test that used that predictability as its failure-injection fixture — check sibling WPs' suites before assuming a red test is your own defect.
- WP-private-state-writers-mode-pin: the `stubCollaborators` require-cache-swap idiom is the established way to unit-test an unexported failure branch without widening a production signature; it generalizes cleanly across multiple modules sharing one collaborator (`stubWriteFilePrivateFor`).
- WP-private-state-writers-mode-pin: pre-writing an oversized malformed line directly to `alerts.jsonl` is the cheap established trigger for the compaction branch — no 200-call seeding.
- WP-private-state-writers-mode-pin: a test asserting only a writer's *final on-disk mode* (Table C) cannot distinguish a correct fix from a regression that reintroduces a hand-rolled writer which happens to land the same mode by luck — pair mode assertions with a delegation spy on the shared primitive.
- WP-private-state-writers-mode-pin: before adding a platform skip guard to a new/modified test, check whether the surrounding test family already relies on an implicit platform restriction (here: shebang fake-job scripts) — matching the existing convention is smaller and more honest than a locally-added guard that implies the rest of the family is portable when it isn't.

---
Generated-by: Claude Sonnet 5 (implementer) / Claude Fable 5 (orchestrator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCXat1SiCGPBaijqCCkAjG
