### PR TITLE
fix(dream): ledger-parser correctness and hostile corpus (WP-audit-e-ledger-parser-corpus)

### DIFF
--- a/docs/adr/0020-skill-revision-lifecycle.md
+++ b/docs/adr/0020-skill-revision-lifecycle.md
@@ -378,6 +378,25 @@ no manifest entry, no uninstall change. **Migration:** no dream-created skills
 exist in any field vault yet, so there is nothing to backfill; a pre-registry
 dream-created skill is un-revisable (fail closed), which is acceptable.
 
+## Amendment (2026-09-05): ledger-parser correctness (WP-audit-e-ledger-parser-corpus)
+
+Three additive corrections to the ledger keep-conditions above. Nothing above
+this amendment is edited; it stands as the historical record.
+
+(a) The keep-condition "every `##` entry validates against the schema" was
+    FALSE for the heading `__proto__`, which set the collector's prototype
+    instead of becoming a key and was therefore skipped by every schema and
+    history loop. It is true as of this work package.
+(b) `derived_from_untrusted` is honoured only as the exact literals `true` and
+    `false`. Any other value — a case variant, a quoted form, a number, an
+    empty value — is a schema violation on the keep/revert path, and is treated
+    as untrusted (fail closed) on the authorization path and by the raise-only
+    comparison.
+(c) A repeated `##` heading is a schema violation and a refusal reason at ALL
+    THREE reads of a ledger: the candidate, the committed baseline used for the
+    append-only comparison, and the committed read on the authorization path,
+    which never runs the schema loop.
+
 ## Future work (parked, not specced)
 
 - **Dormancy / staleness aging.** Hermes's curator auto-archives skills unused

--- a/docs/specs/WP-audit-e-ledger-parser-corpus.md
+++ b/docs/specs/WP-audit-e-ledger-parser-corpus.md
@@ -1,7 +1,7 @@
 ---
 id: WP-audit-e-ledger-parser-corpus
 title: Ledger-parser correctness — three-state trust reader, null-prototype records, contract-complete hostile corpus
-status: Ready
+status: In-Review
 model: sonnet
 size: M
 depends_on: []

--- a/docs/specs/logbook/2026-09-05-audit-e-pr226-raw-round1-codex-plugin.txt
+++ b/docs/specs/logbook/2026-09-05-audit-e-pr226-raw-round1-codex-plugin.txt
@@ -1,0 +1,27 @@
+# PR gate raw — PR #226 round 1 — Codex plugin native review — WP-audit-e-ledger-parser-corpus
+# tip reviewed: e4be97333800995e1322f2c3b625a7b32edf344b ; base main = 881f0d81 ; porcelain before/after identical ; committed pre-adjudication ; 52 focused tests executed by the reviewer; full suite not run in its sandbox (disclosed)
+
+[codex] Starting Codex review thread.
+[codex] Thread ready (01a07238-b57d-78a0-a599-d11b41e27088).
+[codex] Reviewer started: changes against 'main'
+[codex] Running command: /bin/zsh -lc 'pwd; git status --short; git diff --stat 881f0d818fc43abc0ea84064b73d0d7a86ec2b...
+[codex] Command completed: /bin/zsh -lc 'pwd; git status --short; git diff --stat 881f0d818fc43abc0ea84064b73d0d7a86ec2b... (exit 0)
+[codex] Running command: /bin/zsh -lc 'cat AGENTS.md; cat docs/specs/WP-audit-e-ledger-parser-corpus.md; git diff 881f...
+[codex] Running command: /bin/zsh -lc 'git diff 881f0d818fc43abc0ea84064b73d0d7a86ec2b2c -- tests/unit/dream-validate....
+[codex] Command completed: /bin/zsh -lc 'git diff 881f0d818fc43abc0ea84064b73d0d7a86ec2b2c -- tests/unit/dream-validate.... (exit 0)
+[codex] Running command: /bin/zsh -lc "sed -n '270,410p' src/core/dream/validate.js; sed -n '470,670p' src/core/dream/...
+[codex] Command completed: /bin/zsh -lc "sed -n '270,410p' src/core/dream/validate.js; sed -n '470,670p' src/core/dream/... (exit 0)
+[codex] Running command: /bin/zsh -lc "sed -n '1,85p' tests/unit/dream-validate.test.js; sed -n '315,457p' docs/specs/...
+[codex] Running command: /bin/zsh -lc "node --test --test-name-pattern='ledger corpus|parseFrontmatter|no-separator-sp...
+[codex] Command completed: /bin/zsh -lc "node --test --test-name-pattern='ledger corpus|parseFrontmatter|no-separator-sp... (exit 0)
+[codex] Review output captured.
+[codex] Reviewer finished.
+[codex] Assistant message captured: No actionable regressions were found. The parser changes consistently handle invalid trust va...
+[codex] Turn completed.
+# Codex Review
+
+Target: branch diff against main
+
+No actionable regressions were found. The parser changes consistently handle invalid trust values, duplicate headings, and prototype-sensitive keys across all three ledger reads. All 52 focused tests passed; the full suite was not run.
+rc=0
+PORCELAIN: identical

--- a/docs/specs/logbook/2026-09-05-audit-e-pr226-raw-round1-herdr-shadow.txt
+++ b/docs/specs/logbook/2026-09-05-audit-e-pr226-raw-round1-herdr-shadow.txt
@@ -1,0 +1,9 @@
+# PR gate raw — PR #226 round 1 — hermetic Codex shadow (codex exec, read-only sandbox, CODEX_HOME=~/.codex-review-home, gpt-5.6-sol high, pr-rubric) — WP-audit-e-ledger-parser-corpus
+# tip reviewed: e4be97333800995e1322f2c3b625a7b32edf344b (detached worktree) ; base main = 881f0d81 ; porcelain before/after identical ; committed pre-adjudication
+
+{
+  "findings": [],
+  "overall_correctness": "patch is correct",
+  "overall_explanation": "Read-only inspection commands all exited 0: rubric/spec reads, initial diff/status checks, every changed-file diff, source searches, commit log, syntax/JSON/proof-count checks, regex-count check, and final `git diff --check`; the changed paths exactly match the specification boundary. Required commands were attempted: unit suite exited 1 because sandbox `mkdtemp` was denied, lint exited 1 because markdownlint could not access npm (`ENOTFOUND`) although frontmatter validation passed, and red-proofs exited 1 because sandbox `mkdtemp` was denied; supplemental direct tests exited 0 with 47/47 corpus tests, 2/2 frontmatter-observable tests, and 2/2 shipped readBool checks passing. Proof-selector auditing had two preliminary exit-1 infrastructure/command errors (heredoc temp-file denial and an invalid audit regex), then the corrected audit exited 0 and confirmed all seven selectors exactly match their declared witnesses; initial and final `git status --porcelain` both exited 0 with empty porcelain output, and there are no materiality-band findings.",
+  "overall_confidence_score": 0.95
+}

