### PR TITLE
docs(specs): record the owner's ruling on the audit-D input-bound unit — keep characters (audit-close)

### DIFF
--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -81,10 +81,11 @@ resuming it.
 > **Also recorded, not defects:** the size-ceiling residual **F6** — 594 lines
 > against a ~400 ceiling, all contract and corpus, **zero gate machinery added in
 > any round** — and **C26's lookup-detector-only reach** as a stated property of
-> Table D. **Plus the OPEN owner question carried forward** from audit-D: whether
-> the input bound should be restated in UTF-8 octets to match the output bound — no
-> output-safety consequence either way, but availability differs, and the character
-> bound as ruled is the more permissive.
+> Table D. **The audit-D input-bound unit question is CLOSED — ruled directly by the
+> owner on 2026-09-06 (*"agreed. let us keep characters."*): step 0 stays at 998
+> CHARACTERS as item 8 says, step 7 at 998 UTF-8 octets; no output-safety consequence
+> either way, and the character bound is the more permissive. Record:
+> `docs/specs/logbook/2026-09-05-owner-rulings-audit-d-queue.md`.
 >
 > **Next in the queue:** `WP-process-runbook-sweeps`, then
 > `WP-dream-git-env-pinning` (**owner product decision** — the maturing architect

--- a/docs/specs/done/WP-audit-d-code-derived-recipients.md
+++ b/docs/specs/done/WP-audit-d-code-derived-recipients.md
@@ -100,8 +100,10 @@ epic: audit-close
 > - **`buildMime` emits raw UTF-8 in headers and its optional `From` carries no
 >   length bound.** Both pre-existing, on no path this verb takes.
 >   **Discovered issues.**
-> - **OPEN owner question — the input bound's unit.** Step 0 counts **998
->   characters** (as ruled, item 8); step 7 counts **998 UTF-8 octets**. There is
+> - **The input bound's unit — RULED 2026-09-06, keep characters** (owner, verbatim:
+>   *"agreed. let us keep characters."*; record
+>   `docs/specs/logbook/2026-09-05-owner-rulings-audit-d-queue.md`). Step 0 counts **998
+>   characters** (item 8); step 7 counts **998 UTF-8 octets**. There is
 >   **no output-safety consequence** either way once step 7 covers every emitted
 >   line, but **availability differs**: with 998 `€` characters in `References` and
 >   no `Message-ID`, the character bound drafts while an octet bound would refuse

--- a/docs/specs/logbook/2026-09-05-owner-rulings-audit-d-queue.md
+++ b/docs/specs/logbook/2026-09-05-owner-rulings-audit-d-queue.md
@@ -153,6 +153,13 @@ consequence** either way once the output bound covers every emitted line, but
 bound would refuse at step 0. The character bound is the more permissive; both are
 output-safe.
 
+**RULED — 2026-09-06, directly by the owner.** Asked for a recommendation, the orchestrator recommended
+keeping characters (safety is identical either way once step 7 bounds every emitted line in octets; an
+octet input bound refuses more legitimate non-ASCII mail for no gain; the ruled state is the reviewed
+state). The owner, verbatim: *"agreed. let us keep characters."* Item 8 stands as written — the step-0
+input bound is **998 characters**; step 7's output bound stays **998 UTF-8 octets**; the two units are
+deliberate and this question is CLOSED. This is the session's second direct ruling (the first is item 10).
+
 This is deliberately **not** an owner item and **not** dispatched under the standing
 instruction: the architect was caught in round 5 making exactly this change without
 a licence, so recording it as an open question the owner answers directly is the


### PR DESCRIPTION
## Summary

Records the owner's direct ruling of 2026-09-06 on the one question left open by `WP-audit-d-code-derived-recipients`: the step-0 input bound stays at **998 characters** (item 8 as written); the step-7 output bound stays at 998 UTF-8 octets. Owner, verbatim: *"agreed. let us keep characters."* Three surfaces updated in one pass — the rulings record, the Done spec's residual note, HANDOVER status pass #5. Docs only.

Generated-by: claude-fable-5-1 (orchestrator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VC4ktj5nVJz37jsL6EnrNh