--- a/docs/specs/logbook/2026-09-05-audit-e-pr226-raw-round1-wd-reviewer.txt
+++ b/docs/specs/logbook/2026-09-05-audit-e-pr226-raw-round1-wd-reviewer.txt
@@ -1,0 +1,78 @@
+# PR gate raw — PR #226 round 1 — wd-reviewer (claude-opus-5 agent, detached checkout with real node_modules) — WP-audit-e-ledger-parser-corpus
+# tip reviewed: e4be97333800995e1322f2c3b625a7b32edf344b ; base main = 881f0d81 ; porcelain before/after identical (reported) ; committed pre-adjudication
+
+## REQUEST-CHANGES
+
+The implementation is correct — I independently reproduced every Table C REQUIRED verdict — but two of the corpus's authorization-path rows are built on a fixture that can never produce the `authorize` verdict their own Today column claims, so they cannot exhibit the hole they exist to witness.
+
+### What I executed (in the detached checkout, absolute paths)
+
+| Command | Result |
+|---|---|
+| `node tests/with-temp-root.js tests/run.js` | rc=0 — `tests 2676 / pass 2664 / fail 0 / skipped 12` (matches expected) |
+| `npm run lint` | rc=0 — `0 error(s)`, `frontmatter check passed: 268 spec(s), 4 agent(s)`, `lint passed` |
+| `npm run red-proofs` (whole tree) | rc=0 — `44 declared proof(s), 44 selected`, all 7 `lpc-*` PROVEN, `RUN: PROVEN` |
+| `node scripts/boundary-check.js docs/specs/WP-audit-e-ledger-parser-corpus.md <7 changed files>` | rc=0, no offenders |
+| My own Table C driver (`/private/tmp/.../review-pr226-scratch/drive.js`, drives `makeGates().ledger/.skillBody` directly, written from the spec, all exotic code points via `String.fromCodePoint`) | rc=0 — **140/140 assertions match the spec's REQUIRED column**, C1–C43 including C40's 24×3 matrix |
+| `node --test --test-name-pattern=<each of the 7 patterns> tests/unit/dream-validate.test.js` | each pattern selects **exactly** its declared SELECTED WITNESSES, nothing else |
+| ADR byte-compare (spec's fenced block vs `docs/adr/0020-skill-revision-lifecycle.md`) | verbatim, inserted between `## Revision (2026-07-12)…` and `## Future work (parked, not specced)` |
+| `git diff 881f0d81 HEAD -- docs/specs/WP-audit-e-ledger-parser-corpus.md` | status flip only (`Ready` → `In-Review`) |
+
+`git status --porcelain` in the checkout: **empty before, empty after.** No tracked file modified; probes live only under `review-pr226-scratch/`.
+
+Independent confirmations worth recording: my `\s`-minus-LF enumeration over the full 0–0x10FFFF range is exactly the 24 code points the spec names; `/^[a-z0-9][a-z0-9.-]{0,63}$/` occurs exactly once in `src/core/dream/validate.js` (criterion 5); no `__proto__`-by-name check and no new `Object.hasOwn` guard (the only `Object.hasOwn` is pre-existing at `validate.js:1247` and untouched by the diff, criterion 4); `readBool`'s shipped tests live in `tests/unit/frontmatter.test.js` and `tests/unit/frontmatter-digest-differential.test.js`, neither of which is in the changed set (criterion 3); the five failing `deepEqual` calls were repaired to the three observables with the value check preserved at `frontmatter-unify.test.js` (criterion 3b); all three `parseLedgerEntries` call sites take `{entries, duplicateKeys}` and there is no consumer outside the file.
+
+---
+
+### Findings
+
+**1. [contract] Band B — `tests/unit/dream-validate.test.js:3941` (C18) and `:4235` (C40-authorization): the Path-A fixture uses Codex sessions, so the row can never observe `authorize` and cannot exhibit the hole it witnesses.**
+
+Both rows build their committed ledger with `ledgerK(...)`, whose sections carry `sessionIds: 'codex:s1, codex:s2'` / `recurrence: '2'`. `skillBodyViolation` refuses any such ledger on its own Codex floor, measured on the branch:
+
+```
+codex x2 (the C18/C40-auth fixture shape), NO duplicate:
+  "authorizing learning a.b has 0 distinct Claude-invoked sessions (needs >= 3 distinct sessions; Codex sessions do not authorize in v1)"
+claude x3 (spec fixture shape),            NO duplicate: null
+```
+
+So with the A3 duplicate refusal removed, these two fixtures still refuse — just with a different string. Consequences:
+
+- Table C's Path definition says "`authorize` means the gate returned no reason", and C18's Today column reads **`authorize`**, C40's reads **`keep / authorize for all 24`**. Neither fixture can produce that verdict under any implementation, so the rows do not instantiate the state the canonical table records.
+- Dispatch-precondition item 1's load-bearing security claim — "a committed ledger carrying `## a.b` twice **authorizes a Tier-3 skill-body revision today**" — is left unwitnessed at the exact two rows written to carry it.
+- The test file's own header comment at `tests/unit/dream-validate.test.js:3796` states the rule that was not applied here: *"three distinct `claude:` ids clear `skillBodyViolation`'s own >=3-session floor so a VALID entry actually reaches 'authorize' rather than refusing for an unrelated reason."* `ledgerA` exists for precisely this and is used correctly by C2/C4/C7/C9/C12A/C13A/C14A/C16/C26A/C31–C35/C38/C43A — only C18 and C40-authorization skip it.
+
+Not band A: the REQUIRED verdicts are still correct (my driver reproduces `skill change needs a qualifying learning but the committed ledger has a repeated entry heading (fail closed)` for both, all 24 code points), and LPC-E still discriminates because both rows assert the exact refusal string, so `red-proofs` legitimately reports PROVEN. No `src/` change is needed.
+
+**Fix:** build the duplicate ledger in C18 and C40-authorization from sections carrying `sessionIds: 'claude:s1, claude:s2, claude:s3'` and `recurrence: '3'` (at minimum on the *last* `a.b`-keyed section, since last-wins is what the pre-fix collapse yields). Then removing the A3 refusal makes the row genuinely authorize, which is what the Today column asserts. Note C19 reuses the same `dup` value as its baseline on the K path; the duplicate refusal returns before the Session-IDs append-only comparison, so C19 stays green either way — but keep its clean candidate as-is rather than "fixing" it to match.
+
+**2. [contract] Band C — PR title does not match the spec's pinned title.**
+
+`docs/specs/WP-audit-e-ledger-parser-corpus.md:588` (Definition of done item 2) pins:
+
+```
+fix(dream): ledger-parser correctness and hostile corpus (WP-audit-e-ledger-parser-corpus)
+```
+
+The PR is titled `fix(dream): harden the skill-learnings ledger parser — three-state trust, null-prototype collectors, hostile corpus (WP-audit-e-ledger-parser-corpus)`. Retitle the PR. (The five commits are conventional, correctly scoped and all carry the WP id — no commit change needed.)
+
+---
+
+### The two "Decisions made", judged
+
+Both are legitimate: the spec genuinely left each open, and each took the simpler option.
+
+- **Shared `headDuplicateKeys` local at both committed-baseline reads** — I verified the two lines are byte-identical (`    if (headDuplicateKeys.length > 0) {`, four-space indent at `validate.js:391` and `:585`), which is what lets LPC-E move both with one `occurrences: 2` mutation instead of two declarations. Pure naming; no behaviour moves. Spec never pinned local names.
+- **Candidate-read duplicate check placed before the "no valid entries" and schema-loop checks** — the spec pins the refusal and its string but not its position among the three early checks, and no Table C row can distinguish the orderings. Simpler option, correctly recorded.
+
+Decision 3 (red-proof `signal` values re-measured to real TAP substrings; nine assertions gained a message argument) is a correction rather than an ambiguity, is honestly reported, and changed no assertion logic — I confirmed the nine added messages are pure third arguments to `assert.equal`.
+
+### Contract-density / Closed-Contract Drift Check
+
+Clean. The spec diff is the status flip and nothing else, so no canonical table was edited and no mirror was promoted to primary. The ADR-0020 amendment landed byte-identical to the spec's "Exact contracts" block at the stated insertion point, with nothing above it touched — an additive amendment, which is the correct shape for a settled contract. Criterion 7's `37 → 44` mirror is now true (measured 44). Current state's `2630/2618` and `37 declared` baselines are correctly left alone: they are pinned historical measurements on `8c52808f`, not mirrors that drift. The seven `why` fields in `ledger-parser-corpus.proofs.json` restate Table A/D reasoning at length, but `scripts/red-proofs.js` requires `why` per declaration, so that is the format's own shape rather than contract-dense prose wanting extraction. No routing to wd-architect needed — the spec is not at fault here; finding 1 is a fixture that diverged from a table the spec states correctly.
+
+### Conventions
+
+Zero new runtime dependencies; no new `require` outside the repo. JSDoc only, no TypeScript — `parseLedgerEntries`' return type was widened correctly to `{{entries: Record<…>, duplicateKeys:string[]}}` with `untrusted:boolean|null|typeof INVALID`. No process, socket or telemetry (ADR-0004). Installer idempotence/reversibility is N/A per criterion 8. Glossary terms (ledger, dream, work package, vault) used canonically.
+
+Files: `/private/tmp/claude-501/-Users-gyulafeher-Documents-Claude-Projects-wienerdog/0a5c0402-a14b-46f2-8f2d-9f6a0e123cdd/scratchpad/review-wt-pr226/tests/unit/dream-validate.test.js`, `/private/tmp/claude-501/-Users-gyulafeher-Documents-Claude-Projects-wienerdog/0a5c0402-a14b-46f2-8f2d-9f6a0e123cdd/scratchpad/review-wt-pr226/src/core/dream/validate.js`, `/private/tmp/claude-501/-Users-gyulafeher-Documents-Claude-Projects-wienerdog/0a5c0402-a14b-46f2-8f2d-9f6a0e123cdd/scratchpad/review-wt-pr226/docs/specs/WP-audit-e-ledger-parser-corpus.md`. My driver and captured gate output are under `/private/tmp/claude-501/-Users-gyulafeher-Documents-Claude-Projects-wienerdog/0a5c0402-a14b-46f2-8f2d-9f6a0e123cdd/scratchpad/review-pr226-scratch/`.

--- a/docs/specs/logbook/2026-09-05-audit-e-pr226-raw-round2-codex-plugin.txt
+++ b/docs/specs/logbook/2026-09-05-audit-e-pr226-raw-round2-codex-plugin.txt
@@ -1,0 +1,29 @@
+# PR gate raw — PR #226 round 2 — Codex plugin native review — WP-audit-e-ledger-parser-corpus
+# tip reviewed: 3efcac1f75565bd2a51db1299f4155694a84bbe2 ; base main = 881f0d81 ; porcelain before/after identical ; committed pre-adjudication ; 51 focused tests executed by the reviewer; broader testing limited by its sandbox (disclosed)
+
+[codex] Starting Codex review thread.
+[codex] Thread ready (01a0724f-71c3-7cb0-8ee3-36c6adb68be7).
+[codex] Reviewer started: changes against 'main'
+[codex] Running command: /bin/zsh -lc 'pwd; git status --short; git diff --stat 881f0d818fc43abc0ea84064b73d0d7a86ec2b...
+[codex] Command completed: /bin/zsh -lc 'pwd; git status --short; git diff --stat 881f0d818fc43abc0ea84064b73d0d7a86ec2b... (exit 0)
+[codex] Running command: /bin/zsh -lc 'cat AGENTS.md; cat docs/specs/WP-audit-e-ledger-parser-corpus.md; git diff 881f...
+[codex] Running command: /bin/zsh -lc 'git diff 881f0d818fc43abc0ea84064b73d0d7a86ec2b2c -- tests/unit/dream-validate....
+[codex] Command completed: /bin/zsh -lc 'git diff 881f0d818fc43abc0ea84064b73d0d7a86ec2b2c -- tests/unit/dream-validate.... (exit 0)
+[codex] Running command: /bin/zsh -lc "sed -n '300,410p' docs/specs/WP-audit-e-ledger-parser-corpus.md; sed -n '1,180p...
+[codex] Running command: /bin/zsh -lc "node --test --test-name-pattern='ledger corpus|parseFrontmatter' tests/unit/dre...
+[codex] Command completed: /bin/zsh -lc "node --test --test-name-pattern='ledger corpus|parseFrontmatter' tests/unit/dre... (exit 0)
+[codex] Running command: /bin/zsh -lc 'git diff 881f0d818fc43abc0ea84064b73d0d7a86ec2b2c -- docs/specs/logbook docs/sp...
+[codex] Command completed: /bin/zsh -lc 'git diff 881f0d818fc43abc0ea84064b73d0d7a86ec2b2c -- docs/specs/logbook docs/sp... (exit 0)
+[codex] Running command: /bin/zsh -lc "git diff 881f0d818fc43abc0ea84064b73d0d7a86ec2b2c | wc -l; node --test --test-n...
+[codex] Command completed: /bin/zsh -lc "git diff 881f0d818fc43abc0ea84064b73d0d7a86ec2b2c | wc -l; node --test --test-n... (exit 0)
+[codex] Review output captured.
+[codex] Reviewer finished.
+[codex] Assistant message captured: No actionable regressions were found. The changes consistently enforce invalid-value handling...
+[codex] Turn completed.
+# Codex Review
+
+Target: branch diff against main
+
+No actionable regressions were found. The changes consistently enforce invalid-value handling, duplicate-heading refusal, and prototype-safe records. All 51 focused tests passed; broader testing was limited by the read-only sandbox.
+rc=0
+PORCELAIN: identical

--- a/docs/specs/logbook/2026-09-05-audit-e-pr226-raw-round2-herdr-shadow.txt
+++ b/docs/specs/logbook/2026-09-05-audit-e-pr226-raw-round2-herdr-shadow.txt
@@ -1,0 +1,9 @@
+# PR gate raw — PR #226 round 2 — hermetic Codex shadow (codex exec, read-only sandbox, CODEX_HOME=~/.codex-review-home, gpt-5.6-sol high, pr-rubric) — WP-audit-e-ledger-parser-corpus
+# tip reviewed: 3efcac1f75565bd2a51db1299f4155694a84bbe2 (detached worktree) ; base main = 881f0d81 ; porcelain before/after identical ; committed pre-adjudication
+
+{
+  "findings": [],
+  "overall_correctness": "patch is correct",
+  "overall_explanation": "All read-only inspection commands exited 0, including rubric/spec and changed-file reads, boundary check, syntax and JSON checks, proof-count/selector audits, ADR verbatim comparison, source-shape searches, commit/diff inspection, and `git diff --check main...HEAD`; no Band A, B, or C findings were identified. Required commands were attempted: the unit suite exited 1 because sandbox `mkdtemp` was denied, lint exited 1 because markdownlint could not reach the npm registry while its frontmatter check passed, and red-proofs exited 1 because sandbox `mkdtemp` was denied; supplemental read-only tests exited 0 with 46/46 corpus tests, 5/5 frontmatter tests, and 2/2 shipped readBool tests passing, while an in-memory LPC-E mutation confirmed C18 and all 24 C40 authorization cases fail open as required. Initial and final `git status --porcelain` both exited 0 with empty output, so the worktree remained unchanged.",
+  "overall_confidence_score": 0.97
+}

--- a/docs/specs/logbook/2026-09-05-audit-e-pr226-raw-round2-wd-reviewer.txt
+++ b/docs/specs/logbook/2026-09-05-audit-e-pr226-raw-round2-wd-reviewer.txt
@@ -1,0 +1,69 @@
+# PR gate raw — PR #226 round 2 — wd-reviewer (claude-opus-5 agent, detached checkout with real node_modules) — WP-audit-e-ledger-parser-corpus
+# tip reviewed: 3efcac1f75565bd2a51db1299f4155694a84bbe2 ; base main = 881f0d81 ; porcelain before/after identical (reported) ; committed pre-adjudication
+
+# APPROVE
+
+Round-2 review of PR #226 at `3efcac1f`, base main `881f0d81`. Both round-1 dispositions are closed by execution, and every gate is green on a re-run.
+
+---
+
+## Round-1 item closure
+
+**1. [contract] Band B — C18 / C40-authorization fixtures cannot reach `authorize`. → CLOSED.**
+
+Executed: copied the head tree with `git archive 3efcac1f` into a scratch dir, applied LPC-E's declared mutation (`find: "    if (headDuplicateKeys.length > 0) {"`, `occurrences: 2`) to the scratch `src/core/dream/validate.js` only — **2 occurrences found, 2 `RP_MUT_LPC_E_BASELINE_DUPLICATE_REVERTED` markers written**; the checkout's own `src/` was never touched. A driver (`/private/tmp/claude-501/-Users-gyulafeher-Documents-Claude-Projects-wienerdog/0a5c0402-a14b-46f2-8f2d-9f6a0e123cdd/scratchpad/review-pr226r2-scratch/drive-lpce.js`) then loaded `makeGates().skillBody` from **both** trees and drove the two committed fixtures, transcribed from `tests/unit/dream-validate.test.js:4008-4013` and `:4270-4277`:
+
+| Fixture | Real tree (`3efcac1f`) | LPC-E mutant |
+|---|---|---|
+| C18 committed duplicate | `"skill change needs a qualifying learning but the committed ledger has a repeated entry heading (fail closed)"` | **`null`** — genuine authorize |
+| C40-authorization, all 24 code points | **24/24** the same exact refusal | **24/24 `null`** — genuine authorize |
+| C18, the *round-1* (pre-fix) fixture | — | `"authorizing learning a.b has 0 distinct Claude-invoked sessions (needs >= 3 distinct sessions; Codex sessions do not authorize in v1)"` |
+| C40-auth, the pre-fix fixture | — | **0/24 null**, same Codex-floor string |
+
+`FAILS=0`, exit 0. The pre-fix rows are the control: they prove the Codex floor really was refusing first, and that the three-`claude:`-session change on the *last* `a.b`-keyed section is what makes the row witness the fail-open its Today column claims. The last section is the right one — C40's heading is `a.b<cp>`, which `/^##\s+(.+?)\s*$/` normalizes to `a.b`, so last-wins surfaces exactly that section. `\s` minus LF re-derived over the full 0–0x10FFFF range in the driver: **24** code points, matching the spec's list byte for byte. C19 correctly keeps its clean candidate (`:4020-4031`).
+
+**2. [contract] Band C — PR title. → CLOSED.** `gh pr view 226 --json title` returns `fix(dream): ledger-parser correctness and hostile corpus (WP-audit-e-ledger-parser-corpus)`, byte-equal to the spec's Definition of done item 2 (`docs/specs/WP-audit-e-ledger-parser-corpus.md:585-586`).
+
+**3. Test-only round. → CONFIRMED.** `git diff e4be9733 3efcac1f -- src` is **empty**. The four changed files are the three round-1 gate raws under `docs/specs/logbook/` (`…-codex-plugin.txt`, `…-herdr-shadow.txt`, `…-wd-reviewer.txt`) and `tests/unit/dream-validate.test.js` (+13/−2: the two fixture lines plus two explanatory comment blocks).
+
+---
+
+## What I executed (exit statuses)
+
+| Command | Result |
+|---|---|
+| `node tests/with-temp-root.js tests/run.js` | **rc=0** — `tests 2676 / pass 2664 / fail 0 / skipped 12` (expected exactly) |
+| `npm run lint` | **rc=0** — `lint passed`, `frontmatter check passed: 268 spec(s), 4 agent(s)` |
+| `npm run red-proofs` (whole tree, real `node_modules`) | **rc=0** — `44 declared proof(s), 44 selected`, `RUN: PROVEN`, all seven `lpc-*` PROVEN |
+| `node scripts/boundary-check.js docs/specs/WP-audit-e-ledger-parser-corpus.md <10 changed files>` | **rc=0**, no offenders |
+| LPC-E mutation driver (above) | **rc=0**, FAILS=0 |
+| Table C driver (round-1 driver, re-pointed at the r2 tree, drives `gates.ledger`/`gates.skillBody` directly) | **rc=0** — **140/140 assertions match the spec's REQUIRED column**, 0 mismatches, `ALL TABLE C ROWS MATCH SPEC REQUIRED` |
+| Seven `testNamePattern` selectors vs declared witnesses (`node --test --test-name-pattern` per declaration, skips excluded) | **all 7 MATCH**: 14/4/1/2/4/1/2 declared = selected, `BAD=0` |
+| ADR byte-compare (spec's fenced `markdown` block vs `docs/adr/0020-skill-revision-lifecycle.md:381-398`) | `diff` empty — **byte-identical**; 0 deletion lines in the ADR diff (pure insertion, between `## Revision (2026-07-12)` at :206 and `## Future work (parked, not specced)` at :400) |
+| A7 widening bound, re-measured over 0–0x10FFFF | exactly **U+000D, U+2028, U+2029** — 3 code points, matching Table A row A7's "bounded to exactly three characters" |
+| Criterion 4/5 greps | `/^[a-z0-9][a-z0-9.-]{0,63}$/` occurs **once**; four `Object.create(null)` sites (`validate.js:133,136,432,578`); the only `Object.hasOwn` is pre-existing at `:1247` and absent from the diff; no `__proto__`-by-name check |
+| Corpus identity tags | 45 individually selectable `[Cnn]` identities covering C1–C43 with C40 split three ways (criterion 1) |
+
+`git status --porcelain` in `/private/tmp/claude-501/-Users-gyulafeher-Documents-Claude-Projects-wienerdog/0a5c0402-a14b-46f2-8f2d-9f6a0e123cdd/scratchpad/review-wt-pr226r2`: **empty before, empty after**; HEAD still `3efcac1f`. All probes live under `/private/tmp/claude-501/-Users-gyulafeher-Documents-Claude-Projects-wienerdog/0a5c0402-a14b-46f2-8f2d-9f6a0e123cdd/scratchpad/review-pr226r2-scratch/`.
+
+---
+
+## Findings
+
+1. **[boundary] Band —, clean.** All ten changed files are inside the permitted set: six Deliverables rows (`src/core/frontmatter.js`, `src/core/dream/validate.js`, `tests/unit/dream-validate.test.js`, `tests/unit/frontmatter-unify.test.js`, `tests/red-proofs/ledger-parser-corpus.proofs.json`, `docs/adr/0020-skill-revision-lifecycle.md`), the spec itself, and three `docs/specs/logbook/` raws. `boundary-check.js` agrees, rc=0.
+
+2. **[quality] Band C — `tests/unit/dream-validate.test.js:3789-3791`, non-blocking, no change required.** The file-header convention block still reads "Session-IDs are deliberately `codex:*` on every Path-K fixture and `claude:s1,s2,s3` on every Path-A fixture." C18 and C40-authorization are now Path-A fixtures built through `ledgerK` whose *first two* sections keep `codex:` ids and only the last carries `claude:s1, claude:s2, claude:s3`. The header is therefore slightly broader than the code. I am not asking for an edit: the two inline comments added at `:4002-4007` and `:4268-4270` state the narrower rule precisely at the sites where it matters, and they name the reason (last-wins is what surfaces under the mutant), which is the load-bearing fact. Flagging it only so a future round does not read the header as the canonical statement.
+
+No band-A or band-B findings.
+
+---
+
+## Contract-density and Closed-Contract Drift Check
+
+Clean, and this round is the drift being *closed* rather than created. The spec diff versus `881f0d81` is the `status: Ready → In-Review` flip and nothing else, so no canonical table was edited, no mirror was promoted to primary, and no settled contract was reinterpreted. The round-2 change moves a **fixture** into agreement with a canonical table that was already stated correctly — Table C's C18 "Today: authorize" and C40's "keep / authorize for all 24" — which is the right direction of repair: the table stays authoritative and the test now instantiates it. Criterion 7's `37 → 44` mirror is true (measured 44/44). Current state's `2630/2618` and `37 declared` remain pinned historical measurements on `8c52808f`, correctly untouched. The Mirrored Surface Checklist's Table D entry (proof count, `testNamePattern` selection contract, the 37→44 total) is verified against execution rather than prose. No canonical table is missing and no registered mirror has drifted, so nothing routes to wd-architect. The spec is not at fault in either round: round 1's finding was a fixture that diverged from a table the spec states correctly, and it is now fixed.
+
+## Conventions (CLAUDE.md)
+
+Zero new runtime dependencies — `package.json` is not in the diff and the only new import is `boolFromRaw`/`INVALID` from an in-repo module. JSDoc types only, no TypeScript; `parseLedgerEntries`' return type correctly widened to `{{entries: Record<…>, duplicateKeys: string[]}}` with `untrusted: boolean|null|typeof INVALID`. No process, socket or telemetry (ADR-0004). Installer idempotence/reversibility is N/A per criterion 8. Glossary terms (ledger, dream, work package, vault) used canonically. All five commits are conventional, correctly scoped, and carry the WP id; the round-2 commit `test(dream): C18/C40-A duplicate ledgers carry three claude sessions so the authorize fail-open is witnessed (WP-audit-e-ledger-parser-corpus)` is accurate about what it does.
+
+Files of interest: `/private/tmp/claude-501/-Users-gyulafeher-Documents-Claude-Projects-wienerdog/0a5c0402-a14b-46f2-8f2d-9f6a0e123cdd/scratchpad/review-wt-pr226r2/tests/unit/dream-validate.test.js`, `/private/tmp/claude-501/-Users-gyulafeher-Documents-Claude-Projects-wienerdog/0a5c0402-a14b-46f2-8f2d-9f6a0e123cdd/scratchpad/review-wt-pr226r2/src/core/dream/validate.js`, `/private/tmp/claude-501/-Users-gyulafeher-Documents-Claude-Projects-wienerdog/0a5c0402-a14b-46f2-8f2d-9f6a0e123cdd/scratchpad/review-wt-pr226r2/docs/specs/WP-audit-e-ledger-parser-corpus.md`.

--- a/src/core/dream/validate.js
+++ b/src/core/dream/validate.js
@@ -7,7 +7,7 @@ const { WienerdogError } = require('../errors');
 const { getPaths } = require('../paths');
 const { spawnPinnedSync } = require('../exec-identity');
 const { isCapabilityAllowed, CAPABILITY } = require('../safety-profile');
-const { parse, coerceScalar } = require('../frontmatter');
+const { parse, coerceScalar, boolFromRaw, INVALID } = require('../frontmatter');
 const { scanAndRedact, hasHardFinding } = require('../secret-scan');
 const { displayName } = require('./ledger');
 
@@ -130,10 +130,10 @@ function restoreVaultToHead(vaultDir) {
  * @returns {Record<string, string|boolean>}
  */
 function parseFrontmatter(fileText) {
-  if (typeof fileText !== 'string') return {};
+  if (typeof fileText !== 'string') return Object.create(null);
   const fm = parse(fileText); // shared lexer: delimiters + key-line rules
   /** @type {Record<string, string|boolean>} */
-  const data = {};
+  const data = Object.create(null);
   for (const [k, raw] of fm.fields) {
     const { value, quoted } = coerceScalar(raw);
     if (!quoted && value === 'true') {
@@ -380,13 +380,18 @@ function skillBodyViolation(o) {
   }
   if (needsAuth) {
     const key = cur.revision_pattern_key;
-    if (typeof key !== 'string' || !/^[a-z0-9][a-z0-9.-]{0,63}$/.test(key)) {
+    if (typeof key !== 'string' || !PATTERN_KEY_RE.test(key)) {
       return 'skill change needs a qualifying learning but has no valid revision_pattern_key';
     }
     if (baselineLedgerBytes === null || baselineLedgerBytes === undefined) {
       return 'skill change needs a qualifying learning but no committed ledger authorizes it';
     }
-    const learning = parseLedgerEntries(baselineLedgerBytes.toString('utf8'))[key];
+    const { entries: committedLedger, duplicateKeys: headDuplicateKeys } =
+      parseLedgerEntries(baselineLedgerBytes.toString('utf8'));
+    if (headDuplicateKeys.length > 0) {
+      return 'skill change needs a qualifying learning but the committed ledger has a repeated entry heading (fail closed)';
+    }
+    const learning = committedLedger[key];
     if (!learning) return `revision_pattern_key ${key} not found in the committed learnings ledger`;
     if (learning.untrusted !== false) return `authorizing learning ${key} is untrusted-derived (never promotable)`;
     // Only CLAUDE sessions authorize: WP-084 invocation-binds + window-verifies them.
@@ -404,37 +409,59 @@ function skillBodyViolation(o) {
 /**
  * Parse a LEARNINGS.md ledger into { <patternKey>: entry }. Line-based, mirroring
  * parseFrontmatter's approach. Backticks around the Pattern-Key value are stripped.
+ *
+ * The collector is NULL-PROTOTYPE (A2): a heading literally spelled `__proto__`
+ * becomes an own key instead of silently setting the record's prototype.
+ *
+ * `duplicateKeys` (A3) names every heading text seen more than once, in
+ * first-repeat order, decided on the NORMALISED key this function CAPTURED —
+ * never on the raw `##` line. A repeated heading is refused by every caller at
+ * every read; this function only reports it.
+ *
+ * The bullet key match (A7) does not let `.` decide where a value ends: it
+ * matches only the field name up to its colon, and the raw value is the
+ * REMAINDER of the LF-delimited line, trimmed — so a value containing CR,
+ * U+2028 or U+2029 still reaches the field (and, for booleans, A1's
+ * `boolFromRaw`) instead of making the bullet read as absent.
  * @param {string} text
- * @returns {Record<string, {key:string, patternKey:string|null, status:string|null,
- *   recurrence:string|null, sessionIds:string[], firstSeen:string|null,
- *   lastSeen:string|null, untrusted:boolean|null, observation:string|null}>}
+ * @returns {{entries: Record<string, {key:string, patternKey:string|null, status:string|null,
+ *   recurrence:string|null, sessionIds:string[], firstSeen:string|null, lastSeen:string|null,
+ *   untrusted:boolean|null|typeof INVALID, observation:string|null}>, duplicateKeys:string[]}}
  */
 function parseLedgerEntries(text) {
-  /** @type {Record<string, any>} */ const entries = {};
+  /** @type {Record<string, any>} */ const entries = Object.create(null);
+  const seenKeys = new Set();
+  /** @type {string[]} */ const duplicateKeys = [];
   let cur = null;
   for (const raw of String(text).split('\n')) {
     const h = raw.match(/^##\s+(.+?)\s*$/);
     if (h) {
-      cur = { key: h[1], patternKey: null, status: null, recurrence: null,
+      const key = h[1];
+      if (seenKeys.has(key)) {
+        if (!duplicateKeys.includes(key)) duplicateKeys.push(key);
+      } else {
+        seenKeys.add(key);
+      }
+      cur = { key, patternKey: null, status: null, recurrence: null,
         sessionIds: [], firstSeen: null, lastSeen: null, untrusted: null, observation: null };
-      entries[h[1]] = cur;
+      entries[key] = cur;
       continue;
     }
     if (!cur) continue;
-    const b = raw.match(/^-\s*([A-Za-z_-]+):\s*(.*)$/);
+    const b = raw.match(/^-\s*([A-Za-z_-]+):/);
     if (!b) continue;
     const field = b[1].toLowerCase();
-    const val = b[2].trim();
+    const val = raw.slice(b[0].length).trim();
     if (field === 'pattern-key') cur.patternKey = val.replace(/^`|`$/g, '');
     else if (field === 'status') cur.status = val;
     else if (field === 'recurrence') cur.recurrence = val;
     else if (field === 'session-ids') cur.sessionIds = val.split(',').map((s) => s.trim()).filter(Boolean);
     else if (field === 'first-seen') cur.firstSeen = val;
     else if (field === 'last-seen') cur.lastSeen = val;
-    else if (field === 'derived_from_untrusted') cur.untrusted = val === 'true';
+    else if (field === 'derived_from_untrusted') cur.untrusted = boolFromRaw(val);
     else if (field === 'observation') cur.observation = val;
   }
-  return entries;
+  return { entries, duplicateKeys };
 }
 
 const SID_RE = /^[a-z0-9]+:[A-Za-z0-9_-]+$/;
@@ -533,7 +560,12 @@ function ledgerViolation(o) {
   if (skillFm.created !== regEntry.created) return 'learnings ledger parent skill created does not match the registry (path reuse)';
 
   const curText = candidateBytes.toString('utf8');
-  const cur = parseLedgerEntries(curText);
+  const { entries: cur, duplicateKeys: curDuplicateKeys } = parseLedgerEntries(curText);
+  // (a2) a repeated `##` heading refuses at the candidate read too (A3): last-wins
+  //      on a collector nothing validated is exactly the hole this closes.
+  if (curDuplicateKeys.length > 0) {
+    return `learnings ledger has a repeated entry heading (${curDuplicateKeys[0]}); each ## heading must appear once`;
+  }
   if (Object.keys(cur).length === 0) return 'learnings ledger has no valid entries';
   // (b) every entry validates against the schema.
   for (const [key, e] of Object.entries(cur)) {
@@ -543,15 +575,25 @@ function ledgerViolation(o) {
   // (c) append-only + raise-only vs HEAD (tracked modifications only). A tracked
   //     ledger whose committed version is unreadable FAILS CLOSED — never skip the
   //     history comparison (skipping it was a fail-open gap).
-  let headEntries = {};
+  let headEntries = Object.create(null);
   if (baselineLedgerBytes !== null && baselineLedgerBytes !== undefined) {
-    headEntries = parseLedgerEntries(baselineLedgerBytes.toString('utf8'));
+    const { entries: parsedHeadEntries, duplicateKeys: headDuplicateKeys } =
+      parseLedgerEntries(baselineLedgerBytes.toString('utf8'));
+    // A repeated heading on the COMMITTED baseline makes the append-only history
+    // uncomparable — fail closed rather than compare against a last-wins collapse.
+    if (headDuplicateKeys.length > 0) {
+      return `learnings ledger's committed version has a repeated entry heading (${headDuplicateKeys[0]}); the append-only history cannot be compared (fail closed)`;
+    }
+    headEntries = parsedHeadEntries;
     for (const [key, he] of Object.entries(headEntries)) {
       const ce = cur[key];
       if (!ce) return `learnings ledger deleted an existing entry (${key}); ledger is append-only`;
       if (ce.firstSeen !== he.firstSeen) return `learnings ledger changed First-Seen of ${key} (immutable)`;
       if (ce.observation !== he.observation) return `learnings ledger rewrote the Observation of ${key} (immutable)`;
-      if (he.untrusted === true && ce.untrusted !== true) {
+      // A4: raise-only fails closed on an INVALID committed value too — INVALID is
+      // "present but unreadable" and may not be lowered; only an ABSENT (null)
+      // baseline value stays exempt (owner item 2).
+      if ((he.untrusted === true || he.untrusted === INVALID) && ce.untrusted !== true) {
         return `learnings ledger lowered derived_from_untrusted of ${key} (raise-only)`;
       }
       // (d) Session-IDs are append-only: every committed id must remain present, so

--- a/src/core/frontmatter.js
+++ b/src/core/frontmatter.js
@@ -103,6 +103,18 @@ function coerceScalar(raw) {
  *  normalize it to the exact literal — see parse.) */
 const INVALID = Symbol('frontmatter.invalid');
 
+/** VALUE-LEVEL three-state boolean reader — the single place a stored scalar
+ *  acquires boolean meaning. `readBool(fields, key)` is this over a Map lookup.
+ *  @param {string|undefined} raw
+ *  @returns {true|false|undefined|typeof INVALID}
+ *    undefined = no value; false/true = exactly `false`/`true`; INVALID = anything else. */
+function boolFromRaw(raw) {
+  if (raw === undefined) return undefined;
+  if (raw === 'false') return false;
+  if (raw === 'true') return true;
+  return INVALID;
+}
+
 /**
  * Typed boolean read. Fails closed on any non-exact form.
  * @param {Map<string,string>} fields
@@ -114,10 +126,7 @@ const INVALID = Symbol('frontmatter.invalid');
  */
 function readBool(fields, key) {
   if (!fields.has(key)) return undefined;
-  const raw = fields.get(key);
-  if (raw === 'false') return false;
-  if (raw === 'true') return true;
-  return INVALID;
+  return boolFromRaw(fields.get(key));
 }
 
 /**
@@ -136,4 +145,4 @@ function readNumber(fields, key) {
   return Number(raw);
 }
 
-module.exports = { parse, coerceScalar, readBool, readNumber, INVALID };
+module.exports = { parse, coerceScalar, readBool, boolFromRaw, readNumber, INVALID };

--- a/tests/red-proofs/ledger-parser-corpus.proofs.json
+++ b/tests/red-proofs/ledger-parser-corpus.proofs.json
@@ -1,0 +1,271 @@
+{
+  "suite": "tests/unit/dream-validate.test.js",
+  "proofs": [
+    {
+      "id": "lpc-a-trust-predicate-reverted",
+      "wp": "WP-audit-e-ledger-parser-corpus",
+      "criterion": "1",
+      "why": "the trust predicate is the whole of A1: reverting it back to a two-state test (val === 'true') makes every non-exact-literal value that boolFromRaw distinguishes as INVALID collapse to false (a wrongly-trusted state), so a schema check that used to refuse now passes and an authorization read that used to refuse now authorizes — reddening every case-variant, quoted, comment-carrying, numeric, empty, YAML-ish, homoglyph and interior-invisible witness",
+      "file": "src/core/dream/validate.js",
+      "find": "    else if (field === 'derived_from_untrusted') cur.untrusted = boolFromRaw(val);",
+      "replace": "    else if (field === 'derived_from_untrusted') cur.untrusted = val === 'true'; /* RP_MUT_LPC_A_TRUST_PREDICATE_REVERTED */",
+      "marker": "RP_MUT_LPC_A_TRUST_PREDICATE_REVERTED",
+      "occurrences": 1,
+      "testNamePattern": "\\[C(6|7|8|9|10|11|12|13|14|31|32|33|34|35)\\]",
+      "expectRed": [
+        {
+          "test": [
+            "dream-validate: ledger corpus [C6] case variant False, K refuses"
+          ],
+          "signal": "K path for"
+        },
+        {
+          "test": [
+            "dream-validate: ledger corpus [C7] case variant False, A refuses"
+          ],
+          "signal": "A path for"
+        },
+        {
+          "test": [
+            "dream-validate: ledger corpus [C8] case variant TRUE, K refuses"
+          ],
+          "signal": "K path for"
+        },
+        {
+          "test": [
+            "dream-validate: ledger corpus [C9] case variant TRUE, A refuses"
+          ],
+          "signal": "A path for"
+        },
+        {
+          "test": [
+            "dream-validate: ledger corpus [C10] quoted \"false\", K refuses (the ledger runs no coerceScalar)"
+          ],
+          "signal": "K path for"
+        },
+        {
+          "test": [
+            "dream-validate: ledger corpus [C11] the comment class, K refuses (no inline-comment stripping)"
+          ],
+          "signal": "K path for"
+        },
+        {
+          "test": [
+            "dream-validate: ledger corpus [C12] YAML-ish word yes, K and A refuse"
+          ],
+          "signal": "K path for"
+        },
+        {
+          "test": [
+            "dream-validate: ledger corpus [C13] numeric 1, K and A refuse"
+          ],
+          "signal": "K path for"
+        },
+        {
+          "test": [
+            "dream-validate: ledger corpus [C14] empty value, K and A refuse"
+          ],
+          "signal": "K path for"
+        },
+        {
+          "test": [
+            "dream-validate: ledger corpus [C31] the YAML-ish word class (on, off), K and A refuse"
+          ],
+          "signal": "K path for"
+        },
+        {
+          "test": [
+            "dream-validate: ledger corpus [C32] the YAML null class (~, null), K and A refuse"
+          ],
+          "signal": "K path for"
+        },
+        {
+          "test": [
+            "dream-validate: ledger corpus [C33] the YAML tag class (!!bool false), K and A refuse"
+          ],
+          "signal": "K path for"
+        },
+        {
+          "test": [
+            "dream-validate: ledger corpus [C34] the homoglyph class (fullwidth false), K and A refuse"
+          ],
+          "signal": "K path for"
+        },
+        {
+          "test": [
+            "dream-validate: ledger corpus [C35] the interior-invisible class (U+200B inside false), K and A refuse"
+          ],
+          "signal": "K path for"
+        }
+      ]
+    },
+    {
+      "id": "lpc-b-collector-reverted",
+      "wp": "WP-audit-e-ledger-parser-corpus",
+      "criterion": "4",
+      "why": "parseLedgerEntries' collector reverted to {} restores the __proto__ accessor: a `## __proto__` heading no longer becomes an own key (its assignment is silently absorbed by the inherited setter), so C24/C25 keep instead of refusing the Pattern-Key check, and a bracket lookup on the CANDIDATE side for a heading-shaped key like `constructor` that the candidate never assigned resolves through the prototype chain to the built-in Object.prototype.constructor function instead of undefined, so C27's deleted-entry check never fires and a different (still-wrong) refusal reddens it; C28's `__proto__` sub-case reddens the same way as C24",
+      "file": "src/core/dream/validate.js",
+      "find": "  /** @type {Record<string, any>} */ const entries = Object.create(null);",
+      "replace": "  /** @type {Record<string, any>} */ const entries = {}; /* RP_MUT_LPC_B_COLLECTOR_REVERTED */",
+      "marker": "RP_MUT_LPC_B_COLLECTOR_REVERTED",
+      "occurrences": 1,
+      "testNamePattern": "\\[C24\\]|\\[C25\\]|\\[C27\\]|\\[C28\\]",
+      "expectRed": [
+        {
+          "test": [
+            "dream-validate: ledger corpus [C24] heading __proto__ alone, K refuses (Pattern-Key slug check)"
+          ],
+          "signal": "C24 proto heading"
+        },
+        {
+          "test": [
+            "dream-validate: ledger corpus [C25] heading __proto__ plus one valid entry, K refuses (as C24)"
+          ],
+          "signal": "C25 proto plus valid"
+        },
+        {
+          "test": [
+            "dream-validate: ledger corpus [C27] baseline constructor + a.b, candidate deleted constructor, K refuses (append-only)"
+          ],
+          "signal": "C27 constructor deleted"
+        },
+        {
+          "test": [
+            "dream-validate: ledger corpus [C28] one shared pattern-key sample at both sites, 0 disagreements (A5)"
+          ],
+          "signal": "heading site refuse for"
+        }
+      ]
+    },
+    {
+      "id": "lpc-c-frontmatter-record-reverted",
+      "wp": "WP-audit-e-ledger-parser-corpus",
+      "criterion": "4",
+      "why": "parseFrontmatter's record reverted to {} restores the __proto__ accessor on the frontmatter collector: `__proto__: injected` in a SKILL.md promotion no longer becomes an own key (the inherited setter absorbs it), so the promotion-allowlist loop over Object.keys never sees an unauthorized extra field and the promotion is allowed with no qualifying learning, exactly the pre-fix hole C30 is the witness for",
+      "file": "src/core/dream/validate.js",
+      "find": "  const data = Object.create(null);",
+      "replace": "  const data = {}; /* RP_MUT_LPC_C_FRONTMATTER_RECORD_REVERTED */",
+      "marker": "RP_MUT_LPC_C_FRONTMATTER_RECORD_REVERTED",
+      "occurrences": 1,
+      "testNamePattern": "\\[C30\\]",
+      "expectRed": [
+        {
+          "test": [
+            "dream-validate: ledger corpus [C30] promotion adding __proto__: injected, A refuses (A2 fix — no longer invisible)"
+          ],
+          "signal": "C30 proto promotion"
+        }
+      ]
+    },
+    {
+      "id": "lpc-d-candidate-duplicate-reverted",
+      "wp": "WP-audit-e-ledger-parser-corpus",
+      "criterion": "2",
+      "why": "reverting the candidate-read duplicate-heading refusal (and only it) restores the last-wins collapse at the ONE read this mutation targets: a non-adjacent repeated `##` heading in the CANDIDATE ledger is no longer refused, so C17 keeps instead of refusing, and the candidate-read identity of the generated C40 matrix keeps for all 24 code points instead of refusing — while the two committed-baseline reads (C18, C19, C40 baseline/authorization) are untouched by this mutation and stay green",
+      "file": "src/core/dream/validate.js",
+      "find": "  if (curDuplicateKeys.length > 0) {\n    return `learnings ledger has a repeated entry heading (${curDuplicateKeys[0]}); each ## heading must appear once`;\n  }",
+      "replace": "  if (false && curDuplicateKeys.length > 0) { /* RP_MUT_LPC_D_CANDIDATE_DUPLICATE_REVERTED */\n    return `learnings ledger has a repeated entry heading (${curDuplicateKeys[0]}); each ## heading must appear once`;\n  }",
+      "marker": "RP_MUT_LPC_D_CANDIDATE_DUPLICATE_REVERTED",
+      "occurrences": 1,
+      "testNamePattern": "\\[C17\\]|\\[C40-candidate\\]",
+      "expectRed": [
+        {
+          "test": [
+            "dream-validate: ledger corpus [C17] non-adjacent CANDIDATE duplicate heading, K refuses"
+          ],
+          "signal": "C17 candidate duplicate"
+        },
+        {
+          "test": [
+            "dream-validate: ledger corpus [C40-candidate] generated matrix, candidate read, K refuses (LPC-D)"
+          ],
+          "signal": "cp=U+"
+        }
+      ]
+    },
+    {
+      "id": "lpc-e-baseline-duplicate-reverted",
+      "wp": "WP-audit-e-ledger-parser-corpus",
+      "criterion": "2",
+      "why": "reverting the duplicate-heading refusal at BOTH committed-baseline reads (the append-only-comparison read in ledgerViolation and the authorization read in skillBodyViolation — the shared local name headDuplicateKeys occurs identically at both sites) restores a fail-open comparison against a last-wins collapse of a ledger nothing validated: C18 authorizes instead of refusing, C19 keeps instead of refusing, and the baseline/authorization identities of the generated C40 matrix keep/authorize for all 24 code points instead of refusing — while the candidate-read refusal (C17, C40 candidate) is untouched and stays green",
+      "file": "src/core/dream/validate.js",
+      "find": "    if (headDuplicateKeys.length > 0) {",
+      "replace": "    if (false && headDuplicateKeys.length > 0) { /* RP_MUT_LPC_E_BASELINE_DUPLICATE_REVERTED */",
+      "marker": "RP_MUT_LPC_E_BASELINE_DUPLICATE_REVERTED",
+      "occurrences": 2,
+      "testNamePattern": "\\[C18\\]|\\[C19\\]|\\[C40-baseline\\]|\\[C40-authorization\\]",
+      "expectRed": [
+        {
+          "test": [
+            "dream-validate: ledger corpus [C18] the same ledger as the COMMITTED baseline, A refuses"
+          ],
+          "signal": "C18 committed duplicate authorization"
+        },
+        {
+          "test": [
+            "dream-validate: ledger corpus [C19] COMMITTED baseline duplicate, candidate carries both a.b and c.d, K refuses"
+          ],
+          "signal": "C19 committed duplicate append-only"
+        },
+        {
+          "test": [
+            "dream-validate: ledger corpus [C40-baseline] generated matrix, committed-baseline read, K refuses (LPC-E)"
+          ],
+          "signal": "cp=U+"
+        },
+        {
+          "test": [
+            "dream-validate: ledger corpus [C40-authorization] generated matrix, authorization read, A refuses (LPC-E)"
+          ],
+          "signal": "cp=U+"
+        }
+      ]
+    },
+    {
+      "id": "lpc-f-raise-only-invalid-reverted",
+      "wp": "WP-audit-e-ledger-parser-corpus",
+      "criterion": "1",
+      "why": "reverting the raise-only clause back to `he.untrusted === true` (dropping the `|| he.untrusted === INVALID` disjunct) makes A4 unreachable for an INVALID committed value: C21's baseline `False` (an INVALID committed value under A1) no longer triggers the raise-only comparison, so a candidate lowering it to the exact literal `false` keeps instead of refusing",
+      "file": "src/core/dream/validate.js",
+      "find": "      if ((he.untrusted === true || he.untrusted === INVALID) && ce.untrusted !== true) {",
+      "replace": "      if (he.untrusted === true && ce.untrusted !== true) { /* RP_MUT_LPC_F_RAISE_ONLY_INVALID_REVERTED */",
+      "marker": "RP_MUT_LPC_F_RAISE_ONLY_INVALID_REVERTED",
+      "occurrences": 1,
+      "testNamePattern": "\\[C21\\]",
+      "expectRed": [
+        {
+          "test": [
+            "dream-validate: ledger corpus [C21] baseline False, candidate false, K refuses (raise-only, INVALID fails closed)"
+          ],
+          "signal": "C21 raise-only invalid"
+        }
+      ]
+    },
+    {
+      "id": "lpc-g-bullet-key-match-reverted",
+      "wp": "WP-audit-e-ledger-parser-corpus",
+      "criterion": "2b",
+      "why": "reverting the bullet key match back to the shipped anchored form `/^-\\s*([A-Za-z_-]+):\\s*(.*)$/` restores A7's hole: `.` never matches CR, U+2028 or U+2029, so a bullet whose value contains one of them fails to match at all and the field reads as ABSENT rather than INVALID — C37's committed-baseline value is laundered into an absent bullet that A4 exempts, so the candidate's exact-literal `false` keeps instead of refusing (raise-only never fires), and C39's whole-CRLF ledger fails every bullet line (each ends in a bare `\\r` the anchored `(.*)$ ` cannot reach) so the entry reads as empty and the ledger refuses instead of keeping",
+      "file": "src/core/dream/validate.js",
+      "find": "    const b = raw.match(/^-\\s*([A-Za-z_-]+):/);\n    if (!b) continue;\n    const field = b[1].toLowerCase();\n    const val = raw.slice(b[0].length).trim();",
+      "replace": "    const b = raw.match(/^-\\s*([A-Za-z_-]+):\\s*(.*)$/);\n    if (!b) continue;\n    const field = b[1].toLowerCase();\n    const val = b[2].trim(); /* RP_MUT_LPC_G_BULLET_KEY_MATCH_REVERTED */",
+      "marker": "RP_MUT_LPC_G_BULLET_KEY_MATCH_REVERTED",
+      "occurrences": 1,
+      "testNamePattern": "\\[C37\\]|\\[C39\\]",
+      "expectRed": [
+        {
+          "test": [
+            "dream-validate: ledger corpus [C37] same three values on the COMMITTED baseline, candidate false, K refuses (A7 makes it INVALID, A4 fires)"
+          ],
+          "signal": "cp=U+"
+        },
+        {
+          "test": [
+            "dream-validate: ledger corpus [C39] a whole ledger with CRLF line endings, otherwise valid, K keeps (A7 deliberate widening)"
+          ],
+          "signal": "C39 crlf ledger"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit/dream-validate.test.js
+++ b/tests/unit/dream-validate.test.js
@@ -4000,10 +4000,16 @@ test('dream-validate: ledger corpus [C17] non-adjacent CANDIDATE duplicate headi
   );
 });
 test('dream-validate: ledger corpus [C18] the same ledger as the COMMITTED baseline, A refuses', () => {
+  // The LAST a.b-keyed section carries 3 distinct claude: sessions: with A3's
+  // duplicate refusal mutated away, last-wins is what the pre-fix collapse
+  // yields, and only THIS section's fields are visible to skillBodyViolation's
+  // own >=3-Claude-session floor — codex: sessions here would let that floor
+  // refuse first, on its OWN unrelated string, and the row would never reach
+  // the "authorize" its Today column records (round-1 gate finding).
   const dup = ledgerK(
     { heading: 'a.b', untrustedLine: untrustedBullet('true') },
     { heading: 'c.d', patternKey: '`c.d`' },
-    { heading: 'a.b', untrustedLine: untrustedBullet('false') },
+    { heading: 'a.b', untrustedLine: untrustedBullet('false'), sessionIds: 'claude:s1, claude:s2, claude:s3', recurrence: '3' },
   );
   assert.equal(
     runA(dup, 'a.b'),
@@ -4260,11 +4266,14 @@ test('dream-validate: ledger corpus [C40-baseline] generated matrix, committed-b
   }
 });
 test('dream-validate: ledger corpus [C40-authorization] generated matrix, authorization read, A refuses (LPC-E)', () => {
+  // Same reason as C18: the LAST a.b-keyed section (the one last-wins would
+  // surface if A3's duplicate refusal were mutated away) needs 3 distinct
+  // claude: sessions, or skillBodyViolation's own Codex floor refuses first.
   for (const cp of WS_CODEPOINTS) {
     const dup = ledgerK(
       { heading: 'a.b' },
       { heading: 'c.d', patternKey: '`c.d`' },
-      { heading: `a.b${String.fromCodePoint(cp)}` },
+      { heading: `a.b${String.fromCodePoint(cp)}`, sessionIds: 'claude:s1, claude:s2, claude:s3', recurrence: '3' },
     );
     assert.equal(
       runA(dup, 'a.b'),

--- a/tests/unit/dream-validate.test.js
+++ b/tests/unit/dream-validate.test.js
@@ -304,8 +304,10 @@ test('dream-validate: parseFrontmatter coerces unquoted booleans, keeps quoted s
 });
 
 test('dream-validate: parseFrontmatter returns {} without a leading block', () => {
-  assert.deepEqual(parseFrontmatter('no frontmatter here'), {});
-  assert.deepEqual(parseFrontmatter('---\nunterminated: x\nbody'), {});
+  // A2: the record is null-prototype, so a `{}` comparison is not `deepEqual`
+  // to it any more — the OBSERVABLE is zero own keys.
+  assert.deepEqual(Object.keys(parseFrontmatter('no frontmatter here')), []);
+  assert.deepEqual(Object.keys(parseFrontmatter('---\nunterminated: x\nbody')), []);
 });
 
 // ── the gate ─────────────────────────────────────────────────────────────────
@@ -3774,4 +3776,523 @@ test('WP-validator-decided-bytes AC6: a malformed Tier-1/2 note is committed exa
   assert.equal(fs.readFileSync(path.join(vault, '01-Journal/2026-07-03.md'), 'utf8'), log);
   assert.equal(res.promoted.find((p) => p.rel === '03-Resources/malformed-note.md').bytes.toString('utf8'), note);
   assert.equal(res.promoted.find((p) => p.rel === '01-Journal/2026-07-03.md').bytes.toString('utf8'), log);
+});
+
+// ── WP-audit-e-ledger-parser-corpus: Table C, the ledger-parser hostile corpus ──
+//
+// Every row calls a gate DIRECTLY on hand-built VALUES (Table D rule (b) — every
+// input arrives as a value): no git repo, no ownership-registry write, no
+// extracts file. `gates.ledger` is `ledgerViolation` and `gates.skillBody` is
+// `skillBodyViolation` (both returned by `makeGates`), and both take
+// `{rel, candidateBytes, ...}` as plain buffers/objects — exactly the inputs
+// Table C's Path column names (K = `gates.ledger`, A = `gates.skillBody`).
+//
+// Session-IDs are deliberately `codex:*` on every Path-K fixture and
+// `claude:s1,s2,s3` on every Path-A fixture: a `codex:` id is "loose
+// accumulation" (WP-084) and never consults `extractsBySession`, so a Path-K
+// corpus row never exercises invocation-binding (already covered above, not
+// this work package's subject); three distinct `claude:` ids clear
+// `skillBodyViolation`'s own >=3-session floor so a VALID entry actually
+// reaches "authorize" rather than refusing for an unrelated reason.
+//
+// Every exotic code point below is written as a JS escape or
+// `String.fromCodePoint`, never as a literal glyph in source (a design-round
+// driver silently lost raw U+2028 through a heredoc) — the self-check test
+// re-derives the 24-code-point `\s`-minus-LF set from the runtime's own regex
+// engine and echoes it, rather than trusting a hand-copied list.
+
+const corpusGates = makeGates();
+const CORPUS_LEDGER_REL = '05-Skills/corpus/LEARNINGS.md';
+const CORPUS_SKILL_REL = '05-Skills/corpus/SKILL.md';
+const CORPUS_SKILL = [
+  '---', 'id: corpus', 'type: skill', 'created: 2026-08-01', 'updated: 2026-08-01',
+  'origin: dream', 'confidence: 0.9', 'recurrence: 3', 'derived_from_untrusted: false',
+  '---', '', 'corpus skill body', '',
+].join('\n');
+const corpusRegistry = { skills: { [CORPUS_SKILL_REL]: { id: 'corpus', created: '2026-08-01' } } };
+
+/** One `## <heading>` ledger section. Every field is a JS string the caller
+ *  supplies verbatim — `untrustedLine` is the RAW bullet line (its own leading
+ *  `- derived_from_untrusted:` and everything after), or `null` to omit the
+ *  bullet entirely (the ABSENT class, C15/C16/C23). */
+function ledgerSection(opts = {}) {
+  const {
+    heading = 'a.b',
+    patternKey = '`a.b`',
+    status = 'open',
+    recurrence = '2',
+    sessionIds = 'codex:s1, codex:s2',
+    firstSeen = '2026-01-01',
+    lastSeen = '2026-01-01',
+    untrustedLine = '- derived_from_untrusted: false',
+    observation = 'a recurring pattern.',
+  } = opts;
+  const lines = [
+    `## ${heading}`,
+    '',
+    `- Pattern-Key: ${patternKey}`,
+    `- Status: ${status}`,
+    `- Recurrence: ${recurrence}`,
+    `- Session-IDs: ${sessionIds}`,
+    `- First-Seen: ${firstSeen}`,
+    `- Last-Seen: ${lastSeen}`,
+  ];
+  if (untrustedLine !== null) lines.push(untrustedLine);
+  lines.push(`- Observation: ${observation}`, '');
+  return lines.join('\n');
+}
+
+/** One or more sections, `codex:` sessions (Path K — invocation-binding never consulted). */
+function ledgerK(...sections) {
+  return sections.map((s) => ledgerSection(s)).join('\n');
+}
+
+/** One section, `claude:` sessions (Path A — clears the >=3-distinct-session floor). */
+function ledgerA(opts = {}) {
+  return ledgerSection({ sessionIds: 'claude:s1, claude:s2, claude:s3', recurrence: '3', ...opts });
+}
+
+/** The `- derived_from_untrusted:` bullet line for RAW value `v` (may embed
+ *  any character, including CR / U+2028 / U+2029 — A7's remainder-of-line rule). */
+function untrustedBullet(v) {
+  return `- derived_from_untrusted: ${v}`;
+}
+
+/** Path K: `gates.ledger` on a candidate LEARNINGS.md, with an optional committed baseline. */
+function runK(candidateText, baselineText) {
+  return corpusGates.ledger({
+    rel: CORPUS_LEDGER_REL,
+    candidateBytes: Buffer.from(candidateText, 'utf8'),
+    baselineLedgerBytes: baselineText == null ? null : Buffer.from(baselineText, 'utf8'),
+    pairedSkillBytes: Buffer.from(CORPUS_SKILL, 'utf8'),
+    registry: corpusRegistry,
+    extractsBySession: new Map(),
+    layout: defaultLayout(),
+  });
+}
+
+/** Path A: `gates.skillBody` on a Tier-3 body revision whose `revision_pattern_key`
+ *  names `key`, with `ledgerText` as the committed `baselineLedgerBytes`. The
+ *  body always changes, so `needsAuth` is unconditionally true — this fixture
+ *  isolates the authorization read, never the bare-promotion allowlist (C29/C30
+ *  use their own dedicated fixture below). */
+function runA(ledgerText, key = 'a.b') {
+  const head = CORPUS_SKILL;
+  const cur = CORPUS_SKILL
+    .replace('corpus skill body', 'revised corpus skill body')
+    .replace('updated: 2026-08-01', 'updated: 2026-08-02')
+    .replace('origin: dream\n', `origin: dream\nrevision_pattern_key: ${key}\n`);
+  return corpusGates.skillBody({
+    rel: CORPUS_SKILL_REL,
+    candidateBytes: Buffer.from(cur, 'utf8'),
+    baselineBytes: Buffer.from(head, 'utf8'),
+    baselineLedgerBytes: ledgerText == null ? null : Buffer.from(ledgerText, 'utf8'),
+    registry: corpusRegistry,
+    layout: defaultLayout(),
+    date: '2026-08-02',
+  });
+}
+
+const K_INVALID_REFUSAL = 'learnings ledger entry a.b: missing/invalid derived_from_untrusted';
+const A_INVALID_REFUSAL = 'authorizing learning a.b is untrusted-derived (never promotable)';
+
+/** @param {string} rawValue @param {boolean} expectKeep */
+function checkK(rawValue, expectKeep) {
+  const text = ledgerK({ untrustedLine: untrustedBullet(rawValue) });
+  const reason = runK(text);
+  if (expectKeep) assert.equal(reason, null, `K path for ${JSON.stringify(rawValue)}`);
+  else assert.equal(reason, K_INVALID_REFUSAL, `K path for ${JSON.stringify(rawValue)}`);
+}
+
+/** @param {string} rawValue @param {boolean} expectAuthorize */
+function checkA(rawValue, expectAuthorize) {
+  const text = ledgerA({ untrustedLine: untrustedBullet(rawValue) });
+  const reason = runA(text);
+  if (expectAuthorize) assert.equal(reason, null, `A path for ${JSON.stringify(rawValue)}`);
+  else assert.equal(reason, A_INVALID_REFUSAL, `A path for ${JSON.stringify(rawValue)}`);
+}
+
+// The self-check the task requires: ECMAScript `\s` matches exactly 24 non-LF
+// code points, GENERATED here (never hand-enumerated) and echoed on failure so
+// a silently-lost exotic code point is caught immediately rather than producing
+// a corpus that quietly tests fewer than 24 members.
+const WS_CODEPOINTS = [];
+for (let cp = 0; cp <= 0xffff; cp += 1) {
+  if (cp === 0x0a) continue; // LF is excluded by definition (the heading/line delimiter)
+  if (/^\s$/.test(String.fromCharCode(cp))) WS_CODEPOINTS.push(cp);
+}
+
+test('dream-validate: ledger corpus self-check — ECMAScript \\s minus LF is exactly 24 code points', () => {
+  const hex = WS_CODEPOINTS.map((cp) => `U+${cp.toString(16).toUpperCase().padStart(4, '0')}`).join(' ');
+  assert.equal(WS_CODEPOINTS.length, 24, `code points observed: ${hex}`);
+});
+
+// ── C1–C16: the trust predicate's value classes (A1) ─────────────────────────
+
+test('dream-validate: ledger corpus [C1] exact literal true, K keeps', () => {
+  checkK('true', true);
+});
+test('dream-validate: ledger corpus [C2] exact literal true, A refuses (untrusted, unchanged)', () => {
+  checkA('true', false);
+});
+test('dream-validate: ledger corpus [C3] exact literal false, K keeps', () => {
+  checkK('false', true);
+});
+test('dream-validate: ledger corpus [C4] exact literal false, A authorizes', () => {
+  checkA('false', true);
+});
+test('dream-validate: ledger corpus [C5] the padding class normalises to the exact literal, K keeps (green control)', () => {
+  const pads = [' ', '\t', String.fromCodePoint(0x00a0), String.fromCodePoint(0xfeff)];
+  for (const pad of pads) checkK(`${pad}false${pad}`, true);
+});
+test('dream-validate: ledger corpus [C6] case variant False, K refuses', () => {
+  checkK('False', false);
+});
+test('dream-validate: ledger corpus [C7] case variant False, A refuses', () => {
+  checkA('False', false);
+});
+test('dream-validate: ledger corpus [C8] case variant TRUE, K refuses', () => {
+  checkK('TRUE', false);
+});
+test('dream-validate: ledger corpus [C9] case variant TRUE, A refuses', () => {
+  checkA('TRUE', false);
+});
+test('dream-validate: ledger corpus [C10] quoted "false", K refuses (the ledger runs no coerceScalar)', () => {
+  checkK('"false"', false);
+});
+test('dream-validate: ledger corpus [C11] the comment class, K refuses (no inline-comment stripping)', () => {
+  checkK('false # ok', false);
+  checkK('false\t# ok', false);
+});
+test('dream-validate: ledger corpus [C12] YAML-ish word yes, K and A refuse', () => {
+  checkK('yes', false);
+  checkA('yes', false);
+});
+test('dream-validate: ledger corpus [C13] numeric 1, K and A refuse', () => {
+  checkK('1', false);
+  checkA('1', false);
+});
+test('dream-validate: ledger corpus [C14] empty value, K and A refuse', () => {
+  checkK('', false);
+  checkA('', false);
+});
+test('dream-validate: ledger corpus [C15] bullet ABSENT, K refuses (regression pin, do not "fix")', () => {
+  const text = ledgerK({ untrustedLine: null });
+  assert.equal(runK(text), K_INVALID_REFUSAL);
+});
+test('dream-validate: ledger corpus [C16] bullet ABSENT, A refuses (regression pin)', () => {
+  const text = ledgerA({ untrustedLine: null });
+  assert.equal(runA(text), A_INVALID_REFUSAL);
+});
+
+// ── C17–C20: duplicate `##` heading, the candidate and its green control ─────
+
+test('dream-validate: ledger corpus [C17] non-adjacent CANDIDATE duplicate heading, K refuses', () => {
+  const text = ledgerK(
+    { heading: 'a.b', untrustedLine: untrustedBullet('true') },
+    { heading: 'c.d', patternKey: '`c.d`' },
+    { heading: 'a.b', untrustedLine: untrustedBullet('false') },
+  );
+  assert.equal(
+    runK(text),
+    'learnings ledger has a repeated entry heading (a.b); each ## heading must appear once',
+    'C17 candidate duplicate'
+  );
+});
+test('dream-validate: ledger corpus [C18] the same ledger as the COMMITTED baseline, A refuses', () => {
+  const dup = ledgerK(
+    { heading: 'a.b', untrustedLine: untrustedBullet('true') },
+    { heading: 'c.d', patternKey: '`c.d`' },
+    { heading: 'a.b', untrustedLine: untrustedBullet('false') },
+  );
+  assert.equal(
+    runA(dup, 'a.b'),
+    'skill change needs a qualifying learning but the committed ledger has a repeated entry heading (fail closed)',
+    'C18 committed duplicate authorization'
+  );
+});
+test('dream-validate: ledger corpus [C19] COMMITTED baseline duplicate, candidate carries both a.b and c.d, K refuses', () => {
+  const dup = ledgerK(
+    { heading: 'a.b', untrustedLine: untrustedBullet('true') },
+    { heading: 'c.d', patternKey: '`c.d`' },
+    { heading: 'a.b', untrustedLine: untrustedBullet('false') },
+  );
+  const clean = ledgerK({ heading: 'a.b' }, { heading: 'c.d', patternKey: '`c.d`' });
+  assert.equal(
+    runK(clean, dup),
+    "learnings ledger's committed version has a repeated entry heading (a.b); the append-only history cannot be compared (fail closed)",
+    'C19 committed duplicate append-only'
+  );
+});
+test('dream-validate: ledger corpus [C20] a clean baseline and a clean candidate, K keeps (green control for C17-C19)', () => {
+  const clean = ledgerK({ heading: 'a.b' }, { heading: 'c.d', patternKey: '`c.d`' });
+  assert.equal(runK(clean, clean), null);
+});
+
+// ── C21–C23: raise-only (A4) ──────────────────────────────────────────────────
+
+test('dream-validate: ledger corpus [C21] baseline False, candidate false, K refuses (raise-only, INVALID fails closed)', () => {
+  const baseline = ledgerK({ untrustedLine: untrustedBullet('False') });
+  const candidate = ledgerK({ untrustedLine: untrustedBullet('false') });
+  assert.equal(
+    runK(candidate, baseline),
+    'learnings ledger lowered derived_from_untrusted of a.b (raise-only)',
+    'C21 raise-only invalid'
+  );
+});
+test('dream-validate: ledger corpus [C22] baseline False, candidate true, K keeps (green control for C21)', () => {
+  const baseline = ledgerK({ untrustedLine: untrustedBullet('False') });
+  const candidate = ledgerK({ untrustedLine: untrustedBullet('true') });
+  assert.equal(runK(candidate, baseline), null);
+});
+test('dream-validate: ledger corpus [C23] baseline bullet ABSENT, candidate false, K keeps (unchanged, owner item 2)', () => {
+  const baseline = ledgerK({ untrustedLine: null });
+  const candidate = ledgerK({ untrustedLine: untrustedBullet('false') });
+  assert.equal(runK(candidate, baseline), null);
+});
+
+// ── C24–C27: `__proto__` / `constructor` headings (A2) ────────────────────────
+
+test('dream-validate: ledger corpus [C24] heading __proto__ alone, K refuses (Pattern-Key slug check)', () => {
+  const text = ledgerK({ heading: '__proto__', patternKey: '`__proto__`' });
+  assert.equal(
+    runK(text),
+    'learnings ledger entry __proto__: Pattern-Key heading is not a valid area.symptom slug',
+    'C24 proto heading'
+  );
+});
+test('dream-validate: ledger corpus [C25] heading __proto__ plus one valid entry, K refuses (as C24)', () => {
+  const text = ledgerK({ heading: '__proto__', patternKey: '`__proto__`' }, { heading: 'a.b' });
+  assert.equal(
+    runK(text),
+    'learnings ledger entry __proto__: Pattern-Key heading is not a valid area.symptom slug',
+    'C25 proto plus valid'
+  );
+});
+test('dream-validate: ledger corpus [C26] heading constructor, fully valid, K keeps and A authorizes (green control)', () => {
+  const kText = ledgerK({ heading: 'constructor', patternKey: '`constructor`' });
+  assert.equal(runK(kText), null);
+  const aText = ledgerA({ heading: 'constructor', patternKey: '`constructor`' });
+  assert.equal(runA(aText, 'constructor'), null);
+});
+test('dream-validate: ledger corpus [C27] baseline constructor + a.b, candidate deleted constructor, K refuses (append-only)', () => {
+  const baseline = ledgerK({ heading: 'constructor', patternKey: '`constructor`' }, { heading: 'a.b' });
+  const candidate = ledgerK({ heading: 'a.b' });
+  assert.equal(
+    runK(candidate, baseline),
+    'learnings ledger deleted an existing entry (constructor); ledger is append-only',
+    'C27 constructor deleted'
+  );
+});
+
+// ── C28: the shared pattern-key sample, at both sites (A5) ───────────────────
+
+const PATTERN_KEY_SAMPLE = [
+  'a.b', 'a', '0', 'a-b', 'a.b-c.d', 'A.b', '_x', '__proto__', 'constructor', 'toString',
+  '.a', '-a', 'a b', 'a/b', 'a..b', 'z'.repeat(64), 'z'.repeat(65), 'a#b', 'a:b',
+];
+// The oracle IS the shipped regex (Table A5: both sites are required to be this
+// SAME regex) — used here only to compute the expected keep/refuse split, never
+// to replace the assertion against the two real call sites below.
+const PATTERN_KEY_ORACLE = /^[a-z0-9][a-z0-9.-]{0,63}$/;
+
+test('dream-validate: ledger corpus [C28] one shared pattern-key sample at both sites, 0 disagreements (A5)', () => {
+  for (const key of PATTERN_KEY_SAMPLE) {
+    const ok = PATTERN_KEY_ORACLE.test(key);
+
+    // Site 1: the `##` heading check.
+    const headingText = ledgerK({ heading: key, patternKey: `\`${key}\`` });
+    const headingReason = runK(headingText);
+    if (ok) {
+      assert.equal(headingReason, null, `heading site keep for ${JSON.stringify(key)}`);
+    } else {
+      assert.equal(
+        headingReason,
+        `learnings ledger entry ${key}: Pattern-Key heading is not a valid area.symptom slug`,
+        `heading site refuse for ${JSON.stringify(key)}`
+      );
+    }
+
+    // Site 2: `revision_pattern_key`. No committed ledger, so a VALID key falls
+    // through to a DIFFERENT (still-refusing) message and an INVALID key is
+    // caught by the regex check itself — the two are distinguishable, which is
+    // what lets this assert each key's exact verdict rather than an agreement
+    // count alone.
+    const revisionReason = runA(null, key);
+    if (ok) {
+      assert.equal(
+        revisionReason,
+        'skill change needs a qualifying learning but no committed ledger authorizes it',
+        `revision_pattern_key site accepts ${JSON.stringify(key)}`
+      );
+    } else {
+      assert.equal(
+        revisionReason,
+        'skill change needs a qualifying learning but has no valid revision_pattern_key',
+        `revision_pattern_key site rejects ${JSON.stringify(key)}`
+      );
+    }
+  }
+});
+
+// ── C29–C30: the bare-promotion allowlist and __proto__ (A2) ─────────────────
+
+const PROMOTE_HEAD = [
+  '---', 'id: promo', 'type: skill', 'created: 2026-08-01', 'updated: 2026-08-01',
+  'origin: dream', 'status: incubating', 'confidence: 0.9', 'recurrence: 3',
+  'derived_from_untrusted: false', '---', '', 'same body', '',
+].join('\n');
+const PROMOTE_REGISTRY = { skills: { '05-Skills/promo/SKILL.md': { id: 'promo', created: '2026-08-01' } } };
+
+/** A bare incubating→active promotion (body unchanged) that ALSO adds one extra
+ *  frontmatter line — the only unauthorized-exempt change is a REAL promotion,
+ *  so any other added field forces `needsAuth`. */
+function runPromotion(extraFrontmatterLine) {
+  const cur = PROMOTE_HEAD
+    .replace('status: incubating', 'status: active')
+    .replace('updated: 2026-08-01', 'updated: 2026-08-02')
+    .replace('derived_from_untrusted: false\n---', `derived_from_untrusted: false\n${extraFrontmatterLine}\n---`);
+  return corpusGates.skillBody({
+    rel: '05-Skills/promo/SKILL.md',
+    candidateBytes: Buffer.from(cur, 'utf8'),
+    baselineBytes: Buffer.from(PROMOTE_HEAD, 'utf8'),
+    baselineLedgerBytes: null,
+    registry: PROMOTE_REGISTRY,
+    layout: defaultLayout(),
+    date: '2026-08-02',
+  });
+}
+
+test('dream-validate: ledger corpus [C29] promotion adding tags: injected, A refuses (green control for C30)', () => {
+  assert.equal(runPromotion('tags: injected'), 'skill change needs a qualifying learning but has no valid revision_pattern_key');
+});
+test('dream-validate: ledger corpus [C30] promotion adding __proto__: injected, A refuses (A2 fix — no longer invisible)', () => {
+  assert.equal(
+    runPromotion('__proto__: injected'),
+    'skill change needs a qualifying learning but has no valid revision_pattern_key',
+    'C30 proto promotion'
+  );
+});
+
+// ── C31–C35: more value classes (A1's class rule) ─────────────────────────────
+
+test('dream-validate: ledger corpus [C31] the YAML-ish word class (on, off), K and A refuse', () => {
+  for (const v of ['on', 'off']) { checkK(v, false); checkA(v, false); }
+});
+test('dream-validate: ledger corpus [C32] the YAML null class (~, null), K and A refuse', () => {
+  for (const v of ['~', 'null']) { checkK(v, false); checkA(v, false); }
+});
+test('dream-validate: ledger corpus [C33] the YAML tag class (!!bool false), K and A refuse', () => {
+  checkK('!!bool false', false);
+  checkA('!!bool false', false);
+});
+test('dream-validate: ledger corpus [C34] the homoglyph class (fullwidth false), K and A refuse', () => {
+  const fullwidthFalse = String.fromCodePoint(0xff46, 0xff41, 0xff4c, 0xff53, 0xff45); // fullwidth f a l s e
+  checkK(fullwidthFalse, false);
+  checkA(fullwidthFalse, false);
+});
+test('dream-validate: ledger corpus [C35] the interior-invisible class (U+200B inside false), K and A refuse', () => {
+  const interiorZwsp = `fal${String.fromCodePoint(0x200b)}se`; // NOT trimmable whitespace
+  checkK(interiorZwsp, false);
+  checkA(interiorZwsp, false);
+});
+
+// ── C36–C39: the unparseable-line class and CRLF (A7) ─────────────────────────
+
+const UNPARSEABLE_CODEPOINTS = [0x0d, 0x2028, 0x2029]; // CR, U+2028, U+2029
+
+test('dream-validate: ledger corpus [C36] unparseable-line value as the CANDIDATE (CR/LS/PS), K refuses (regression pin)', () => {
+  for (const cp of UNPARSEABLE_CODEPOINTS) {
+    checkK(`fal${String.fromCodePoint(cp)}se`, false);
+  }
+});
+test('dream-validate: ledger corpus [C37] same three values on the COMMITTED baseline, candidate false, K refuses (A7 makes it INVALID, A4 fires)', () => {
+  for (const cp of UNPARSEABLE_CODEPOINTS) {
+    const baseline = ledgerK({ untrustedLine: untrustedBullet(`fal${String.fromCodePoint(cp)}se`) });
+    const candidate = ledgerK({ untrustedLine: untrustedBullet('false') });
+    assert.equal(
+      runK(candidate, baseline),
+      'learnings ledger lowered derived_from_untrusted of a.b (raise-only)',
+      `cp=U+${cp.toString(16)}`
+    );
+  }
+});
+test('dream-validate: ledger corpus [C38] same three values on the COMMITTED ledger, A refuses (regression pin)', () => {
+  for (const cp of UNPARSEABLE_CODEPOINTS) {
+    const ledger = ledgerA({ untrustedLine: untrustedBullet(`fal${String.fromCodePoint(cp)}se`) });
+    assert.equal(runA(ledger), A_INVALID_REFUSAL, `cp=U+${cp.toString(16)}`);
+  }
+});
+test('dream-validate: ledger corpus [C39] a whole ledger with CRLF line endings, otherwise valid, K keeps (A7 deliberate widening)', () => {
+  const text = ledgerK({}).split('\n').join('\r\n');
+  assert.equal(runK(text), null, 'C39 crlf ledger');
+});
+
+// ── C40: the generated matrix over all 24 non-LF `\s` code points, all three reads ──
+
+test('dream-validate: ledger corpus [C40-candidate] generated matrix, candidate read, K refuses (LPC-D)', () => {
+  for (const cp of WS_CODEPOINTS) {
+    const text = ledgerK(
+      { heading: 'a.b' },
+      { heading: 'c.d', patternKey: '`c.d`' },
+      { heading: `a.b${String.fromCodePoint(cp)}` },
+    );
+    assert.equal(
+      runK(text),
+      'learnings ledger has a repeated entry heading (a.b); each ## heading must appear once',
+      `cp=U+${cp.toString(16)}`
+    );
+  }
+});
+test('dream-validate: ledger corpus [C40-baseline] generated matrix, committed-baseline read, K refuses (LPC-E)', () => {
+  for (const cp of WS_CODEPOINTS) {
+    const dup = ledgerK(
+      { heading: 'a.b' },
+      { heading: 'c.d', patternKey: '`c.d`' },
+      { heading: `a.b${String.fromCodePoint(cp)}` },
+    );
+    const clean = ledgerK({ heading: 'a.b' }, { heading: 'c.d', patternKey: '`c.d`' });
+    assert.equal(
+      runK(clean, dup),
+      "learnings ledger's committed version has a repeated entry heading (a.b); the append-only history cannot be compared (fail closed)",
+      `cp=U+${cp.toString(16)}`
+    );
+  }
+});
+test('dream-validate: ledger corpus [C40-authorization] generated matrix, authorization read, A refuses (LPC-E)', () => {
+  for (const cp of WS_CODEPOINTS) {
+    const dup = ledgerK(
+      { heading: 'a.b' },
+      { heading: 'c.d', patternKey: '`c.d`' },
+      { heading: `a.b${String.fromCodePoint(cp)}` },
+    );
+    assert.equal(
+      runA(dup, 'a.b'),
+      'skill change needs a qualifying learning but the committed ledger has a repeated entry heading (fail closed)',
+      `cp=U+${cp.toString(16)}`
+    );
+  }
+});
+
+// ── C41–C43: heading edge cases — the boundary controls for C40 ──────────────
+
+test('dream-validate: ledger corpus [C41] whitespace INSIDE a heading (interior NBSP), K refuses (boundary control for C40)', () => {
+  const nbsp = String.fromCodePoint(0x00a0);
+  const text = ledgerK({ heading: `a${nbsp}b`, patternKey: `\`a${nbsp}b\`` });
+  assert.equal(runK(text), `learnings ledger entry a${nbsp}b: Pattern-Key heading is not a valid area.symptom slug`);
+});
+test('dream-validate: ledger corpus [C42] a Unicode-bearing hostile heading that is NOT whitespace, K refuses', () => {
+  const fullwidthAB = `${String.fromCodePoint(0xff41)}.${String.fromCodePoint(0xff42)}`; // fullwidth a . b
+  const text1 = ledgerK({ heading: fullwidthAB, patternKey: `\`${fullwidthAB}\`` });
+  assert.equal(runK(text1), `learnings ledger entry ${fullwidthAB}: Pattern-Key heading is not a valid area.symptom slug`);
+
+  const zwspHeading = `a${String.fromCodePoint(0x200b)}b`; // U+200B is not matched by \s
+  const text2 = ledgerK({ heading: zwspHeading, patternKey: `\`${zwspHeading}\`` });
+  assert.equal(runK(text2), `learnings ledger entry ${zwspHeading}: Pattern-Key heading is not a valid area.symptom slug`);
+});
+test('dream-validate: ledger corpus [C43] heading prototype, fully valid, K keeps and A authorizes (green control)', () => {
+  const kText = ledgerK({ heading: 'prototype', patternKey: '`prototype`' });
+  assert.equal(runK(kText), null);
+  const aText = ledgerA({ heading: 'prototype', patternKey: '`prototype`' });
+  assert.equal(runA(aText, 'prototype'), null);
 });

--- a/tests/unit/frontmatter-unify.test.js
+++ b/tests/unit/frontmatter-unify.test.js
@@ -58,7 +58,13 @@ test('config.readScalar round-trips the corpus through the one coercer', () => {
 });
 
 test('a no-separator-space line agrees with the spaced form on both consumers', () => {
-  assert.deepEqual(parseFrontmatter('---\nk:v\n---\n'), { k: 'v' });
+  // A2: the record is null-prototype, so it is not `deepEqual` to a `{k:'v'}`
+  // plain object any more — the OBSERVABLE is own keys exactly ['k'] WITH the
+  // value check (a keys-only compare would accept `{k: 'wrong'}`).
+  const got = parseFrontmatter('---\nk:v\n---\n');
+  assert.deepEqual(Object.keys(got), ['k']);
+  assert.equal(got.k, 'v');
+  // Both sides are null-prototype, so this comparison needs no repair.
   assert.deepEqual(parseFrontmatter('---\nk:v\n---\n'), parseFrontmatter('---\nk: v\n---\n'));
   assert.equal(readScalar('k:v', 'k'), 'v');
   assert.equal(readScalar('k:v', 'k'), readScalar('k: v', 'k'));
@@ -90,6 +96,7 @@ test('the skill-body split matches the shared parser body rule', () => {
 test('validator semantics preserved: quoted booleans stay strings, absent block is {}', () => {
   assert.equal(parseFrontmatter('---\nk: "true"\n---\n').k, 'true');
   assert.equal(parseFrontmatter('---\nk: \'false\'\n---\n').k, 'false');
-  assert.deepEqual(parseFrontmatter('no frontmatter'), {});
-  assert.deepEqual(parseFrontmatter('---\nunclosed: 1\n'), {});
+  // A2: null-prototype — the OBSERVABLE is zero own keys.
+  assert.deepEqual(Object.keys(parseFrontmatter('no frontmatter')), []);
+  assert.deepEqual(Object.keys(parseFrontmatter('---\nunclosed: 1\n')), []);
 });


### PR DESCRIPTION
Spec: docs/specs/WP-audit-e-ledger-parser-corpus.md

## Deliverables checklist

- [x] Every changed file is listed in the spec's Deliverables table
- [x] Spec status flipped to In-Review

## Verification output

Full V1 (`node tests/with-temp-root.js tests/run.js`) and V3 (`npm run red-proofs`) transcripts are large (452 KB / 28 KB); posted in the first two PR comments. Condensed below. **Re-run after the round-1 gate fix (head `3efcac1f`) — same counts, unchanged.**

**V1** — `node tests/with-temp-root.js tests/run.js` — rc=0
```
ℹ tests 2676
ℹ pass 2664
ℹ fail 0
ℹ skipped 12
```
(rose from 2630/2618/0/12 on the pinned base — +46 new tests, 0 regressions)

**V2** — `npm run lint` — rc=0
```
--- markdownlint ---
markdownlint-cli2 v0.23.0 (markdownlint v0.41.0)
Finding: docs/**/*.md skills/**/*.md templates/**/*.md tests/**/*.md *.md
Linting: 646 file(s)
Summary: 0 error(s)
--- shellcheck ---
--- PSScriptAnalyzer ---
--- frontmatter check ---
frontmatter check passed: 268 spec(s), 4 agent(s)

lint passed
```

**V3** — `npm run red-proofs` — rc=0
```
44 declared proof(s), 44 selected
snapshot: 1351 entries under the declared domain (`.git/` and `node_modules/` excluded)

PROVEN       lpc-a-trust-predicate-reverted  (WP-audit-e-ledger-parser-corpus criterion 1)
PROVEN       lpc-b-collector-reverted  (WP-audit-e-ledger-parser-corpus criterion 4)
PROVEN       lpc-c-frontmatter-record-reverted  (WP-audit-e-ledger-parser-corpus criterion 4)
PROVEN       lpc-d-candidate-duplicate-reverted  (WP-audit-e-ledger-parser-corpus criterion 2)
PROVEN       lpc-e-baseline-duplicate-reverted  (WP-audit-e-ledger-parser-corpus criterion 2)
PROVEN       lpc-f-raise-only-invalid-reverted  (WP-audit-e-ledger-parser-corpus criterion 1)
PROVEN       lpc-g-bullet-key-match-reverted  (WP-audit-e-ledger-parser-corpus criterion 2b)
...
PROVEN       WP-audit-e-ledger-parser-corpus criterion 1 — lpc-a-trust-predicate-reverted=PROVEN; lpc-f-raise-only-invalid-reverted=PROVEN
PROVEN       WP-audit-e-ledger-parser-corpus criterion 4 — lpc-b-collector-reverted=PROVEN; lpc-c-frontmatter-record-reverted=PROVEN
PROVEN       WP-audit-e-ledger-parser-corpus criterion 2 — lpc-d-candidate-duplicate-reverted=PROVEN; lpc-e-baseline-duplicate-reverted=PROVEN
PROVEN       WP-audit-e-ledger-parser-corpus criterion 2b — lpc-g-bullet-key-match-reverted=PROVEN

RUN: PROVEN
```

**Boundary check** — `node scripts/boundary-check.js docs/specs/WP-audit-e-ledger-parser-corpus.md $(git diff --name-only 881f0d81 HEAD | tr '\n' ' ')` — rc=0, no offenders (re-run at `3efcac1f`; the three round-1 gate-raw logbook commits are covered by the `docs/specs/logbook/` allowance).

## Decisions made

- **Round-1 gate fix (wd-reviewer REQUEST-CHANGES, otherwise judged CORRECT).** C18 and C40's authorization-read identity built their committed duplicate ledger with `codex:` sessions (2 of them). Under LPC-E's mutation (the A3 duplicate-heading refusal removed), `skillBodyViolation` refused those fixtures anyway — but on its OWN unrelated ">=3 distinct Claude-invoked sessions" floor, never reaching `authorize`, so the row never actually witnessed the fail-open its Today column claims. Fixed by giving the LAST `a.b`-keyed section in both fixtures (the one last-wins surfaces once A3's refusal is gone) three distinct `claude:` sessions and `Recurrence: 3`. Verified on a scratch copy with LPC-E's mutation applied by hand (marker `RP_MUT_LPC_E_BASELINE_DUPLICATE_REVERTED` grepped present at both sites): the fixed fixture now measures `actual: null` (genuine authorize) where the pre-fix fixture measured the Codex-floor string instead. Real-tree required verdicts are unchanged (the exact repeated-heading refusal string) — reconfirmed by execution, and `npm run red-proofs` still reports LPC-E's selected set unchanged (44/44 PROVEN).

- The two committed-baseline duplicate-heading refusal sites (`ledgerViolation`'s append-only-comparison read and `skillBodyViolation`'s authorization read) both destructure `parseLedgerEntries`'s `duplicateKeys` into a local named `headDuplicateKeys`. This is a naming choice, not a behavior change — it makes the two `if (headDuplicateKeys.length > 0) {` lines byte-identical, which is what lets LPC-E's red-proof mutation move both sites with one `find`/`replace` (`occurrences: 2`) instead of needing two separate proof declarations for what the spec describes as one mutation ("the duplicate-heading refusal at the two committed-baseline reads").
- The candidate-read duplicate-heading refusal is placed immediately after the candidate ledger is parsed, before the "no valid entries" and schema-loop checks — a structural fault (a repeated heading) preempts per-entry judgment. The spec does not pin the exact position among these three early checks, so this is the simpler ordering.
- Red-proof `signal` values: initially written as descriptive phrases (e.g. `'trust predicate'`), which is wrong — `evaluateRed` requires `signal` to be a literal substring of the actual TAP diagnostic, not a description of the fix. Re-measured against the actual mutated-tree diagnostics and rewritten to real substrings (e.g. `'K path for'`, matching the `checkK` helper's own assertion message; `'cp=U+'`, matching the per-code-point loop's own message). Nine corpus assertions that had no message argument (C17, C18, C19, C21, C24, C25, C27, C30, C39) gained one, purely to give their red-proof declaration a stable signal to anchor on — no assertion logic changed.

## Discovered issues (out of scope, not fixed)

None — the spec's Out of scope list routes everything relevant: `src/gws/`, `src/cli/gws-broker.js`, `src/core/runtime-profile.js` (the concurrent audit-d design loop); the quarantine/preservation machinery, secret gate and invocation-window trust derivation elsewhere in `src/core/dream/validate.js`; duplicate field bullets inside one section (last-wins stays); entry honesty/truth (schema checks shape only); user-hand-authored ledgers outside a dream run; `coerceScalar` on the ledger, a `__proto__`-by-name check, `Object.hasOwn` guards, a warn channel, a distinct authorization-path INVALID message, a source-shape grep gate, and narrowing A7 or constraining the duplicate detector's shape — all explicitly considered and rejected by the spec itself, not left undone by this PR.

---
Generated-by: claude-sonnet-5 (implementer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VC4ktj5nVJz37jsL6EnrNh

